### PR TITLE
fix: separate transformation of observation table

### DIFF
--- a/apis/core/lib/csvw-builder/index.ts
+++ b/apis/core/lib/csvw-builder/index.ts
@@ -78,11 +78,20 @@ export async function buildCsvw({ table, resources }: { table: Table; resources:
     throw new Error(`CSV Mapping resource not found for table ${table.id.value}`)
   }
 
-  const column: Initializer<Csvw.Column>[] = [{
-    virtual: true,
-    propertyUrl: cc.cube.value,
-    valueUrl: csvMapping.namespace.value,
-  }]
+  let template: string
+  const column: Initializer<Csvw.Column>[] = []
+
+  if (table.isObservationTable) {
+    template = `observation/${table.identifierTemplate}`
+    column.push({
+      virtual: true,
+      propertyUrl: cc.cube.value,
+      valueUrl: csvMapping.namespace.value,
+    })
+  } else {
+    template = table.identifierTemplate
+  }
+
   for await (const csvwColumn of buildColumns({ csvMapping, table, source, resources })) {
     column.push(csvwColumn)
   }
@@ -93,7 +102,7 @@ export async function buildCsvw({ table, resources }: { table: Table; resources:
       ...source.dialect.toJSON(),
     },
     tableSchema: {
-      aboutUrl: csvMapping.createIdentifier(`observation/${table.identifierTemplate}`).value,
+      aboutUrl: csvMapping.createIdentifier(template).value,
       column,
     },
   })

--- a/apis/core/test/csvw-builder/index.test.ts
+++ b/apis/core/test/csvw-builder/index.test.ts
@@ -69,12 +69,23 @@ describe('lib/csvw-builder', () => {
     expect(csvw.url).to.eq(csvSource.id.value)
   })
 
