### PR TITLE
build: set up docker images for app and apis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+.git/

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -1,0 +1,42 @@
+# First step: build the assets
+FROM node:lts-alpine AS builder
+
+WORKDIR /
+ADD package.json yarn.lock ./
+ADD ./apis/core/package.json ./apis/core/
+ADD ./ui/package.json ./ui/
+
+# for every new package foo add
+#ADD ./packages/foo/package.json ./packages/foo/
+
+# install and build backend
+ENV NODE_ENV=
+RUN yarn install --ci
+
+COPY . .
+
+RUN yarn tsc --outDir dist
+
+FROM node:14-alpine
+
+WORKDIR /app
+
+ADD package.json yarn.lock ./
+ADD ./apis/core/package.json ./apis/core/
+ADD ./ui/package.json ./ui/
+
+# for every new package foo add
+#ADD ./packages/foo/package.json ./packages/foo/
+
+RUN yarn install --production
+COPY --from=builder dist/apis ./apis/
+#COPY --from=builder dist/packages/ ./packages/
+
+RUN apk add --no-cache tini
+ENTRYPOINT ["tini", "--", "node"]
+
+EXPOSE 45670
+USER nobody
+
+WORKDIR /app/apis
+CMD ["core"]

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -10,7 +10,6 @@ ADD ./ui/package.json ./ui/
 #ADD ./packages/foo/package.json ./packages/foo/
 
 # install and build backend
-ENV NODE_ENV=
 RUN yarn install --ci
 
 COPY . .

--- a/apis/core/index.ts
+++ b/apis/core/index.ts
@@ -1,11 +1,12 @@
 import express from 'express'
 import { error, log } from './lib/log'
 import authentication from './lib/auth'
+import env from './lib/env'
 
 import guard = require('express-jwt-permissions')
 
 async function main() {
-  log('Starting Core API. Environment %s', process.env.NODE_ENV ?? 'production')
+  log('Starting Core API. Environment %s', env.production ? 'production' : 'development')
 
   const app = express()
 

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -2,6 +2,9 @@
   "name": "@cube-creator/core-api",
   "version": "0.0.0",
   "private": true,
+  "scripts": {
+    "build": "tsc"
+  },
   "dependencies": {
     "commander": "^6.1.0",
     "debug": "^4.1.1",

--- a/apis/core/tsconfig.json
+++ b/apis/core/tsconfig.json
@@ -1,13 +1,7 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
-    "target": "ESNext",
-    "esModuleInterop": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "noImplicitReturns": true,
-    "strictNullChecks": true,
-    "allowSyntheticDefaultImports": true
+    "target": "ESNext"
   }
 }

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /
 ADD package.json yarn.lock ./
 ADD ./ui/package.json ./ui/
 # install and build backend
-ENV NODE_ENV=
 RUN yarn install --ci
 
 COPY . .
@@ -19,8 +18,6 @@ FROM nginx:1.16.0-alpine
 HEALTHCHECK --timeout=1s --retries=99 \
         CMD wget -q --spider http://127.0.0.1:80/ \
          || exit 1
-
-RUN apk add --update --upgrade --no-cache wget
 
 ADD ./nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder ui/dist /usr/share/nginx/html

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -1,0 +1,26 @@
+# First step: build the assets
+FROM node:lts-alpine AS builder
+
+WORKDIR /
+ADD package.json yarn.lock ./
+ADD ./ui/package.json ./ui/
+# install and build backend
+ENV NODE_ENV=
+RUN yarn install --ci
+
+COPY . .
+
+WORKDIR /ui
+
+ENV NODE_ENV=production
+RUN yarn build
+
+FROM nginx:1.16.0-alpine
+HEALTHCHECK --timeout=1s --retries=99 \
+        CMD wget -q --spider http://127.0.0.1:80/ \
+         || exit 1
+
+RUN apk add --update --upgrade --no-cache wget
+
+ADD ./nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder ui/dist /usr/share/nginx/html

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,38 @@
+server {
+  listen 80;
+  server_name localhost;
+  charset utf-8;
+
+  # files transfer
+  client_body_in_file_only clean;
+  client_body_buffer_size 32K;
+  client_max_body_size 1026g;
+  sendfile on;
+  send_timeout 300s;
+
+  # redirect server error pages / and set response status to 200 / ok
+  error_page 404 =200 /;
+
+  root /usr/share/nginx/html;
+  index index.html index.html;
+
+  location / {
+    try_files $uri /index.html =404;
+  }
+
+  ## Proxy requests to "/auth" and "/api" to api-server.
+  #location ~ ^/(auth|api) {
+  #  proxy_pass http://api-server;
+  #  proxy_redirect off;
+  #}
+
+  # deny access to .htaccess files, if Apache's document root concurs with nginx's one
+  location ~ /\.ht {
+    deny all;
+  }
+
+  # deny access to hidden files (beginning with a period)
+  location ~ /\. {
+      access_log off; log_not_found off; deny all;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "apis/*",
     "packages/*"
   ],
-  "dependencies": {
+  "devDependencies": {
     "@tpluscode/eslint-config": "^0.1.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,13 @@
 {
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true,
+    "strictNullChecks": true,
+    "allowSyntheticDefaultImports": true
+  },
   "include": [
     "packages",
     "apis",


### PR DESCRIPTION
I created docker files for the API and UI.

Separate because I want to avoid the complication of having UI conditionally hosted inside express and build together. In this approach the UI is simply a static nginx container. The API is a node app like before but also made simpler

This time my proposal is to have them deployed like

| What | Where |
| -- | -- |
| API | https://creator.cube |
| UI | https://app.creator.cube |