### PR TITLE
feat: use collection resource to populate dash:InstancesSelectEditor

### DIFF
--- a/apis/core/bootstrap/shapes/table.ts
+++ b/apis/core/bootstrap/shapes/table.ts
@@ -14,6 +14,7 @@ ${shape('table/create')} {
       ${sh.maxCount} 1 ;
       ${sh.class} ${cc.CSVSource} ;
       ${sh.order} 10 ;
+      ${dash.editor} ${dash.InstancesSelectEditor} ;
     ] ;
     ${sh.property} [
       ${sh.name} "Table name" ;

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -32,6 +32,7 @@ type OtherTerms =
 
 type CubeCreatorNamespace = Record<CubeCreatorClass | CubeCreatorProperty | OtherTerms, NamedNode>
 
+export const hashi = namespace('http://hypermedia.app/shapes#')
 export const cube = namespace('http://ns.bergnet.org/cube/')
 export const cc: CubeCreatorNamespace = namespace('https://cube-creator.zazuko.com/vocab#') as any
 export const editor = namespace(cc.dash.value)

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,6 +17,7 @@
     "@hydrofoil/shaperone-wc": "^0.1.1",
     "@rdf-esm/data-model": "^0.5.3",
     "@rdf-esm/dataset": "^0.5.1",
+    "@rdfine/shacl": "^0.5.1",
     "@tpluscode/rdf-ns-builders": "^0.4",
     "@tpluscode/rdfine": "^0.5.10",
     "alcaeus": "1.0.0-RC.4",

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -1,6 +1,7 @@
 import { Hydra } from 'alcaeus/web'
 import { RdfResource, Resource, RuntimeOperation } from 'alcaeus'
 import { RdfResourceCore } from '@tpluscode/rdfine/RdfResource'
+import { ShapeBundle } from '@rdfine/shacl/bundles'
 import store from '@/store'
 import { APIError } from './errors'
 import { apiResourceMixin } from './mixins/ApiResource'
@@ -32,6 +33,7 @@ Hydra.resources.factory.addMixin(CSVSourceMixin)
 Hydra.resources.factory.addMixin(CSVColumnMixin)
 Hydra.resources.factory.addMixin(TableCollectionMixin)
 Hydra.resources.factory.addMixin(TableMixin)
+Hydra.resources.factory.addMixin(...ShapeBundle)
 
 // Inject the access token in all requests if present
 Hydra.defaultHeaders = () => {

--- a/ui/src/forms/BulmaSelect.vue
+++ b/ui/src/forms/BulmaSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-select placeholder="Select" @input="emit">
+  <b-select placeholder="Select" @input="emit" :value="value">
     <option
       v-for="option in options"
       :value="option.id"
@@ -23,6 +23,7 @@ const labelProperty = schema.name
 export default class extends Vue {
   @Prop() collection?: RdfResource
   @Prop() update!: (newValue: string | NamedNode) => void
+  @Prop() value?: NamedNode;
 
   options: RdfResource[] = []
 

--- a/ui/src/forms/BulmaSelect.vue
+++ b/ui/src/forms/BulmaSelect.vue
@@ -1,0 +1,44 @@
+<template>
+  <b-select placeholder="Select" @input="emit">
+    <option
+      v-for="option in options"
+      :value="option.id"
+      :key="option.id.value"
+    >
+      {{ label(option) }}
+    </option>
+  </b-select>
+</template>
+
+<script lang="ts">
+import { Prop, Component, Vue } from 'vue-property-decorator'
+import { RdfResource } from '@tpluscode/rdfine'
+import { Hydra } from 'alcaeus/web'
+import { NamedNode } from 'rdf-js'
+import { schema } from '@tpluscode/rdf-ns-builders'
+
+const labelProperty = schema.name
+
+@Component
+export default class extends Vue {
+  @Prop() collection?: RdfResource
+  @Prop() update!: (newValue: string | NamedNode) => void
+
+  options: RdfResource[] = []
+
+  label (option: RdfResource) {
+    return option.getString(labelProperty, { strict: false }) || option.id.value
+  }
+
+  async mounted () {
+    if (this.collection && this.collection.id.termType === 'NamedNode') {
+      const { representation } = await Hydra.loadResource(this.collection.id)
+      this.options = representation?.root?.member || []
+    }
+  }
+
+  emit (value: NamedNode): void {
+    this.update(value)
+  }
+}
+</script>

--- a/ui/src/forms/components.ts
+++ b/ui/src/forms/components.ts
@@ -2,7 +2,7 @@ import { html, SingleEditorComponent } from '@hydrofoil/shaperone-wc'
 import * as ns from '@cube-creator/core/namespace'
 import { dash } from '@tpluscode/rdf-ns-builders'
 import { createCustomElement } from '@/forms/bulma'
-import {hashi} from '@cube-creator/core/namespace';
+import { hashi } from '@cube-creator/core/namespace'
 
 export const textField: SingleEditorComponent = {
   editor: dash.TextFieldEditor,

--- a/ui/src/forms/components.ts
+++ b/ui/src/forms/components.ts
@@ -20,7 +20,8 @@ export const instanceSelect: SingleEditorComponent = {
   editor: dash.InstancesSelectEditor,
   render ({ property, value }, { update }) {
     return html`<b-select .collection="${property.shape.get(hashi.collection)}"
-                          .update="${update}"></b-select>`
+                          .update="${update}"
+                          .value="${value.object.term}"></b-select>`
   },
   loadDependencies () {
     return [

--- a/ui/src/forms/components.ts
+++ b/ui/src/forms/components.ts
@@ -2,6 +2,7 @@ import { html, SingleEditorComponent } from '@hydrofoil/shaperone-wc'
 import * as ns from '@cube-creator/core/namespace'
 import { dash } from '@tpluscode/rdf-ns-builders'
 import { createCustomElement } from '@/forms/bulma'
+import {hashi} from '@cube-creator/core/namespace';
 
 export const textField: SingleEditorComponent = {
   editor: dash.TextFieldEditor,
@@ -11,6 +12,19 @@ export const textField: SingleEditorComponent = {
   loadDependencies () {
     return [
       import('./BulmaTextBox.vue').then(createCustomElement('b-textbox'))
+    ]
+  }
+}
+
+export const instanceSelect: SingleEditorComponent = {
+  editor: dash.InstancesSelectEditor,
+  render ({ property, value }, { update }) {
+    return html`<b-select .collection="${property.shape.get(hashi.collection)}"
+                          .update="${update}"></b-select>`
+  },
+  loadDependencies () {
+    return [
+      import('./BulmaSelect.vue').then(createCustomElement('b-select'))
     ]
   }
 }

--- a/ui/src/views/TableCreate.vue
+++ b/ui/src/views/TableCreate.vue
@@ -60,6 +60,9 @@ export default Vue.extend({
       const { representation } = await expects.load()
       const { root: shape } = representation
       if (shape) {
+        const sourceProperty = shape.property.find(p => p.class?.equals(ns.cc.CSVSource))
+        sourceProperty[ns.hashi.collection.value] = this.sourcesCollection
+
         this.shapes = shape.pointer
       }
     }
@@ -67,6 +70,7 @@ export default Vue.extend({
 
   computed: {
     ...mapState({
+      sourcesCollection: (state) => state.cubeProjects.sourcesCollection,
       operation: (state) => state.cubeProjects.tableCollection?.actions.create,
     }),
   },


### PR DESCRIPTION
I implemented the csv source select by directly linking the required `hydra:Collection` on the property.

A little out-of-band, in a better solution this would have been included on a specific instance of shape, directly linked to the table resource.