### PR TITLE
ci: exclude some code from coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
       "ui",
       "typings",
       "apis/*/test",
+      "apis/*/bootstrap",
+      "apis/*/types",
       "cli/test"
     ]
   }


### PR DESCRIPTION
Removing `types` and `bootstrap` from API's coverage. The latter could be unit-tested but I think it makes little sense if any syntax mistake there either brings the entire thing down immediately and other error should be caught by e2e tests