### PR TITLE
feat: use cc:identifier template for csvw:aboutUrl

### DIFF
--- a/apis/core/lib/domain/table/csvw.ts
+++ b/apis/core/lib/domain/table/csvw.ts
@@ -49,7 +49,7 @@ export async function createCsvw({
       types: [csvw.Dialect],
     },
     tableSchema: {
-      aboutUrl: `${namespace}observation/{station_id}-{year}-{aggregation_id}`,
+      aboutUrl: `${namespace}observation/${table.identifierTemplate}`,
       column: [{
         title: 'unit_id',
         datatype: xsd.string,

--- a/apis/core/test/domain/table/csvw.test.ts
+++ b/apis/core/test/domain/table/csvw.test.ts
@@ -1,79 +1,90 @@
-import { describe, it } from 'mocha'
+import { describe, it, beforeEach } from 'mocha'
 import { expect } from 'chai'
 import $rdf from 'rdf-ext'
-import clownface from 'clownface'
+import clownface, { GraphPointer } from 'clownface'
 import { cc } from '@cube-creator/core/namespace'
 import { csvw, rdf, schema } from '@tpluscode/rdf-ns-builders'
 import { createCsvw } from '../../../lib/domain/table/csvw'
 import { TestResourceStore } from '../../support/TestResourceStore'
+import { ResourceStore } from '../../../lib/ResourceStore'
+import { NamedNode } from 'rdf-js'
+import DatasetExt from 'rdf-ext/lib/Dataset'
 
 describe('domain/table/csvw', () => {
   describe('createCsvw', () => {
-    it('copies csvw:dialect from CsvSource', async function () {
-      // given
-      const tableResource = $rdf.namedNode('cc:table')
+    let table: GraphPointer<NamedNode, DatasetExt>
+    let source: GraphPointer<NamedNode, DatasetExt>
+    let mapping: GraphPointer<NamedNode, DatasetExt>
+    let resources: ResourceStore
+
+    beforeEach(() => {
+      const tableId = $rdf.namedNode('cc:table')
       const sourceId = $rdf.namedNode('cc:source')
       const mappingId = $rdf.namedNode('cc:mapping')
-      const resources = new TestResourceStore([
-        clownface({ dataset: $rdf.dataset() })
-          .node(tableResource)
-          .addOut(cc.csvSource, sourceId)
-          .addOut(cc.csvw, $rdf.namedNode('cc:table/csvw'))
-          .addOut(cc.csvMapping, mappingId),
-        clownface({ dataset: $rdf.dataset() })
-          .namedNode(mappingId)
-          .addOut(rdf.type, cc.CsvMapping)
-          .addOut(cc.namespace, $rdf.namedNode('http://example.com/cube')),
-        clownface({ dataset: $rdf.dataset() })
-          .node(sourceId)
-          .addOut(schema.associatedMedia, media => {
-            media.addOut(schema.contentUrl, $rdf.namedNode('content url'))
-          })
-          .addOut(csvw.dialect, dialect => {
-            dialect.addOut(csvw.quoteChar, '""')
-            dialect.addOut(csvw.delimiter, '-')
-          }),
+      table = clownface({ dataset: $rdf.dataset() })
+        .namedNode(tableId)
+        .addOut(cc.csvSource, sourceId)
+        .addOut(cc.csvw, $rdf.namedNode('cc:table/csvw'))
+        .addOut(cc.csvMapping, mappingId)
+      mapping = clownface({ dataset: $rdf.dataset() })
+        .namedNode(mappingId)
+        .addOut(rdf.type, cc.CsvMapping)
+        .addOut(cc.namespace, $rdf.namedNode('http://example.com/cube/'))
+      source = clownface({ dataset: $rdf.dataset() })
+        .node(sourceId)
+        .addOut(csvw.dialect)
+
+      resources = new TestResourceStore([
+        table,
+        source,
+        mapping,
       ])
+    })
+
+    it('copies csvw:dialect from CsvSource', async function () {
+      // given
+      source
+        .addOut(schema.associatedMedia, media => {
+          media.addOut(schema.contentUrl, $rdf.namedNode('content url'))
+        })
+        .out(csvw.dialect)
+        .addOut(csvw.quoteChar, '""')
+        .addOut(csvw.delimiter, '-')
 
       // when
-      const table = await createCsvw({
+      const generatedCsvw = await createCsvw({
         resources,
-        tableResource,
+        tableResource: table.term,
       })
 
       // then
-      expect(table.dialect?.quoteChar).to.eq('""')
-      expect(table.dialect?.delimiter).to.eq('-')
+      expect(generatedCsvw.dialect?.quoteChar).to.eq('""')
+      expect(generatedCsvw.dialect?.delimiter).to.eq('-')
     })
 
     it('copies sources url to csvw:url', async function () {
-      // given
-      const tableResource = $rdf.namedNode('cc:table')
-      const sourceId = $rdf.namedNode('cc:source')
-      const mappingId = $rdf.namedNode('cc:mapping')
-      const resources = new TestResourceStore([
-        clownface({ dataset: $rdf.dataset() })
-          .node(tableResource)
-          .addOut(cc.csvSource, sourceId)
-          .addOut(cc.csvw, $rdf.namedNode('cc:table/csvw'))
-          .addOut(cc.csvMapping, mappingId),
-        clownface({ dataset: $rdf.dataset() })
-          .namedNode(mappingId)
-          .addOut(rdf.type, cc.CsvMapping)
-          .addOut(cc.namespace, $rdf.namedNode('http://example.com/cube')),
-        clownface({ dataset: $rdf.dataset() })
-          .node(sourceId)
-          .addOut(csvw.dialect),
-      ])
-
       // when
-      const table = await createCsvw({
+      const generatedCsvw = await createCsvw({
         resources,
-        tableResource,
+        tableResource: table.term,
       })
 
       // then
-      expect(table.url).to.equal(sourceId.value)
+      expect(generatedCsvw.url).to.equal(source.value)
+    })
+
+    it('constructs observation table aboutUrl by concatenating namespace and id template', async () => {
+      // given
+      table.addOut(cc.identifierTemplate, '{foo}/{bar}/{baz}')
+
+      // when
+      const generatedCsvw = await createCsvw({
+        resources,
+        tableResource: table.term,
+      })
+
+      // then
+      expect(generatedCsvw.tableSchema?.aboutUrl).to.eq('http://example.com/cube/observation/{foo}/{bar}/{baz}')
     })
   })
 })

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -206,7 +206,8 @@ graph <project/ubd/csv-mapping/table-observation> {
     cc:csvSource <cube-project/ubd/csv-source/ubd> ;
     schema:name "Observations" ;
     schema:color "#AAAAAA" ;
-    cc:identifierTemplate "ammonia/observation/{STATION}-{YEAR}-annualmean" ;
+    # cc:identifierTemplate "ammonia/observation/{STATION}-{YEAR}-annualmean" ;
+    cc:identifierTemplate "{station_id}-{year}-{aggregation_id}" ;
     cc:columnMapping <project/ubd/csv-mapping/table-observation/column-mapping-1> ;
     cc:columnMapping <project/ubd/csv-mapping/table-observation/column-mapping-2> ;
     cc:columnMapping <project/ubd/csv-mapping/table-observation/column-mapping-3> ;
@@ -266,7 +267,8 @@ graph <project/ubd/csv-mapping/table-station> {
     cc:csvw <project/ubd/csv-mapping/table-station/csvw> ;
     schema:name "Station" ;
     schema:color "#BBBBBB" ;
-    cc:identifierTemplate "station/{STATION_ID}" ;
+    # cc:identifierTemplate "station/{STATION_ID}" ;
+    cc:identifierTemplate "{station_id}-{year}-{aggregation_id}" ;
     cc:columnMapping <project/ubd/csv-mapping/table-station/column-mapping-1> ;
     cc:columnMapping <project/ubd/csv-mapping/table-station/column-mapping-2> ;
     cc:columnMapping <project/ubd/csv-mapping/table-station/column-mapping-3> ;

--- a/packages/model/Table.ts
+++ b/packages/model/Table.ts
@@ -12,6 +12,7 @@ export interface Table extends RdfResourceCore {
   csvSource: Link<CsvSource>
   name: string
   csvMapping: NamedNode
+  identifierTemplate: string
 }
 
 export function TableMixin<Base extends Constructor>(base: Base) {
@@ -28,6 +29,9 @@ export function TableMixin<Base extends Constructor>(base: Base) {
 
     @property.literal({ path: schema.name })
     name!: string
+
+    @property.literal()
+    identifierTemplate!: string
   }
 
   return Impl


### PR DESCRIPTION
With this PR the generated csvw mapping will combine the mapping's `cc:namespace` and table's `cc:identifierTemplate` to create the observation URL