### PR TITLE
chore(ui): do not display build progress

### DIFF
--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -3,6 +3,7 @@ const publicPath = process.env.PUBLIC_PATH || '/'
 module.exports = {
   publicPath,
   devServer: {
-    disableHostCheck: true
+    disableHostCheck: true,
+    progress: false
   }
 }


### PR DESCRIPTION
Do not display UI build progress to reduce noise in the lando logs.