### PR TITLE
Docker: Serve the app under /app/

### DIFF
--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -13,7 +13,6 @@ WORKDIR /app/ui
 
 ENV NODE_ENV=production
 ENV VUE_APP_API_URL=/
-ENV BASE_URL=/app/
 RUN yarn build
 
 FROM nginx:1.16.0-alpine
@@ -22,4 +21,4 @@ HEALTHCHECK --timeout=1s --retries=99 \
          || exit 1
 
 ADD ./nginx/default.conf /etc/nginx/conf.d/default.conf
-COPY --from=builder /app/ui/dist /usr/share/nginx/html
+COPY --from=builder /app/ui/dist /usr/share/nginx/html/app

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -17,7 +17,7 @@ server {
   index index.html index.html;
 
   location / {
-    try_files $uri /index.html =404;
+    try_files $uri /app/index.html =404;
   }
 
   ## Proxy requests to "/auth" and "/api" to api-server.

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  publicPath: process.env.NODE_ENV === 'production'
+    ? '/app/'
+    : '/',
   devServer: {
     disableHostCheck: true
   }


### PR DESCRIPTION
That was not really the case, now it is. Please check that the changes in `vue.config.js` do not break the dev environment, I haven't set it up locally.