### PR TITLE
fix: use cookie to store OIDC state

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,7 @@
     "alcaeus": "1.0.0-RC.4",
     "buefy": "^0.9.2",
     "bulma-quickview": "^2.0.0",
+    "cookie-storage": "^6.1.0",
     "core-js": "^3.6.5",
     "oidc-client": "^1.11.0-beta.2",
     "vue": "^2.6.11",

--- a/ui/src/store/modules/auth.ts
+++ b/ui/src/store/modules/auth.ts
@@ -1,14 +1,24 @@
+import { CookieStorage } from 'cookie-storage'
 import { Module } from 'vuex'
 import { VuexOidcClientSettings, VuexOidcState, vuexOidcCreateStoreModule } from 'vuex-oidc'
+import { WebStorageStateStore } from 'oidc-client'
 import { RootState } from '../types'
 
 const oidc = window.APP_CONFIG.oidc
 const base = new URL(process.env.BASE_URL || '/', window.location.toString())
 
+const cookieStorage = new CookieStorage({
+  path: base.pathname,
+  domain: base.hostname,
+  secure: base.protocol === 'https:',
+  sameSite: 'Strict',
+})
+
 const oidcSettings: VuexOidcClientSettings = {
   redirectUri: new URL('oidc-callback', base).toString(),
   postLogoutRedirectUri: new URL('logout', base).toString(),
   responseType: 'code',
+  stateStore: new WebStorageStateStore({ store: cookieStorage }),
   ...oidc,
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4070,6 +4070,11 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
+cookie-storage@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cookie-storage/-/cookie-storage-6.1.0.tgz#291b2f662d961be44f999626593421cbfcf23790"
+  integrity sha512-HeVqbVy8BjXhAAuFtL6MTG+witHoLbxfky2jgVh9FmxmyL6IKa9gSSyPNjevXCCCxPu6Tzd9J8+eXTRQzYU/cg==
+
 cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"


### PR DESCRIPTION
In private browsing session, Firefox treats localStorage as sessionStorage, meaning that it gets emptied whenever the site is leaved. This is a problem with the oidc-client, because it uses the localStorage to store informations about the current OIDC flow.

This patch changes the state store to use `cookie-storage`, which is a WebStorage-compatible layer on top of cookies.