### PR TITLE
refactor: move jobs collection to project

### DIFF
--- a/apis/core/lib/domain/csv-mapping/CsvMapping.ts
+++ b/apis/core/lib/domain/csv-mapping/CsvMapping.ts
@@ -80,27 +80,6 @@ export default function Mixin<Base extends Constructor<Omit<CsvMapping, keyof Ap
       })
     }
 
-    initializeJobCollection(store: ResourceStore) {
-      if (this.jobCollection) {
-        throw new Error('Job collection already exists')
-      }
-
-      this.jobCollection = new Hydra.CollectionMixin.Class(store.create(id.jobCollection(this)), {
-        types: [cc.JobCollection],
-        title: 'Jobs',
-        [cc.csvMapping.value]: this,
-        manages: [{
-          // ?member rdf:type cc:Job
-          property: rdf.type,
-          object: cc.Job,
-        }, {
-          // ?member cc:csvMapping <mapping>
-          object: this,
-          property: cc.csvMapping,
-        }],
-      })
-    }
-
     addSource(store: ResourceStore, { fileName }: AddSource): CsvSource.CsvSource {
       const source = CsvSource.create(store.create(id.csvSource(this, fileName)), {
         name: fileName,

--- a/apis/core/lib/domain/cube-projects/create.ts
+++ b/apis/core/lib/domain/cube-projects/create.ts
@@ -31,6 +31,7 @@ export async function createProject({
     label,
   })
 
+  project.initializeJobCollection(store)
   const dataset = Dataset.create(store.create(project.dataset))
 
   if (shape('cube-project/create#CSV').equals(resource.out(cc.projectSourceKind).term)) {

--- a/apis/core/lib/domain/identifiers.ts
+++ b/apis/core/lib/domain/identifiers.ts
@@ -36,10 +36,6 @@ export function columnMapping(table: Table, columnName: string): NamedNode {
   return $rdf.namedNode(`${table.id.value}/column-mapping/${url.slugify(columnName)}`)
 }
 
-export function jobCollection(csvMapping: CsvMapping): NamedNode {
-  return $rdf.namedNode(`${csvMapping.id.value}/jobs`)
-}
-
 export function csvSource(mapping: CsvMapping, fileName: string): NamedNode {
   return $rdf.namedNode(`${mapping.id.value}/csv-source/${url.slugify(fileName)}`)
 }

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -1,10 +1,11 @@
 import { cc } from '@cube-creator/core/namespace'
 import { GraphPointer } from 'clownface'
 import { NamedNode } from 'rdf-js'
+import * as Job from '@cube-creator/model/Job'
+import { CsvMapping, Project } from '@cube-creator/model'
 import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
 import * as id from '../identifiers'
-import { rdfs } from '@tpluscode/rdf-ns-builders'
 
 interface StartTransformationCommand {
   resource: NamedNode
@@ -16,28 +17,25 @@ export async function createJob({
   store = resourceStore(),
 }: StartTransformationCommand): Promise<GraphPointer<NamedNode>> {
   const jobCollection = (await store.get(resource))!
-  const csvMapping = jobCollection.out(cc.csvMapping).term
+  const project = await store.getResource<Project>(jobCollection.out(cc.project).term)
+  const csvMapping = await store?.getResource<CsvMapping>(project?.csvMapping?.id)
 
-  if (!csvMapping || csvMapping.termType !== 'NamedNode') {
-    throw new Error('CSV-Mapping is missing')
+  if (!project) {
+    throw new Error('Project not found from jobs collection')
   }
 
-  const csvMappingResource = (await store.get(csvMapping))!
-  const project = csvMappingResource.out(cc.project).term
-  if (project?.termType !== 'NamedNode') {
-    throw new Error('Project is missing')
+  if (!csvMapping) {
+    throw new Error('CSV Mapping not found from project')
   }
 
-  const projectResource = (await store.get(project))!
-  const cubeGraph = projectResource.out(cc.cubeGraph)
-
-  const job = await store.createMember(jobCollection.term, id.job(jobCollection))
-
-  job.addOut(cc.cubeGraph, cubeGraph)
-    .addOut(cc.tables, csvMappingResource.out(cc.tables))
-    .addOut(rdfs.label, projectResource.out(rdfs.label))
+  const jobPointer = await store.createMember(jobCollection.term, id.job(jobCollection))
+  Job.create(jobPointer, {
+    cubeGraph: project.cubeGraph,
+    label: 'Transformation job',
+    tableCollection: csvMapping.tableCollection,
+  })
 
   await store.save()
 
-  return job
+  return jobPointer
 }

--- a/apis/core/test/domain/cube-projects/create.test.ts
+++ b/apis/core/test/domain/cube-projects/create.test.ts
@@ -69,6 +69,52 @@ describe('domain/cube-projects/create', () => {
     })
   })
 
+  it('creates a job collection resource linked to itself', async () => {
+    // given
+    const resource = clownface({ dataset: $rdf.dataset() })
+      .namedNode('')
+      .addOut(rdfs.label, 'Foo bar project')
+
+    // when
+    const project = await createProject({ resource, store, projectsCollection, user })
+
+    // then
+    const jobs = await store.get(project.jobCollection.id)
+    expect(project.jobCollection.id.value).to.match(/project\/.+\/jobs$/)
+    expect(jobs).to.matchShape({
+      property: [{
+        path: rdf.type,
+        [sh.hasValue.value]: [hydra.Collection, cc.JobCollection],
+        minCount: 2,
+      }, {
+        path: hydra.manages,
+        node: {
+          xone: [{
+            property: [{
+              path: hydra.object,
+              hasValue: cc.Job,
+              minCount: 1,
+            }, {
+              path: hydra.property,
+              hasValue: rdf.type,
+              minCount: 1,
+            }],
+          }, {
+            property: [{
+              path: hydra.object,
+              hasValue: project.id,
+              minCount: 1,
+            }, {
+              path: hydra.property,
+              hasValue: cc.project,
+              minCount: 1,
+            }],
+          }],
+        },
+      }],
+    })
+  })
+
   describe('CSV project', () => {
     it('creates a CSV Mapping resource', async () => {
       // given

--- a/apis/core/test/domain/job/create.test.ts
+++ b/apis/core/test/domain/job/create.test.ts
@@ -2,9 +2,9 @@ import { describe, it, beforeEach } from 'mocha'
 import { expect } from 'chai'
 import clownface from 'clownface'
 import $rdf from 'rdf-ext'
-import { rdfs } from '@tpluscode/rdf-ns-builders'
+import { dcterms, rdf, schema } from '@tpluscode/rdf-ns-builders'
 import { cc } from '@cube-creator/core/namespace'
-
+import '../../../lib/domain'
 import { TestResourceStore } from '../../support/TestResourceStore'
 import { createJob } from '../../../lib/domain/job/create'
 
@@ -13,12 +13,14 @@ describe('domain/job/create', () => {
   const project = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('myProject') })
     .addOut(cc.csvMapping, $rdf.namedNode('myCsvMapping'))
     .addOut(cc.cubeGraph, $rdf.namedNode('myCubeGraph'))
-    .addOut(rdfs.label, 'My Cube Name')
+    .addOut(rdf.type, cc.CubeProject)
   const tableCollection = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('myTables') })
   const csvMapping = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('myCsvMapping') })
-    .addOut(cc.project, project).addOut(cc.tables, tableCollection)
+    .addOut(cc.project, project)
+    .addOut(cc.tables, tableCollection)
+    .addOut(rdf.type, cc.CsvMapping)
   const jobCollection = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('jobs') })
-    .addOut(cc.csvMapping, csvMapping)
+    .addOut(cc.project, project)
 
   beforeEach(() => {
     store = new TestResourceStore([
@@ -38,6 +40,7 @@ describe('domain/job/create', () => {
     // then
     expect(job.out(cc.cubeGraph).value).to.eq('myCubeGraph')
     expect(job.out(cc.tables).value).to.eq('myTables')
-    expect(job.out(rdfs.label).value).to.eq('My Cube Name')
+    expect(job.out(schema.name).value).to.be.ok
+    expect(job.out(dcterms.created).value).to.be.ok
   })
 })

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -22,6 +22,7 @@ graph <cube-project/ubd> {
     cc:csvMapping <cube-project/ubd/csv-mapping> ;
     dcterms:creator <user> ;
     rdfs:label "UBD28 Project" ;
+    cc:jobCollection <cube-project/jobs> ;
   .
 }
 
@@ -52,7 +53,6 @@ graph <cube-project/ubd/csv-mapping> {
     a cc:CsvMapping , hydra:Resource ;
     cc:csvSource <cube-project/ubd/csv-source/ubd> ;
     cc:csvSourceCollection <cube-project/ubd/csv-mapping/sources> ;
-    cc:jobCollection <cube-project/ubd/csv-mapping/jobs> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:namespace <https://environment.ld.admin.ch/foen/ubd/28/> ;
   .
@@ -305,16 +305,17 @@ graph <project/ubd/csv-mapping/table-station/column-mapping-3> {
   .
 }
 
-<cube-project/ubd/csv-mapping/jobs> void:inDataset <ubd-example> .
-graph <project/ubd/csv-mapping/jobs> {
-  <project/ubd/csv-mapping/jobs>
+<cube-project/ubd/jobs> void:inDataset <ubd-example> .
+graph <project/ubd/jobs> {
+  <project/ubd/jobs>
     a hydra:Collection, cc:JobCollection ;
+    cc:project <cube-project/ubd> ;
     hydra:manages [
       hydra:property rdf:type ;
       hydra:object   cc:Job ;
     ] , [
-      hydra:property cc:csvMapping ;
-      hydra:object   <cube-project/ubd/csv-mapping> ;
+      hydra:property cc:project ;
+      hydra:object   <cube-project/ubd> ;
     ]
   .
 }

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -325,7 +325,7 @@ graph <project/ubd/csv-mapping/jobs/test-job> {
   <project/ubd/csv-mapping/jobs/test-job>
     a hydra:Resource, cc:Job ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
-    schema:label "cli-test" ;
+    schema:name "cli-test" ;
     cc:cubeGraph <cube-project/ubd/cube-data> ;
     dcterms:created "2020-10-29T12:01:54"^^xsd:dateTime ;
     rdfs:seeAlso <https://github.com/zazuko/cube-creator/actions/runs/345020887> ;
@@ -338,6 +338,6 @@ graph <project/ubd/csv-mapping/jobs/broken-job> {
   <project/ubd/csv-mapping/jobs/broken-job>
     a hydra:Resource, cc:Job ;
     cc:tables <cube-project/ubd/csv-mapping/no-tables> ;
-    schema:label "cli-test" ;
+    schema:name "cli-test" ;
   .
 }

--- a/packages/model/CsvMapping.ts
+++ b/packages/model/CsvMapping.ts
@@ -14,7 +14,6 @@ export interface CsvMapping extends RdfResourceCore {
   namespace: NamedNode
   sources: CsvSource[]
   sourcesCollection: Link<Collection<CsvSource>>
-  jobCollection: Link<Collection<Job>>
   tableCollection: Link<Collection<Table>>
   project: Link<Project>
 }
@@ -29,9 +28,6 @@ export function CsvMappingMixin<Base extends Constructor>(base: Base) {
 
     @property.resource({ path: cc.csvSourceCollection })
     sourcesCollection!: Link<Collection<CsvSource>>
-
-    @property.resource({ path: cc.jobCollection })
-    jobCollection!: Link<Collection<Job>>
 
     @property.resource({ path: cc.tables })
     tableCollection!: Link<Collection<Table>>

--- a/packages/model/CsvMapping.ts
+++ b/packages/model/CsvMapping.ts
@@ -7,7 +7,6 @@ import { Table } from './Table'
 import { Link } from './lib/Link'
 import { initializer } from './lib/initializer'
 import { NamedNode } from 'rdf-js'
-import { Job } from './Job'
 import { Project } from './Project'
 
 export interface CsvMapping extends RdfResourceCore {

--- a/packages/model/Job.ts
+++ b/packages/model/Job.ts
@@ -7,12 +7,13 @@ import { Table } from './Table'
 import { Link } from './lib/Link'
 import { NamedNode } from 'rdf-js'
 import { schema, dcterms } from '@tpluscode/rdf-ns-builders'
+import { initializer } from './lib/initializer'
 
 export interface Job extends Action, Rdfs.Resource, RdfResource {
   tableCollection: Link<Collection<Table>>
-  cubeGraph?: NamedNode
+  cubeGraph: NamedNode
   label: string
-  create?: Date
+  created: Date
 }
 
 export function JobMixin<Base extends Constructor<RdfResource>>(base: Base) {
@@ -21,16 +22,22 @@ export function JobMixin<Base extends Constructor<RdfResource>>(base: Base) {
     tableCollection!: Link<Collection<Table>>
 
     @property({ path: cc.cubeGraph })
-    cubeGraph?: NamedNode
+    cubeGraph!: NamedNode
 
-    @property.literal({ path: schema.label })
+    @property.literal({ path: schema.name })
     label!: string
 
-    @property.literal({ path: dcterms.created, type: Date })
-    create!: Date
+    @property.literal({ path: dcterms.created, type: Date, initial: () => new Date() })
+    created!: Date
   }
 
   return Impl
 }
 
 JobMixin.appliesTo = cc.Job
+
+type RequiredProperties = 'label' | 'cubeGraph' | 'tableCollection'
+
+export const create = initializer<Job, RequiredProperties>(JobMixin, {
+  types: [cc.Job],
+})

--- a/packages/model/Project.ts
+++ b/packages/model/Project.ts
@@ -7,6 +7,9 @@ import { NamedNode } from 'rdf-js'
 import { dcterms } from '@tpluscode/rdf-ns-builders'
 import { initializer } from './lib/initializer'
 import { childResource } from './lib/resourceIdentifiers'
+import { Link } from './lib/Link'
+import { Collection } from '@rdfine/hydra'
+import { Job } from './Job'
 
 export interface Project extends RdfResourceCore {
   csvMapping?: CsvMapping
@@ -14,6 +17,7 @@ export interface Project extends RdfResourceCore {
   cubeGraph: NamedNode
   creator: NamedNode
   label: string
+  jobCollection: Link<Collection<Job>>
 }
 
 export function ProjectMixin<Base extends Constructor>(base: Base) {
@@ -30,6 +34,9 @@ export function ProjectMixin<Base extends Constructor>(base: Base) {
 
     @property({ path: dcterms.creator })
     creator!: NamedNode
+
+    @property.resource({ path: cc.jobCollection })
+    jobCollection!: Link<Collection<Job>>
   }
 
   return Impl


### PR DESCRIPTION
@martinmaillard rightly pointed out that we will have more jobs than just the csv transformation.

For that purpose I am moving the job collection to project resource