### PR TITLE
Docker/API: use a numeric UID instead of a user name

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -36,7 +36,9 @@ RUN apk add --no-cache tini
 ENTRYPOINT ["tini", "--", "node"]
 
 EXPOSE 45670
-USER nobody
+# USER nobody. Needs to be a numeric UID, else the "runAsNonRoot" security
+# directive in Kubernetes does not work.
+USER 65534
 
 WORKDIR /app/apis
 CMD ["core"]


### PR DESCRIPTION
The Kubernetes manifests have a `runAsNonRoot` policy. But because the user set in the Dockerfile is a username and not a user ID, Kubernetes can't check if that username is not actually `root` without running the image, so it refuses to run the image.

*/me goes fixing his "Docker best practices" doc*