### PR TITLE
feat: auto-generated identifier template

### DIFF
--- a/apis/core/bootstrap/shapes/table.ts
+++ b/apis/core/bootstrap/shapes/table.ts
@@ -36,11 +36,10 @@ ${shape('table/create')} {
     ] ;
     ${sh.property} [
       ${sh.name} "Identifier template" ;
-      ${sh.description} "Used to build a unique identifier for each row of this table. Not supported yet: Leave empty to get an auto-generated identifier." ;
+      ${sh.description} "Used to build a unique identifier for each row of this table. Leave empty to get an auto-generated identifier." ;
       ${sh.path} ${cc.identifierTemplate} ;
       ${sh.minCount} 1 ;
       ${sh.maxCount} 1 ;
-      ${sh.pattern} "[\w\d]" ;
       ${sh.defaultValue} "" ;
       ${sh.order} 30 ;
     ] ;

--- a/apis/core/lib/domain/table/create.ts
+++ b/apis/core/lib/domain/table/create.ts
@@ -71,6 +71,6 @@ export async function createTable({
 }
 
 function getTemplate(template: string | undefined, columns: CsvColumn[]): string {
-  if (template) return template
-  return columns.map((column) => `{${column.name}}`).join('/')
+  if (template?.trim()) return template
+  return columns.sort((a, b) => (a.order - b.order)).map((column) => `{${column.name}}`).join('/')
 }

--- a/apis/core/lib/domain/table/create.ts
+++ b/apis/core/lib/domain/table/create.ts
@@ -6,7 +6,7 @@ import { resourceStore } from '../resources'
 import { NamedNode } from 'rdf-js'
 import $rdf from 'rdf-ext'
 import { NotFoundError } from '../../errors'
-import { CsvMapping, CsvSource } from '@cube-creator/model'
+import { CsvColumn, CsvMapping, CsvSource } from '@cube-creator/model'
 
 const trueTerm = $rdf.literal('true', xsd.boolean)
 
@@ -41,16 +41,17 @@ export async function createTable({
     throw new NotFoundError(csvSourceId)
   }
 
+  const columns = [...csvSource.columns]
+
   const table = await csvMapping.addTable(store, {
     name: label.value,
     csvSource,
-    identifierTemplate: resource.out(cc.identifierTemplate).value,
+    identifierTemplate: getTemplate(resource.out(cc.identifierTemplate).value, columns),
     color: resource.out(schema.color).value,
     isObservationTable: trueTerm.equals(resource.out(cc.isObservationTable).term),
   })
 
   // Create default column mappings for provided columns
-  const columns = [...csvSource.columns]
   resource.out(csvw.column)
     .forEach(({ term: columnId }) => {
       const column = columns
@@ -67,4 +68,9 @@ export async function createTable({
 
   await store.save()
   return table.pointer
+}
+
+function getTemplate(template: string | undefined, columns: CsvColumn[]): string {
+  if (template) return template
+  return columns.map((column) => `{${column.name}}`).join('/')
 }

--- a/apis/core/test/domain/table/create.test.ts
+++ b/apis/core/test/domain/table/create.test.ts
@@ -2,7 +2,7 @@ import { describe, it, beforeEach } from 'mocha'
 import { expect } from 'chai'
 import clownface from 'clownface'
 import $rdf from 'rdf-ext'
-import { csvw, hydra, rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
+import { csvw, dtype, hydra, rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
 import { cc } from '@cube-creator/core/namespace'
 import { createTable } from '../../../lib/domain/table/create'
 import { TestResourceStore } from '../../support/TestResourceStore'
@@ -149,8 +149,8 @@ describe('domain/table/create', () => {
       .addOut(cc.identifierTemplate, '')
       .addOut(cc.csvSource, $rdf.namedNode('foo'))
       .addOut(csvw.column, [$rdf.namedNode('source-column-1'), $rdf.namedNode('source-column-2')])
-    csvSource.addOut(csvw.column, $rdf.namedNode('source-column-1'), column => column.addOut(schema.name, 'column 1'))
-    csvSource.addOut(csvw.column, $rdf.namedNode('source-column-2'), column => column.addOut(schema.name, 'column 2'))
+    csvSource.addOut(csvw.column, $rdf.namedNode('source-column-1'), column => column.addOut(schema.name, 'column 1').addOut(dtype.order, 0))
+    csvSource.addOut(csvw.column, $rdf.namedNode('source-column-2'), column => column.addOut(schema.name, 'column 2').addOut(dtype.order, 1))
 
     // when
     const table = await createTable({ resource, store, tableCollection })

--- a/apis/core/test/domain/table/create.test.ts
+++ b/apis/core/test/domain/table/create.test.ts
@@ -140,4 +140,22 @@ describe('domain/table/create', () => {
       }],
     })
   })
+
+  it('generates template if missing', async () => {
+    const resource = clownface({ dataset: $rdf.dataset() })
+      .node($rdf.namedNode(''))
+      .addOut(schema.name, 'the name')
+      .addOut(schema.color, '#aaa')
+      .addOut(cc.identifierTemplate, '')
+      .addOut(cc.csvSource, $rdf.namedNode('foo'))
+      .addOut(csvw.column, [$rdf.namedNode('source-column-1'), $rdf.namedNode('source-column-2')])
+    csvSource.addOut(csvw.column, $rdf.namedNode('source-column-1'), column => column.addOut(schema.name, 'column 1'))
+    csvSource.addOut(csvw.column, $rdf.namedNode('source-column-2'), column => column.addOut(schema.name, 'column 2'))
+
+    // when
+    const table = await createTable({ resource, store, tableCollection })
+
+    // then
+    expect(table.out(cc.identifierTemplate).value).to.eq('{column 1}/{column 2}')
+  })
 })

--- a/e2e-tests/table/create.hydra
+++ b/e2e-tests/table/create.hydra
@@ -57,7 +57,7 @@ With Class cc:TableCollection {
                 cc:isObservationTable false .
             ```
         } => {
-            Expect Status 400
+            Expect Status 201
         }
     }
 }


### PR DESCRIPTION
when there is no template the set `{column name 1}/{column name 2}`

fixes #170 