### PR TITLE
refactor(api): authorize explicitly

### DIFF
--- a/apis/core/hydra/index.ttl
+++ b/apis/core/hydra/index.ttl
@@ -1,5 +1,7 @@
-@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
-@prefix code:  <https://code.described.at/> .
+prefix hydra:  <http://www.w3.org/ns/hydra/core#>
+prefix code:   <https://code.described.at/>
+prefix auth:   <http://hypermedia.app/auth#>
+PREFIX scopes: <https://cube-creator.zazuko.com/scopes#>
 
 <api>
   a
@@ -8,9 +10,12 @@
     <> ;
   hydra:supportedClass
     hydra:Resource,
-    hydra:Collection .
+    hydra:Collection
+.
 
 hydra:Resource
+  auth:scopes
+    scopes:pipelines-read ;
   hydra:supportedOperation
     [
       hydra:method
@@ -25,6 +30,8 @@ hydra:Resource
     ] .
 
 hydra:Collection
+  auth:scopes
+    scopes:pipelines-read ;
   hydra:supportedOperation
     [
       hydra:method

--- a/apis/core/hydra/projects.ttl
+++ b/apis/core/hydra/projects.ttl
@@ -1,9 +1,13 @@
-BASE          <urn:hydra-box:api>
-PREFIX cc:    <https://cube-creator.zazuko.com/vocab#>
-prefix hydra: <http://www.w3.org/ns/hydra/core#>
-prefix code:  <https://code.described.at/>
+BASE           <urn:hydra-box:api>
+PREFIX cc:     <https://cube-creator.zazuko.com/vocab#>
+prefix hydra:  <http://www.w3.org/ns/hydra/core#>
+prefix code:   <https://code.described.at/>
+prefix auth:   <http://hypermedia.app/auth#>
+PREFIX scopes: <https://cube-creator.zazuko.com/scopes#>
 
-cc:CubeProject a hydra:Class .
+cc:CubeProject
+  a
+    hydra:Class .
 
 cc:ProjectsCollection
   a
@@ -27,4 +31,6 @@ cc:ProjectsCollection
           code:link
             <file:handlers/cube-projects#post> ;
         ] ;
+      auth:scopes
+        scopes:pipelines-write
     ] .

--- a/apis/core/hydra/scopes.ttl
+++ b/apis/core/hydra/scopes.ttl
@@ -1,0 +1,16 @@
+PREFIX scopes: <https://cube-creator.zazuko.com/scopes#>
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+scopes:pipelines-read
+  rdf:first
+    "pipelines:read" ;
+  rdf:rest
+    rdf:nil ;
+.
+
+scopes:pipelines-write
+  rdf:first
+    "pipelines:write" ;
+  rdf:rest
+    rdf:nil ;
+.

--- a/apis/core/lib/auth.ts
+++ b/apis/core/lib/auth.ts
@@ -10,11 +10,11 @@ import jwksRsa from 'jwks-rsa'
 declare module '@hydrofoil/labyrinth' {
   export interface User {
     sub: string
-    permissions: string[]
+    scope: string[]
   }
 }
 
-const createJwtHandler = (credentialsRequired: boolean, jwksUri: string) => jwt({
+const createJwtHandler = (jwksUri: string) => jwt({
   // Dynamically provide a signing key
   // based on the kid in the header and
   // the signing keys provided by the JWKS endpoint.
@@ -29,7 +29,7 @@ const createJwtHandler = (credentialsRequired: boolean, jwksUri: string) => jwt(
   audience: env.AUTH_AUDIENCE,
   issuer: env.AUTH_ISSUER,
   algorithms: ['RS256'],
-  credentialsRequired,
+  credentialsRequired: false,
 })
 
 function devAuthHandler(req: Request, res: Response, next: NextFunction) {
@@ -40,13 +40,13 @@ function devAuthHandler(req: Request, res: Response, next: NextFunction) {
   }
 
   if (sub) {
-    const permissionHeader = req.headers['x-permission']
-    const permissions = typeof permissionHeader === 'string' ? permissionHeader.split(',').map(s => s.trim()) : permissionHeader || []
+    const permissionHeader = req.headers['x-scope']
+    const scope = typeof permissionHeader === 'string' ? permissionHeader.split(',').map(s => s.trim()) : permissionHeader || []
 
     req.user = {
       id: $rdf.namedNode(sub),
       sub,
-      permissions,
+      scope,
     }
 
     return next()
@@ -63,7 +63,7 @@ export default async () => {
     const response = await fetch(`${env.AUTH_ISSUER}/.well-known/openid-configuration`)
     if (response.ok) {
       const oidcConfig = await response.json()
-      router.use(createJwtHandler(env.production, oidcConfig.jwks_uri))
+      router.use(createJwtHandler(oidcConfig.jwks_uri))
     } else {
       warning('Failed to load OpenID Connect settings from issuer')
     }

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@cube-creator/core": "*",
-    "@hydrofoil/labyrinth": "^0.1.4",
+    "@hydrofoil/labyrinth": "^0.1.5",
     "@rdfjs/express-handler": "tpluscode/express-handler#dataset-multiple-times",
     "@rdfjs/namespace": "^1.1.0",
     "@rdfjs/parser-n3": "^1.1.4",

--- a/e2e-tests/cube-projects/create-invalid.hydra
+++ b/e2e-tests/cube-projects/create-invalid.hydra
@@ -4,7 +4,7 @@ PREFIX cc: <https://cube-creator.zazuko.com/vocab#>
 
 HEADERS {
   x-user "john-doe"
-  x-permission "pipelines:write"
+  x-scope "pipelines:read, pipelines:write"
 }
 
 With Class api:EntryPoint {

--- a/e2e-tests/cube-projects/create.hydra
+++ b/e2e-tests/cube-projects/create.hydra
@@ -5,7 +5,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 HEADERS {
   x-user "john-doe"
-  x-permission "pipelines:write"
+  x-scope "pipelines:read, pipelines:write"
 }
 
 With Class api:EntryPoint {

--- a/e2e-tests/entrypoint.hydra
+++ b/e2e-tests/entrypoint.hydra
@@ -4,7 +4,7 @@ PREFIX cc: <https://cube-creator.zazuko.com/vocab#>
 
 HEADERS {
   x-user "john-doe"
-  x-permission "pipelines:read"
+  x-scope "pipelines:read"
 }
 
 With Class api:EntryPoint {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,10 +1000,10 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@hydrofoil/labyrinth@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@hydrofoil/labyrinth/-/labyrinth-0.1.4.tgz#c9c7e8bbf01dfcbcb39da61eb653f59b0b543736"
-  integrity sha512-3C8lYS6Dck3PrOdKTuQkkphGes2Q4CL0ahZs2xZi9GMcYOg9TX4w11+c7fOcdHBF6gx8AWKmykdwMRxjdSAAzQ==
+"@hydrofoil/labyrinth@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@hydrofoil/labyrinth/-/labyrinth-0.1.5.tgz#9f7393dd8de25ada609b44d12e0daa1065fcc99e"
+  integrity sha512-4+yxdDo0UHV7OWpQ6y02MjDJqmw2KufBWpF1uTQAjuIM6mJSr00NzRZnmfZNs2iov6ZvxhrGa8jNNOcJjbA1Hw==
   dependencies:
     "@fcostarodrigo/walk" "^5.0.0"
     "@rdfine/hydra" "^0.3.12"


### PR DESCRIPTION
Related to a discussion with @sandhose, I propose not to secure the entire API by default and instead apply scope-based restrictions on specific handlers/classes