### PR TITLE
fix: fail pipeline if csv fails to fetch

### DIFF
--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@cube-creator/core": "*",
     "@cube-creator/model": "*",
-    "@hydrofoil/labyrinth": "^0.1.14",
+    "@hydrofoil/labyrinth": "^0.1.15",
     "@rdfine/csvw": "^0.5.1",
     "@rdfine/hydra": "^0.5.1",
     "@rdfine/schema": "^0.5.2",

--- a/cli/lib/csv.ts
+++ b/cli/lib/csv.ts
@@ -15,11 +15,12 @@ export function openFromCsvw(csvw: Csvw.Table) {
       accept: 'text/csv',
     })
 
-    if (response && response.xhr.body) {
-      (response.xhr.body as any).pipe(csvStream)
-    } else {
-      csvStream.end()
+    if (!response?.xhr.ok || !response.xhr.body) {
+      csvStream.emit('error', new Error('Failed to load CSV. Response was: ' + response?.xhr.statusText))
+      return
     }
+
+    (response.xhr.body as any).pipe(csvStream)
   })
 
   return readable(csvStream)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1078,10 +1078,10 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@hydrofoil/labyrinth@^0.1.14":
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/@hydrofoil/labyrinth/-/labyrinth-0.1.14.tgz#3255e037898ea5ffa3a0add6788bac7e64b185b3"
-  integrity sha512-YbHkmF363Jjjedp5FtDb94a/2/tgX+IIpYRWHD25dGAP9mzBiwke7BKIUxhyANRKi96d6xeEe3I+7L7KNe6HQg==
+"@hydrofoil/labyrinth@^0.1.15":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@hydrofoil/labyrinth/-/labyrinth-0.1.15.tgz#57138cfc2a36bae6c0e4d3f27bf13cf07cae9369"
+  integrity sha512-wf9KnohCDFH53IbbJhCjMWMuvVxh24Sy0WVW/4VWvD5RisNalpFSq1PMHFZzbdohiMc7gBg6PmyhdBK9IUqexw==
   dependencies:
     "@fcostarodrigo/walk" "^5.0.0"
     "@rdfine/hydra" "^0.5.5"


### PR DESCRIPTION
fixes #267 

Turns out the "quote" string was in fact a bug in the operations which caused a 405 error from the API

At the same time I changed the pipeline to fail fast when the CSV fails to load. This will prevent false positive pipeline runs in the future