-  it('combines namespace and identifier template to construct csvw:aboutUrl', async () => {
+  it('combines namespace and identifier template to construct csvw:aboutUrl of observation table', async () => {
+    // given
+    table.types.add(cc.ObservationTable)
+
     // when
     const csvw = await buildCsvw({ table, resources })
 
     // then
     expect(csvw.tableSchema?.aboutUrl).to.eq('http://example.com/test-cube/observation/{id}-{sub_id}')
+  })
+
+  it('does not add "/observation" segment to csvw:aboutUrl when it is not observation table', async () => {
+    // when
+    const csvw = await buildCsvw({ table, resources })
+
+    // then
+    expect(csvw.tableSchema?.aboutUrl).to.eq('http://example.com/test-cube/{id}-{sub_id}')
   })
 
   it('copies csvw:dialect from CsvSource', async () => {
@@ -162,7 +173,10 @@ describe('lib/csvw-builder', () => {
     expect(csvwColumn?.datatype?.id).to.deep.eq(xsd.gYear)
   })
 
-  it('adds a cc:cube virtual column to output', async () => {
+  it('adds a cc:cube virtual column to output of observation table', async () => {
+    // given
+    table.types.add(cc.ObservationTable)
+
     // when
     const csvw = await buildCsvw({ table, resources })
 
@@ -185,5 +199,14 @@ describe('lib/csvw-builder', () => {
         minCount: 1,
       }],
     })
+  })
+
+  it('does not add a cc:cube virtual column to output of ordinary table', async () => {
+    // when
+    const csvw = await buildCsvw({ table, resources })
+
+    // then
+    const csvwColumn = findColumn(csvw, cc.cube)
+    expect(csvwColumn).to.be.undefined
   })
 })

--- a/cli/lib/job.ts
+++ b/cli/lib/job.ts
@@ -145,7 +145,10 @@ export class JobIterator extends stream.Readable {
 
               log.debug(`Will transform table '${table.name}' from ${csvwResource.url}. Dialect: delimiter=${csvwResource.dialect.delimiter} quote=${csvwResource.dialect.quoteChar}`)
 
-              this.push(csvwResource)
+              this.push({
+                isObservationTable: table.isObservationTable,
+                csvwResource,
+              })
             })
             .catch(e => {
               log.error(`Failed to load ${table.csvw.id.value}`)

--- a/cli/lib/pipeline.ts
+++ b/cli/lib/pipeline.ts
@@ -1,3 +1,13 @@
 import type Pipeline from 'barnard59-core/lib/Pipeline'
 
 export const asStep = (pipeline: Pipeline) => pipeline
+
+export function selectTransformation(this: Pipeline.Context, arg: {observationTable: Pipeline; otherTable: Pipeline}) {
+  if (this.variables.get('isObservationTable') === true) {
+    this.log.info('Input is observation table')
+    return arg.observationTable
+  }
+
+  this.log.info('Input is ordinary table')
+  return arg.otherTable
+}

--- a/cli/pipelines/main.ttl
+++ b/cli/pipelines/main.ttl
@@ -29,12 +29,32 @@
                        a         code:EcmaScript ] ;
   code:arguments     ( "jobUri"^^:VariableName ) .
 
+<#SelectAndRunTransformation>
+ a :Pipeline, :ReadableObjectMode ;
+  :steps [ :stepList (<#selectTransformation>) ]
+.
+
+<#selectTransformation>
+  a :Step ;
+  code:implementedBy [code:link <file:../lib/pipeline#selectTransformation> ;
+  a         code:EcmaScript ] ;
+  code:arguments [
+                    code:name "observationTable" ;
+                    code:value <#TransformObservationCsv>
+                 ], [
+                    code:name "otherTable" ;
+                    code:value <#TransformCsv>
+                 ] .
+
 <#doTransform>
   a                  :Step ;
   code:implementedBy [ code:link <node:barnard59-core#forEach> ;
                        a         code:EcmaScript ] ;
-  code:arguments     ( <#TransformCsv>
-                       "(p, csvwResource) => { p.variables.set('csvw', csvwResource) }"^^code:EcmaScript ) .
+  code:arguments     ( <#SelectAndRunTransformation>
+                       """(p, { csvwResource, isObservationTable }) => {
+                            p.variables.set('csvw', csvwResource)
+                            p.variables.set('isObservationTable', isObservationTable)
+                           }"""^^code:EcmaScript ) .
 
 # ------------------------------
 #
@@ -42,7 +62,7 @@
 #
 # ------------------------------
 
-<#TransformCsv>
+<#TransformObservationCsv>
   a      :Pipeline, :ReadableObjectMode ;
   :steps [ :stepList (
                        <#loadCsvStep>
@@ -53,6 +73,14 @@
                        <#toCubeShape>
                        <#flatten>
                        <#filterCubeLinks>
+                     ) ] .
+
+<#TransformCsv>
+  a      :Pipeline, :ReadableObjectMode ;
+  :steps [ :stepList (
+                       <#loadCsvStep>
+                       <#parse>
+                       <#filterNotCsvw>
                      ) ] .
 
 <#LoadCsv>

--- a/cli/test/lib/commands/transform.test.ts
+++ b/cli/test/lib/commands/transform.test.ts
@@ -5,7 +5,7 @@ import $rdf from 'rdf-ext'
 import { ASK, CONSTRUCT } from '@tpluscode/sparql-builder'
 import debug from 'debug'
 import { Hydra } from 'alcaeus/node'
-import { dcterms, rdf, rdfs, schema, sh, xsd } from '@tpluscode/rdf-ns-builders'
+import { rdf, rdfs, schema, sh, xsd } from '@tpluscode/rdf-ns-builders'
 import transform from '../../../lib/commands/transform'
 import { setupEnv } from '../../support/env'
 import { client, insertTestData } from '@cube-creator/testing/lib'
@@ -72,7 +72,7 @@ describe('lib/commands/transform', function () {
     })
     expect(cubePointer.namedNode('https://environment.ld.admin.ch/foen/ubd/28/station/blBAS')).to.matchShape({
       property: [{
-        path: dcterms.identifier,
+        path: schema.identifier,
         hasValue: 'blBAS',
         minCount: 1,
         maxCount: 1,

--- a/cli/test/lib/commands/transform.test.ts
+++ b/cli/test/lib/commands/transform.test.ts
@@ -5,7 +5,7 @@ import $rdf from 'rdf-ext'
 import { ASK, CONSTRUCT } from '@tpluscode/sparql-builder'
 import debug from 'debug'
 import { Hydra } from 'alcaeus/node'
-import { rdf, rdfs, schema, sh, xsd } from '@tpluscode/rdf-ns-builders'
+import { dcterms, rdf, rdfs, schema, sh, xsd } from '@tpluscode/rdf-ns-builders'
 import transform from '../../../lib/commands/transform'
 import { setupEnv } from '../../support/env'
 import { client, insertTestData } from '@cube-creator/testing/lib'
@@ -45,9 +45,8 @@ describe('lib/commands/transform', function () {
       .execute(client.query))
 
     const cubePointer = clownface({ dataset })
-    expect(cubePointer.has(rdf.type, cube.Observation).terms).to.have.length.greaterThan(10)
     expect(cubePointer.has(rdf.type, sh.NodeShape).terms.length).to.eq(1)
-    expect(cubePointer.has(rdf.type, cube.Observation).toArray()[0]).to.matchShape({
+    expect(cubePointer.namedNode('https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-2000-annualmean')).to.matchShape({
       property: [{
         path: rdf.type,
         hasValue: cube.Observation,
@@ -57,16 +56,29 @@ describe('lib/commands/transform', function () {
         minCount: 1,
       }, {
         path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/dimension/year'),
+        hasValue: $rdf.literal('2000', xsd.gYear),
         minCount: 1,
         maxCount: 1,
       }, {
         path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/dimension/value'),
+        hasValue: $rdf.literal('4.7', xsd.float),
         minCount: 1,
         maxCount: 1,
       }, {
         path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/station'),
         minCount: 1,
         maxCount: 1,
+      }],
+    })
+    expect(cubePointer.namedNode('https://environment.ld.admin.ch/foen/ubd/28/station/blBAS')).to.matchShape({
+      property: [{
+        path: dcterms.identifier,
+        hasValue: 'blBAS',
+        minCount: 1,
+        maxCount: 1,
+      }, {
+        path: rdfs.label,
+        minCount: 1,
       }],
     })
   })

--- a/cli/test/lib/job.test.ts
+++ b/cli/test/lib/job.test.ts
@@ -36,7 +36,7 @@ describe('lib/job', function () {
       // when
       const results: Table[] = []
       for await (const table of iteratorStream) {
-        results.push(table)
+        results.push(table.csvwResource)
       }
 
       // then

--- a/packages/model/Table.ts
+++ b/packages/model/Table.ts
@@ -20,6 +20,7 @@ export interface Table extends RdfResource {
   identifierTemplate: string
   color: string
   columnMappings: Array<Link<ColumnMapping>>
+  isObservationTable: boolean
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -50,6 +51,10 @@ export function TableMixin<Base extends Constructor>(base: Base): Mixin {
 
     @property.resource({ values: 'array', path: cc.columnMapping })
     columnMappings!: Array<Link<ColumnMapping>>
+
+    get isObservationTable(): boolean {
+      return this.types.has(cc.ObservationTable)
+    }
   }
 
   return Impl

--- a/packages/model/lib/Link.ts
+++ b/packages/model/lib/Link.ts
@@ -2,6 +2,6 @@ import { RdfResource, RdfResourceCore } from '@tpluscode/rdfine/RdfResource'
 import { DatasetCore } from 'rdf-js'
 import { HydraResponse } from 'alcaeus'
 
-export type Link<T extends RdfResourceCore> = RdfResourceCore & Partial<RdfResource> & {
+export type Link<T extends RdfResourceCore> = RdfResourceCore & Partial<Omit<RdfResource, 'load'>> & {
   load?(): Promise<HydraResponse<DatasetCore, T>>
 }

--- a/ui/src/api/mixins/Table.ts
+++ b/ui/src/api/mixins/Table.ts
@@ -4,22 +4,12 @@ import * as ns from '@cube-creator/core/namespace'
 import { Table } from '@cube-creator/model'
 import { AdditionalActions } from '@/api/mixins/ApiResource'
 
-declare module '@cube-creator/model' {
-  interface Table {
-    isObservationTable: boolean;
-  }
-}
-
 export default function mixin<Base extends Constructor> (base: Base): Mixin {
   return class extends base implements Partial<Table>, AdditionalActions {
     get _additionalActions () {
       return {
         createColumnMapping: ns.cc.CreateColumnMappingAction,
       }
-    }
-
-    get isObservationTable (): boolean {
-      return this.types.has(ns.cc.ObservationTable)
     }
   }
 }


### PR DESCRIPTION
Some changes required to process observation tables differently from the others:

1. Only observation tables get `/observation` injected into their identifier
2. Only observation tables get the `cc:cube` virtual column
3. Run only plain csvw transformation for table which are not observation tables