### PR TITLE
Barebones projects list

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -6,8 +6,8 @@ ADD package.json yarn.lock ./
 ADD ./apis/core/package.json ./apis/core/
 ADD ./packages/core/package.json ./packages/core/
 
-# for every new package foo add
-#ADD ./packages/foo/package.json ./packages/foo/
+# for every new package foo add:
+# ADD ./packages/foo/package.json ./packages/foo/
 
 # install and build backend
 RUN yarn install --frozen-lockfile

--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -4,6 +4,12 @@ FROM node:lts-alpine AS builder
 WORKDIR /app
 ADD package.json yarn.lock ./
 ADD ./ui/package.json ./ui/
+ADD ./apis/core/package.json ./apis/core/
+ADD ./packages/core/package.json ./packages/core/
+
+# for every new package foo add:
+# ADD ./packages/foo/package.json ./packages/foo/
+
 # install and build backend
 RUN yarn install --frozen-lockfile
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@cube-creator/core": "*",
     "@fortawesome/fontawesome-svg-core": "^1.2.30",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/vue-fontawesome": "^2.0.0",

--- a/ui/src/components/NavBar.vue
+++ b/ui/src/components/NavBar.vue
@@ -5,6 +5,11 @@
         Cube Creator
       </b-navbar-item>
     </template>
+    <template slot="start">
+      <b-navbar-item tag="router-link" :to="{ name: 'CubeProjects' }">
+        Cube Projects
+      </b-navbar-item>
+    </template>
     <template slot="end">
       <b-navbar-item>
         <sign-out-button />

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -7,6 +7,7 @@ import OidcError from '@/components/auth/OidcError.vue'
 import store from '@/store'
 import Authenticated from '@/views/Authenticated.vue'
 import CubeProjects from '@/views/CubeProjects.vue'
+import CubeProject from '@/views/CubeProject.vue'
 
 Vue.use(VueRouter)
 
@@ -20,6 +21,11 @@ const routes: Array<RouteConfig> = [
         path: '/cube-projects',
         name: 'CubeProjects',
         component: CubeProjects,
+      },
+      {
+        path: '/cube-projects/:id',
+        name: 'CubeProject',
+        component: CubeProject,
       }
     ],
   },

--- a/ui/src/store/index.ts
+++ b/ui/src/store/index.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import { auth } from './modules/auth'
 import api from './modules/api'
+import cubeProjects from './modules/cube-projects'
 import { RootState } from './types'
 
 Vue.use(Vuex)
@@ -10,5 +11,6 @@ export default new Vuex.Store<RootState>({
   modules: {
     auth: auth(),
     api,
+    cubeProjects,
   },
 })

--- a/ui/src/store/modules/cube-projects.ts
+++ b/ui/src/store/modules/cube-projects.ts
@@ -1,0 +1,42 @@
+import { HydraResource } from 'alcaeus'
+import { ActionTree, MutationTree, GetterTree } from 'vuex'
+import { api } from '@/api'
+import { RootState } from '../types'
+import * as ns from '@cube-creator/core/namespace'
+
+export interface CubeProjectsState {
+  collection: null | HydraResource,
+}
+
+const initialState = {
+  collection: null,
+}
+
+const getters: GetterTree<CubeProjectsState, RootState> = {
+}
+
+const actions: ActionTree<CubeProjectsState, RootState> = {
+  async fetchCollection (context) {
+    const entrypoint = context.rootState.api.entrypoint
+    const collectionURI = entrypoint?.get(ns.cc.projects)?.id
+
+    if (!collectionURI) throw new Error('Missing projects collection in entrypoint')
+
+    const collection = await api.fetchResource(collectionURI.value)
+    context.commit('storeCollection', collection)
+  }
+}
+
+const mutations: MutationTree<CubeProjectsState> = {
+  storeCollection (state, collection) {
+    state.collection = collection
+  }
+}
+
+export default {
+  namespaced: true,
+  state: initialState,
+  getters,
+  actions,
+  mutations,
+}

--- a/ui/src/views/Authenticated.vue
+++ b/ui/src/views/Authenticated.vue
@@ -1,6 +1,6 @@
 <template>
   <router-view v-if="apiEntrypoint" />
-  <b-loading v-else active />
+  <b-loading v-else active :is-full-page="false" />
 </template>
 
 <script>

--- a/ui/src/views/CubeProject.vue
+++ b/ui/src/views/CubeProject.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    Hey
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'CubeProject',
+})
+</script>

--- a/ui/src/views/CubeProjects.vue
+++ b/ui/src/views/CubeProjects.vue
@@ -1,11 +1,46 @@
 <template>
   <div>
-    The cube projects
+    <h2 class="title">
+      Cube projects
+    </h2>
+    <div v-if="projects && projects.length > 0" class="panel">
+      <router-link
+        v-for="project in projects"
+        :key="project.id.value"
+        :to="{ name: 'CubeProject', params: { id: project.id.value } }"
+        class="panel-block"
+      >
+        {{ project.title }}
+      </router-link>
+    </div>
+    <p v-else-if="projects && projects.length === 0" class="has-text-grey">
+      No projects yet
+    </p>
+    <b-loading v-else active :is-full-page="false" />
   </div>
 </template>
 
 <script>
-export default {
+import Vue from 'vue'
+import { mapState } from 'vuex'
+
+export default Vue.extend({
   name: 'CubeProjects',
-}
+
+  async mounted () {
+    await this.$store.dispatch('cubeProjects/fetchCollection')
+  },
+
+  computed: {
+    ...mapState({
+      projectsCollection: (state) => state.cubeProjects.collection
+    }),
+
+    projects () {
+      if (!this.projectsCollection) return null
+
+      return this.projectsCollection.members
+    }
+  }
+})
 </script>


### PR DESCRIPTION
Part of #12 

Depends on #19 

I figured it would make easier for other people to continue if I wrote an example of how to use the API.

This PR loads the projects collection and displays a list of projects. The main difference with the data-cube-curation project is that I tried to "embrace" Hydra/Alcaeus more. The API wrapper is way lighter and I do a bit more work in the Vuex store. We'll see how this works out.

I didn't setup any [Alcaeus mixin](https://alcaeus.hydra.how/latest/representations/mixins.html) yet, but that's probably going to make things easier in the next steps.