### PR TITLE
fix: avoid access on property of null

### DIFF
--- a/ui/src/api/errors.ts
+++ b/ui/src/api/errors.ts
@@ -5,7 +5,7 @@ export class APIError extends Error {
   response: HydraResponse;
 
   constructor (details: any, response: HydraResponse) {
-    const message = details.title || 'Unknown error'
+    const message = details?.title || 'Unknown error'
 
     super(message)
 


### PR DESCRIPTION
I run into a access of a property of a variable which is null.

details can be null
