### PR TITLE
ENV variable fix in UI build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 node_modules/
+**/node_modules/
 .git/
 dist/
 *.Dockerfile
+minio/

--- a/packages/core/env.ts
+++ b/packages/core/env.ts
@@ -34,7 +34,6 @@ type ENV_VARS =
   | 'STORE_ENDPOINTS_USERNAME'
   | 'STORE_ENDPOINTS_PASSWORD'
   | 'API_CORE_BASE'
-  | 'VUE_APP_API_CORE_BASE'
   | 'AWS_S3_ENDPOINT'
   | 'AWS_S3_BUCKET'
   | 'AWS_ACCESS_KEY_ID'
@@ -50,5 +49,4 @@ const env = new Proxy(process.env, handler) as typeof process['env'] & KnownVari
   maybe: Partial<KnownVariables>
 }
 
-export const baseUri = env.maybe.API_CORE_BASE || env.VUE_APP_API_CORE_BASE
 export default env

--- a/packages/core/namespaces/shapes.ts
+++ b/packages/core/namespaces/shapes.ts
@@ -1,6 +1,8 @@
 import namespace from '@rdf-esm/namespace'
 import { NamedNode } from 'rdf-js'
-import { baseUri } from '../env'
+import env from '../env'
+
+export const baseUri = env.maybe.API_CORE_BASE || ''
 
 type ShapeTerms =
   'cube-project/create' | 'cube-project/create#CSV' | 'cube-project/create#ExistingCube'


### PR DESCRIPTION
The `import { shape } from '@cube-creator/core/namespace'` is based in the APIs base URL and hence the namespace builder uses that to initialise. 

I thought to the have this also usable in the VUE app but turns out it does not bundle the env var and it's not available at runtime as I'd hoped.

For now I change that to ignore the base if in the UI, so that the URI will be relative.