### PR TITLE
feat(ui): display shrunk properties

### DIFF
--- a/ui/src/components/MapperTable.vue
+++ b/ui/src/components/MapperTable.vue
@@ -33,7 +33,7 @@
     <div v-for="columnMapping in table.columnMappings" :key="columnMapping.id.value" class="panel-block">
       <div class="level-left">
         <div class="level-item">
-          {{ columnMapping.targetProperty.value }}
+          <property-display :term="columnMapping.targetProperty" />
         </div>
       </div>
       <div class="level-right">
@@ -63,9 +63,10 @@
 import { Prop, Component, Vue } from 'vue-property-decorator'
 import { ColumnMapping, Table } from '@cube-creator/model'
 import HydraOperationButton from './HydraOperationButton.vue'
+import PropertyDisplay from './PropertyDisplay.vue'
 
 @Component({
-  components: { HydraOperationButton },
+  components: { HydraOperationButton, PropertyDisplay },
 })
 export default class MapperTable extends Vue {
   @Prop() readonly table!: Table;

--- a/ui/src/components/PropertyDisplay.vue
+++ b/ui/src/components/PropertyDisplay.vue
@@ -1,0 +1,32 @@
+<template>
+  <b-tooltip :label="expanded">
+    {{ shrunk }}
+  </b-tooltip>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { namespace } from 'vuex-class'
+import { Term } from 'rdf-js'
+import { expandWithBase, shrink } from '@/rdf-properties'
+
+const projectNS = namespace('project')
+
+@Component
+export default class PropertyDisplay extends Vue {
+  @Prop() term!: Term
+  @projectNS.State((state) => state.csvMapping.namespace.value) projectPrefix!: string
+
+  get value (): string {
+    return this.term.value || ''
+  }
+
+  get expanded (): string {
+    return expandWithBase(this.value, this.projectPrefix)
+  }
+
+  get shrunk (): string {
+    return shrink(this.value)
+  }
+}
+</script>


### PR DESCRIPTION
Display shrunk properties in mapper table instead of full URIs (with full URI in tooltip).