### PR TITLE
fix: remove datatype for frequency

### DIFF
--- a/apis/core/bootstrap/shapes/dataset.ts
+++ b/apis/core/bootstrap/shapes/dataset.ts
@@ -75,7 +75,6 @@ ${shape('dataset/edit-metadata')} {
       ${sh.path} ${dcterms.accrualPeriodicity} ;
       ${sh.minCount} 0 ;
       ${sh.minLength} 1 ;
-      ${sh.datatype} ${dcterms.PeriodOfTime} ;
       ${sh.nodeKind} ${sh.IRI} ;
       ${sh.in} 
         ( ${freq.triennial} 


### PR DESCRIPTION
Since the list of elements if provided by the in clause, I think the data type is redundant and can be omitted instead of adding all the information that the type can correctly be resolved.

fixes #242 

