### PR TITLE
Some small fixes to CSVW et.al.

### DIFF
--- a/apis/core/lib/csvw-builder/index.ts
+++ b/apis/core/lib/csvw-builder/index.ts
@@ -40,6 +40,10 @@ function mappedColumn({ csvMapping, columnMapping, column }: CsvwBuildingContext
     csvwColumn.datatype = columnMapping.datatype
   }
 
+  if (columnMapping.language) {
+    csvwColumn.lang = columnMapping.language
+  }
+
   return csvwColumn
 }
 

--- a/apis/core/lib/csvw-builder/index.ts
+++ b/apis/core/lib/csvw-builder/index.ts
@@ -52,7 +52,7 @@ async function * buildColumns({ table, source, resources, csvMapping }: CsvwBuil
       warning(`Column mapping ${columnMappingLink.id} not found`)
       continue
     }
-    unmappedColumns.delete(columnMapping?.id)
+    unmappedColumns.delete(columnMapping?.sourceColumn.id)
 
     const column = source.columns.find(column => columnMapping.sourceColumn.equals(column))
     if (!column) {

--- a/apis/core/test/csvw-builder/index.test.ts
+++ b/apis/core/test/csvw-builder/index.test.ts
@@ -193,6 +193,27 @@ describe('lib/csvw-builder', () => {
     expect(csvwColumn?.datatype?.id).to.deep.eq(xsd.gYear)
   })
 
+  it('maps column with language', async () => {
+    // given
+    csvSource.columns = [
+      CsvColumn.fromPointer(csvSource.pointer.namedNode('jahr-column'), { name: 'JAHR' }),
+    ]
+    const columnMapping = ColumnMapping.fromPointer(clownface({ dataset: $rdf.dataset() }).namedNode('year-mapping'), {
+      sourceColumn: $rdf.namedNode('jahr-column') as any,
+      targetProperty: schema.yearBuilt,
+      language: 'de-DE',
+    })
+    resources.push(columnMapping.pointer)
+    table.columnMappings = [columnMapping] as any
+
+    // when
+    const csvw = await buildCsvw({ table, resources })
+
+    // then
+    const csvwColumn = findColumn(csvw, 'JAHR')
+    expect(csvwColumn?.lang).to.eq('de-DE')
+  })
+
   it('adds a cc:cube virtual column to output of observation table', async () => {
     // given
     table.types.add(cc.ObservationTable)

--- a/apis/core/test/csvw-builder/index.test.ts
+++ b/apis/core/test/csvw-builder/index.test.ts
@@ -132,6 +132,26 @@ describe('lib/csvw-builder', () => {
     expect(csvwColumn?.propertyUrl).to.eq('http://example.com/test-cube/year')
   })
 
+  it('does not add a duplicate csvw:column as suppressed', async () => {
+    // given
+    csvSource.columns = [
+      CsvColumn.fromPointer(csvSource.pointer.namedNode('jahr-column'), { name: 'JAHR' }),
+    ]
+    const columnMapping = ColumnMapping.fromPointer(clownface({ dataset: $rdf.dataset() }).namedNode('year-mapping'), {
+      sourceColumn: $rdf.namedNode('jahr-column') as any,
+      targetProperty: $rdf.literal('year'),
+    })
+    resources.push(columnMapping.pointer)
+    table.columnMappings = [columnMapping] as any
+
+    // when
+    const csvw = await buildCsvw({ table, resources })
+
+    // then
+    expect(csvw.tableSchema?.column).to.have.length(1)
+    expect(csvw.tableSchema?.column[0].suppressOutput).to.be.undefined
+  })
+
   it("takes source column's target property as-is when it is a NamedNode", async () => {
     // given
     csvSource.columns = [

--- a/cli/lib/output-filter.ts
+++ b/cli/lib/output-filter.ts
@@ -4,7 +4,7 @@ import { cc } from '@cube-creator/core/namespace'
 
 const csvwNs = csvw().value
 
-export function removeCsvwTriples(quad: Quad): boolean {
+function removeCsvwTriples(quad: Quad): boolean {
   if (quad.predicate.value.startsWith(csvwNs)) {
     return false
   }
@@ -16,4 +16,12 @@ export function removeCsvwTriples(quad: Quad): boolean {
 
 export function removeCubeLinks(quad: Quad): boolean {
   return !quad.predicate.equals(cc.cube)
+}
+
+function removeDefaultProperties(quad: Quad): boolean {
+  return !quad.predicate.value.startsWith('#')
+}
+
+export default function (quad: Quad): boolean {
+  return removeCsvwTriples(quad) && removeDefaultProperties(quad)
 }

--- a/cli/pipelines/main.ttl
+++ b/cli/pipelines/main.ttl
@@ -67,7 +67,7 @@
   :steps [ :stepList (
                        <#loadCsvStep>
                        <#parse>
-                       <#filterNotCsvw>
+                       <#filter>
                        <#toDataset>
                        <#toObservation>
                        <#toCubeShape>
@@ -80,7 +80,7 @@
   :steps [ :stepList (
                        <#loadCsvStep>
                        <#parse>
-                       <#filterNotCsvw>
+                       <#filter>
                      ) ] .
 
 <#LoadCsv>
@@ -108,11 +108,11 @@
                        a         code:EcmaScript ] ;
   code:arguments     ( "csvw"^^:VariableName ) .
 
-<#filterNotCsvw>
+<#filter>
   a                  :Step ;
   code:implementedBy [ a         code:EcmaScript ;
                        code:link <node:barnard59-base#filter> ] ;
-  code:arguments     ( [ code:link <file:../lib/output-filter#removeCsvwTriples> ;
+  code:arguments     ( [ code:link <file:../lib/output-filter#default> ;
                          a         code:EcmaScript ] ) .
 
 <#toDataset> a :Step;

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -407,7 +407,6 @@ graph <cube-project/ubd/csv-mapping/table-station/column-mapping-2> {
   <cube-project/ubd/csv-mapping/table-station/column-mapping-2> a cc:ColumnMapping ;
     cc:sourceColumn <cube-project/ubd/csv-source/stations/column/station-name-fr> ;
     cc:targetProperty rdfs:label ;
-    cc:datatype xsd:langString ;
     cc:language "fr" ;
   .
 }
@@ -417,7 +416,6 @@ graph <cube-project/ubd/csv-mapping/table-station/column-mapping-3> {
   <cube-project/ubd/csv-mapping/table-station/column-mapping-3> a cc:ColumnMapping ;
     cc:sourceColumn <cube-project/ubd/csv-source/stations/column/station-name-de> ;
     cc:targetProperty rdfs:label ;
-    cc:datatype xsd:langString ;
     cc:language "de" ;
   .
 }


### PR DESCRIPTION
* adding too many suppressed csvw columns
* remove `?foo <#property> ?bar` quads from output. those columns are auto-generated by csvw processor and break Stardog
* add transformation for `cc:language -> csvw:lang`