### PR TITLE
Build docker images with GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 node_modules/
 .git/
+dist/
+*.Dockerfile

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,141 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*.*.*"
+  pull_request:
+
+jobs:
+  build-api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=zazuko/cube-creator-api
+          VERSION=noop
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+              VERSION=edge
+            fi
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            MINOR=${VERSION%.*}
+            MAJOR=${MINOR%.*}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-api-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-api-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          file: ./api.Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
+
+  build-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=zazuko/cube-creator-app
+          VERSION=noop
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+              VERSION=edge
+            fi
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            MINOR=${VERSION%.*}
+            MAJOR=${MINOR%.*}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-app-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-app-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          file: ./app.Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.name }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,6 +37,9 @@ jobs:
             TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
           elif [ "${{ github.event_name }}" = "push" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+            if [ "$VERSION" = "edge" ]; then
+              TAGS="$TAGS,${DOCKER_IMAGE}:edge-sha-${GITHUB_SHA::8}"
+            fi
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
@@ -102,6 +105,9 @@ jobs:
             TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
           elif [ "${{ github.event_name }}" = "push" ]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+            if [ "$VERSION" = "edge" ]; then
+              TAGS="$TAGS,${DOCKER_IMAGE}:edge-sha-${GITHUB_SHA::8}"
+            fi
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -1,7 +1,7 @@
 # First step: build the assets
 FROM node:lts-alpine AS builder
 
-WORKDIR /
+WORKDIR /app
 ADD package.json yarn.lock ./
 ADD ./apis/core/package.json ./apis/core/
 ADD ./ui/package.json ./ui/
@@ -28,8 +28,8 @@ ADD ./ui/package.json ./ui/
 #ADD ./packages/foo/package.json ./packages/foo/
 
 RUN yarn install --production
-COPY --from=builder dist/apis ./apis/
-#COPY --from=builder dist/packages/ ./packages/
+COPY --from=builder /app/dist/apis ./apis/
+#COPY --from=builder /app/dist/packages/ ./packages/
 
 RUN apk add --no-cache tini
 ENTRYPOINT ["tini", "--", "node"]

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -4,7 +4,6 @@ FROM node:lts-alpine AS builder
 WORKDIR /app
 ADD package.json yarn.lock ./
 ADD ./apis/core/package.json ./apis/core/
-ADD ./ui/package.json ./ui/
 
 # for every new package foo add
 #ADD ./packages/foo/package.json ./packages/foo/
@@ -13,6 +12,7 @@ ADD ./ui/package.json ./ui/
 RUN yarn install --ci
 
 COPY . .
+RUN rm -rf ./ui
 
 RUN yarn tsc --outDir dist
 
@@ -22,7 +22,6 @@ WORKDIR /app
 
 ADD package.json yarn.lock ./
 ADD ./apis/core/package.json ./apis/core/
-ADD ./ui/package.json ./ui/
 
 # for every new package foo add
 #ADD ./packages/foo/package.json ./packages/foo/

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /app/ui
 
 ENV NODE_ENV=production
 ENV VUE_APP_API_URL=/
+ENV BASE_URL=/app/
 RUN yarn build
 
 FROM nginx:1.16.0-alpine

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -1,7 +1,7 @@
 # First step: build the assets
 FROM node:lts-alpine AS builder
 
-WORKDIR /
+WORKDIR /app
 ADD package.json yarn.lock ./
 ADD ./ui/package.json ./ui/
 # install and build backend
@@ -9,9 +9,10 @@ RUN yarn install --ci
 
 COPY . .
 
-WORKDIR /ui
+WORKDIR /app/ui
 
 ENV NODE_ENV=production
+ENV VUE_APP_API_URL=/
 RUN yarn build
 
 FROM nginx:1.16.0-alpine
@@ -20,4 +21,4 @@ HEALTHCHECK --timeout=1s --retries=99 \
          || exit 1
 
 ADD ./nginx/default.conf /etc/nginx/conf.d/default.conf
-COPY --from=builder ui/dist /usr/share/nginx/html
+COPY --from=builder /app/ui/dist /usr/share/nginx/html

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "rootDir": ".",
     "esModuleInterop": true,
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
This is heavily inspired by the [example in the docker/build-push-action](https://github.com/docker/build-push-action#complete-workflow) repo.

It builds two images: `zazuko/cube-creator-{api,app}`. Tags as follow: 
 - `sha-{commit}` on every commit
 - `edge` for the latest commit on master
 - `[branch]` for other branches
 - on git tags like `vX.Y.Z`, tags `vX`, `vX.Y`, `vX.Y.Z` and latest
 - `pr-X` on pull requests (builds but does not push)