### PR TITLE
fix: start core after fuseki is stared

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -17,6 +17,9 @@ services:
         TS_NODE_PROJECT: apis/core/tsconfig.json
         # This should be kept in sync with api.Dockerfile
         DEBUG: creator*,hydra*,hydra-box*,labyrinth*
+      depends_on: 
+        store:
+          condition: service_healthy
     moreHttpPorts:
       - 45671
   ui:
@@ -35,6 +38,11 @@ services:
         ENABLE_UPLOAD: "true"
       volumes:
         - ./fuseki/config.ttl:/data/fuseki/config/config.ttl
+      healthcheck:
+        test: wget --no-verbose --tries=1 --spider http://localhost:3030 || exit 1
+        interval: 5s
+        timeout: 3s
+        retries: 3    
   s3:
     type: compose
     ssl: false

--- a/e2e-tests/install-lando.sh
+++ b/e2e-tests/install-lando.sh
@@ -4,6 +4,6 @@ sudo apt-get -y update || true
 sudo apt-get -y install cgroup-bin curl
 curl -fsSL https://get.docker.com -o get-docker.sh
 sh get-docker.sh
-curl -fsSL -o /tmp/lando-latest.deb https://github.com/lando/lando/releases/download/v3.0.11/lando-v3.0.11.deb
+curl -fsSL -o /tmp/lando-latest.deb https://github.com/lando/lando/releases/download/v3.0.14/lando-v3.0.14.deb
 sudo dpkg -i /tmp/lando-latest.deb
 lando version


### PR DESCRIPTION
fix #60
Core Container starts only when fuseki is up and running
Healthcheck of fuseki via wget 
(https://stackoverflow.com/questions/47722898/how-to-do-a-docker-healthcheck-with-wget-instead-of-curl)