### PR TITLE
refactor: re-remove raw-loader and copy expand into a local module

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -59,7 +59,6 @@
     "cypress-file-upload": "^4.1.1",
     "eslint": "^7.11.0",
     "node-env-run": "^4.0.2",
-    "raw-loader": "^4.0.2",
     "sass": "^1.27.0",
     "sass-loader": "^10.0.3",
     "typescript": "^4.0.3",

--- a/ui/src/lib/expand.ts
+++ b/ui/src/lib/expand.ts
@@ -1,0 +1,16 @@
+import prefixes from '@zazuko/rdf-vocabularies/prefixes'
+
+// todo remove after https://github.com/zazuko/rdf-vocabularies/issues/76
+export function expand (prefixed: string): string {
+  const [prefix, term] = prefixed.split(':')
+  if (!prefix || !term) {
+    return ''
+  }
+
+  const baseIRI = prefixes[prefix]
+  if (!baseIRI) {
+    throw new Error(`Unavailable prefix '${prefix}:'`)
+  }
+
+  return `${baseIRI}${term}`
+}

--- a/ui/src/rdf-properties.ts
+++ b/ui/src/rdf-properties.ts
@@ -1,22 +1,21 @@
 import $rdf from '@rdf-esm/dataset'
 import { Quad } from 'rdf-js'
-import { expand as _expand } from '@zazuko/rdf-vocabularies/expand'
+import { expand as _expand } from './lib/expand'
 import { shrink as _shrink } from '@zazuko/rdf-vocabularies/shrink'
-import { vocabularies } from '@zazuko/rdf-vocabularies/vocabularies'
+import { rdfs, schema, qb, sdmx, dcterms, dc11, skos, skosxl, xkos, xsd, wgs } from '@zazuko/rdf-vocabularies/datasets'
 import prefixes from '@zazuko/rdf-vocabularies/prefixes'
 import { rdf } from '@tpluscode/rdf-ns-builders'
 
-const relevantPrefixes = ['rdfs', 'schema', 'qb', 'sdmx', 'dcterms', 'dc11', 'skos', 'skosxl', 'xkos', 'xsd', 'wgs']
+const vocabs = { rdfs, schema, qb, sdmx, dcterms, dc11, skos, skosxl, xkos, xsd, wgs }
 
-export async function loadCommonProperties (): Promise<string[]> {
-  const vocabs = await vocabularies({ only: relevantPrefixes })
-
-  return Object.entries(vocabs).flatMap(([prefix, dataset]) => {
+export function loadCommonProperties (): string[] {
+  return Object.entries(vocabs).flatMap(([prefix, factory]) => {
+    const dataset = $rdf.dataset(factory($rdf))
     const baseIRI = prefixes[prefix]
     const graph = $rdf.namedNode(baseIRI)
-    const properties = dataset.match(null, rdf.type, rdf.property, graph)
+    const properties = [...dataset.match(null, rdf.type, rdf.property, graph)]
 
-    return properties.toArray().map((property: Quad) => shrink(property.subject.value))
+    return properties.map((property: Quad) => shrink(property.subject.value))
   })
 }
 

--- a/ui/src/store/modules/app.ts
+++ b/ui/src/store/modules/app.ts
@@ -32,8 +32,8 @@ const actions: ActionTree<AppState, RootState> = {
     context.commit('pushMessage', message)
   },
 
-  async loadCommonRDFProperties (context) {
-    const properties = await loadCommonProperties()
+  loadCommonRDFProperties (context) {
+    const properties = loadCommonProperties()
     context.commit('storeCommonRDFProperties', properties)
   },
 }

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -6,37 +6,4 @@ module.exports = {
     disableHostCheck: true,
     progress: false
   },
-  chainWebpack: config => {
-    config.module
-      .rule('nq')
-      .test(/\.nq$/)
-      .use('raw-loader')
-      .loader('raw-loader')
-      .end()
-
-    config.plugin('prefetch').tap(options => {
-      options[0].fileBlacklist = options[0].fileBlacklist || []
-      options[0].fileBlacklist.push(/vocab-\w+/)
-      return options
-    })
-
-    // plugin only present in production build. need to check
-    if (config.plugins.has('named-chunks')) {
-      config.plugin('named-chunks').tap(([defaultName]) => {
-        return [(chunk) => {
-          const vocabModule = [...chunk._modules].find(m => /rdf-vocabularies\/ontologies$/.test(m.context))
-
-          if (vocabModule && vocabModule.resource) {
-            const matchVocabName = vocabModule.resource.match(/(\w+)\.nq$/)
-            if (matchVocabName) {
-              return 'vocab-' + matchVocabName[1]
-            }
-          }
-
-          // use vue's default names for other chunks
-          return defaultName(chunk)
-        }]
-      })
-    }
-  },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10050,14 +10050,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-loader@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.2.tgz#1aac6b7d1ad1501e66efdac1522c73e59a584eb6"
-  integrity sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 rdf-canonize@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/rdf-canonize/-/rdf-canonize-1.2.0.tgz#9872b2cc6ed92a9969e834f9f042addaf0d4f7f9"


### PR DESCRIPTION
Removed the need for raw-loader by copying the expand function from `@zazuko/rdf-vocabularies`. ~~Also memoize the properties so that the datasets are not processed every time one hits `loadCommonProperties`~~