### PR TITLE
fix: use `rdfs:Class` for column dropdown

### DIFF
--- a/ui/src/forms/BulmaSelect.vue
+++ b/ui/src/forms/BulmaSelect.vue
@@ -15,7 +15,7 @@ import { Prop, Component, Vue } from 'vue-property-decorator'
 import { PropertyShape } from '@rdfine/shacl'
 import { Hydra } from 'alcaeus/web'
 import { NamedNode } from 'rdf-js'
-import { rdfs, schema, sh } from '@tpluscode/rdf-ns-builders'
+import { rdf, rdfs, schema, sh } from '@tpluscode/rdf-ns-builders'
 import { hashi } from '@cube-creator/core/namespace'
 import { GraphPointer } from 'clownface'
 
@@ -37,13 +37,15 @@ export default class extends Vue {
 
   async mounted (): Promise<void> {
     const collection = this.property.get(hashi.collection)
-    const shIn = this.property.pointer.out(sh.in).list()
+    const shIn = this.property.in
 
     if (collection && collection.id.termType === 'NamedNode') {
       const { representation } = await Hydra.loadResource(collection.id)
       this.options = (representation?.root?.member || []).map((resource) => resource.pointer)
-    } else if (shIn) {
-      this.options = [...shIn]
+    } else if (shIn.length) {
+      this.options = this.property.pointer.node(shIn).toArray()
+    } else if (this.property.class) {
+      this.options = this.property.pointer.any().has(rdf.type, this.property.class.id).toArray()
     }
   }
 }

--- a/ui/src/views/ColumnMappingCreate.vue
+++ b/ui/src/views/ColumnMappingCreate.vue
@@ -23,7 +23,7 @@ import SidePane from '@/components/SidePane.vue'
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
 import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
-import { csvw, schema } from '@tpluscode/rdf-ns-builders'
+import { rdf, schema } from '@tpluscode/rdf-ns-builders'
 import { dataset } from '@rdf-esm/dataset'
 
 const projectNS = namespace('project')
@@ -56,10 +56,10 @@ export default class CubeProjectEditView extends Vue {
       // Populate Column selector
       if (shape && this.table.csvSource?.clientPath) {
         const source = this.findSource(this.table.csvSource.clientPath)
-        const columnProperty: any = shape.property.find(p => p.class?.equals(csvw.Column))
-        columnProperty.in = source.columns
         source.columns.forEach((column) => {
-          shape.pointer.node(column.id).addOut(schema.name, column.name)
+          shape.pointer.node(column.id)
+            .addOut(schema.name, column.name)
+            .addOut(rdf.type, column.pointer.out(rdf.type))
         })
       }
 


### PR DESCRIPTION
Rather than injecting `sh:in` into the shape to populate the column select we can inject the column labels and their RDF types to have them selected by matching to `sh:class` annotation