### PR TITLE
feat(csv): error if file added twice to same project

### DIFF
--- a/apis/core/lib/domain/csv-source/upload.ts
+++ b/apis/core/lib/domain/csv-source/upload.ts
@@ -11,6 +11,8 @@ import { ResourceStore } from '../../ResourceStore'
 import * as id from '../identifiers'
 import { loadFileHeadString } from '../csv/file-head'
 import { sniffParse } from '../csv'
+import { sourceWithFilenameExists } from '../queries/csv-source'
+import { Conflict } from 'http-errors'
 
 interface UploadCSVCommand {
   file: Readable
@@ -26,6 +28,11 @@ export async function uploadFile({
   store,
 }: UploadCSVCommand): Promise<GraphPointer> {
   const csvMapping = await store.get(resource)
+
+  if (await sourceWithFilenameExists(csvMapping.term, fileName)) {
+    throw new Conflict(`A file with ${fileName} has already been added to the project`)
+  }
+
   const key = `${csvMapping.value.replace(env.API_CORE_BASE, '')}/${fileName}`
   const upload = await saveFile(key, file)
 

--- a/apis/core/lib/domain/queries/csv-source.ts
+++ b/apis/core/lib/domain/queries/csv-source.ts
@@ -1,0 +1,21 @@
+import { NamedNode } from 'rdf-js'
+import { ASK } from '@tpluscode/sparql-builder'
+import { cc } from '@cube-creator/core/namespace'
+import { schema } from '@tpluscode/rdf-ns-builders'
+import { client } from './query-client'
+
+export async function sourceWithFilenameExists(csvMapping: NamedNode, fileName: string): Promise<boolean> {
+  const result = await ASK`
+      GRAPH ${csvMapping} 
+      {
+        ${csvMapping} ${cc.csvSource} ?source
+      }
+      GRAPH ?source
+      {
+          ?source ${schema.name} "${fileName}"
+      }
+      `
+    .execute(client.query)
+
+  return result
+}

--- a/apis/core/lib/domain/queries/csv-source.ts
+++ b/apis/core/lib/domain/queries/csv-source.ts
@@ -5,17 +5,15 @@ import { schema } from '@tpluscode/rdf-ns-builders'
 import { client } from './query-client'
 
 export async function sourceWithFilenameExists(csvMapping: NamedNode, fileName: string): Promise<boolean> {
-  const result = await ASK`
+  return await ASK`
       GRAPH ${csvMapping} 
       {
         ${csvMapping} ${cc.csvSource} ?source
       }
       GRAPH ?source
       {
-          ?source ${schema.name} "${fileName}"
+        ?source ${schema.name} "${fileName}"
       }
       `
     .execute(client.query)
-
-  return result
 }

--- a/apis/core/lib/domain/queries/query-client.ts
+++ b/apis/core/lib/domain/queries/query-client.ts
@@ -1,0 +1,10 @@
+import ParsingClient from 'sparql-http-client/ParsingClient'
+import env from '../../env'
+
+export const client = new ParsingClient({
+  endpointUrl: env.STORE_QUERY_ENDPOINT,
+  updateUrl: env.STORE_UPDATE_ENDPOINT,
+  storeUrl: env.STORE_GRAPH_ENDPOINT,
+  user: env.maybe.STORE_ENDPOINTS_USERNAME,
+  password: env.maybe.STORE_ENDPOINTS_PASSWORD,
+})

--- a/e2e-tests/csv-source/upload.hydra
+++ b/e2e-tests/csv-source/upload.hydra
@@ -57,6 +57,20 @@ With Class cc:CubeProject {
                     }
                 }
 
+                                Invoke {
+                    Content-Type "text/csv"
+                    Content-Disposition "file; filename='test2.jpg'"
+
+                    ```
+                    C,D,E
+                    1,2,test
+                    ```
+                } => {
+                    Expect Status 201
+                    Expect Type <https://cube-creator.zazuko.com/vocab#CSVSource>
+                    Expect Property <http://schema.org/associatedMedia>
+                }
+
                 Invoke {
                     Content-Type "text/csv"
                     Content-Disposition "file; filename='test.jpg'"
@@ -66,9 +80,7 @@ With Class cc:CubeProject {
                     1,2,test
                     ```
                 } => {
-                    Expect Status 201
-                    Expect Type <https://cube-creator.zazuko.com/vocab#CSVSource>
-                    Expect Property <http://schema.org/associatedMedia>
+                    Expect Status 409
                 }
             }
         }

--- a/e2e-tests/csv-source/upload.hydra
+++ b/e2e-tests/csv-source/upload.hydra
@@ -57,7 +57,7 @@ With Class cc:CubeProject {
                     }
                 }
 
-                                Invoke {
+                Invoke {
                     Content-Type "text/csv"
                     Content-Disposition "file; filename='test2.jpg'"
 

--- a/ui/src/api/errors.ts
+++ b/ui/src/api/errors.ts
@@ -1,10 +1,12 @@
 import { HydraResponse } from 'alcaeus'
 
+type ErrorDetails = Record<string, any>
+
 export class APIError extends Error {
-  details: any;
+  details: ErrorDetails | null;
   response: HydraResponse;
 
-  constructor (details: any, response: HydraResponse) {
+  constructor (details: ErrorDetails, response: HydraResponse) {
     const message = details?.title || 'Unknown error'
 
     super(message)
@@ -28,6 +30,8 @@ export class APIError extends Error {
         return new APIErrorNotFound(details, response)
       case 400:
         return new APIErrorValidation(details, response)
+      case 409:
+        return new APIErrorConflict(details, response)
       default:
         return new APIError(details, response)
     }
@@ -36,3 +40,4 @@ export class APIError extends Error {
 
 export class APIErrorNotFound extends APIError {}
 export class APIErrorValidation extends APIError {}
+export class APIErrorConflict extends APIError {}

--- a/ui/src/views/CSVUpload.vue
+++ b/ui/src/views/CSVUpload.vue
@@ -71,6 +71,7 @@ export default Vue.extend({
         } else if (e instanceof APIErrorValidation) {
           this.error = e.details.title
         } else {
+          console.error(e)
           this.error = e.toString()
         }
       } finally {

--- a/ui/src/views/CSVUpload.vue
+++ b/ui/src/views/CSVUpload.vue
@@ -40,6 +40,7 @@
 <script>
 import Vue from 'vue'
 import SidePane from '@/components/SidePane.vue'
+import { APIErrorConflict, APIErrorValidation } from '@/api/errors'
 
 export default Vue.extend({
   name: 'CSVUpload',
@@ -65,9 +66,13 @@ export default Vue.extend({
 
         this.$router.push({ name: 'CSVMapping' })
       } catch (e) {
-        console.error(e)
-        // TODO: Improve error display
-        this.error = e
+        if (e instanceof APIErrorConflict) {
+          this.error = 'Cannot upload a file with the same name twice'
+        } else if (e instanceof APIErrorValidation) {
+          this.error = e.details.title
+        } else {
+          this.error = e.toString()
+        }
       } finally {
         loader.close()
       }


### PR DESCRIPTION
fixes #61 

When a file with the same name is uploaded twice an error 409 Conflict is thrown.

To test if this is the case, it is checked if there exists an other CSVSource with the same schema:name.

```TypeScript 
const result = await ASK`
      GRAPH ${csvMapping} 
      {
        ${csvMapping} ${cc.csvSource} ?source
      }
      GRAPH ?source
      {
          ?source ${schema.name} "${fileName}"
      }
      `
    .execute(client.query)
```

I added a new folder structure in domain for sparql queries. 