### PR TITLE
fix: ensure slash in constructed identifiers

### DIFF
--- a/apis/core/test/domain/csv-mapping/CsvMapping.test.ts
+++ b/apis/core/test/domain/csv-mapping/CsvMapping.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import RdfResourceImpl from '@tpluscode/rdfine'
+import clownface from 'clownface'
+import $rdf from 'rdf-ext'
+import { Initializer } from '@tpluscode/rdfine/RdfResource'
+import { CsvMappingMixin, CsvMapping } from '@cube-creator/model/CsvMapping'
+import CsvMappingMixinEx from '../../../lib/domain/csv-mapping/CsvMapping'
+
+describe('domain/csv-mapping/CsvMapping', () => {
+  class TestCsvMapping extends CsvMappingMixinEx(CsvMappingMixin(RdfResourceImpl)) {
+    constructor(init?: Initializer<CsvMapping>) {
+      super(clownface({ dataset: $rdf.dataset() }).blankNode(), init)
+    }
+  }
+
+  describe('create', function () {
+    it('ensures a slash if namespace does not have it', () => {
+      // given
+      const csvMapping = new TestCsvMapping({
+        namespace: $rdf.namedNode('http://example.com'),
+      })
+
+      // when
+      const identifier = csvMapping.createIdentifier('foo/{bar}')
+
+      // then
+      expect(identifier.value).to.eq('http://example.com/foo/{bar}')
+    })
+  })
+})

--- a/packages/model/CsvMapping.ts
+++ b/packages/model/CsvMapping.ts
@@ -36,12 +36,14 @@ export function CsvMappingMixin<Base extends Constructor>(base: Base): Mixin {
     project!: Link<Project>
 
     createIdentifier(template: string | Term): NamedNode {
+      const namespace = this.namespace.value.match(/[/#]$/) ? this.namespace.value : `${this.namespace.value}/`
+
       if (typeof template === 'string') {
-        return this.pointer.namedNode(this.namespace.value + template).term
+        return this.pointer.namedNode(namespace + template).term
       }
 
       if (template.termType === 'Literal') {
-        return this.pointer.namedNode(this.namespace.value + template.value).term
+        return this.pointer.namedNode(namespace + template.value).term
       }
       if (template.termType === 'NamedNode') {
         return template


### PR DESCRIPTION
I know we added a regex to the shape but it may be a good idea anyway to assume that there should a separator after the base.

Also fixes existing projects