### PR TITLE
chore: bump versions for initial integ deployment

### DIFF
--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cube-creator/core-api",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "build": "tsc"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cube-creator/ui",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
Bumping `@cube-creator/ui` and `@cube-creator/core-api` to `0.0.1`, we needed a tag for the initial deployment to the integ environment. I went for [v0.0.1](https://github.com/zazuko/cube-creator/releases/tag/v0.0.1) and it doesn't matter that much at this point as long as we can make sure GitHub Actions picks it up and deploys to integ.