### PR TITLE
fix(shacl): ability to use sh:targetNode to match request URI

### DIFF
--- a/apis/core/lib/middleware/shacl.ts
+++ b/apis/core/lib/middleware/shacl.ts
@@ -24,6 +24,10 @@ export const shaclMiddleware = (options: ShaclMiddlewareOptions) => asyncMiddlew
     const pointer = await resources.get(expects.term)
     if (pointer?.has(rdf.type, [sh.NodeShape]).values.length) {
       await shapes.addAll([...pointer.dataset])
+
+      if (pointer.out([sh.targetClass, sh.targetNode, sh.targetObjectsOf, sh.targetSubjectsOf]).values.length === 0) {
+        shapes.add($rdf.quad(pointer.term, sh.targetNode, req.hydra.term))
+      }
     }
   }))
 


### PR DESCRIPTION
Requests such as `PUT` or especially `PATCH` may not explicitly include a class triple and thus `sh:targetClass` makes no sense for validation. However, without a target no validation happens.

For these scenarios the SHACL middleware will now assume `sh:targetNode` to be the request URI (`req.hydra.term`)