### PR TITLE
Docker: Have some logs by default

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -15,6 +15,7 @@ services:
       environment:
         TS_NODE_TRANSPILE_ONLY: "true"
         TS_NODE_PROJECT: apis/core/tsconfig.json
+        # This should be kept in sync with api.Dockerfile
         DEBUG: creator*,hydra*,hydra-box*,labyrinth*
     moreHttpPorts:
       - 45671

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -36,6 +36,10 @@ ADD apis/core/hydra/*.ttl ./apis/core/hydra/
 RUN apk add --no-cache tini
 ENTRYPOINT ["tini", "--", "node"]
 
+# Have some logs by default
+# This should be kept in sync with .lando.yml
+ENV DEBUG creator*,hydra*,hydra-box*,labyrinth*
+
 EXPOSE 45670
 # USER nobody. Needs to be a numeric UID, else the "runAsNonRoot" security
 # directive in Kubernetes does not work.


### PR DESCRIPTION
This adds some logs by default. Having `*` is too verbose (especially because of the healthchecks), but at least having some logs when the app starts is nice.

@tpluscode If you have other log scopes to suggest, please do!