### PR TITLE
refactor: throw on not found resources by default

### DIFF
--- a/apis/core/lib/ResourceStore.ts
+++ b/apis/core/lib/ResourceStore.ts
@@ -10,7 +10,6 @@ import { warn } from '@hydrofoil/labyrinth/lib/logger'
 import { sparql } from '@tpluscode/rdf-string'
 import TermSet from '@rdfjs/term-set'
 import RdfResource, { RdfResourceCore } from '@tpluscode/rdfine/RdfResource'
-import { NotFoundError } from './errors'
 
 interface ResourceCreationOptions {
   implicitlyDereferencable?: boolean
@@ -142,7 +141,7 @@ export default class implements ResourceStore {
       if (opts?.allowMissing) {
         return undefined as any
       }
-      throw new NotFoundError(term)
+      throw new Error(`Resource ${id} not found`)
     }
 
     return resource

--- a/apis/core/lib/domain/column-mapping/lib/index.ts
+++ b/apis/core/lib/domain/column-mapping/lib/index.ts
@@ -6,7 +6,7 @@ export async function findMapping(table: Table, targetProperty: Term, store: Res
   const csvMapping = await store.getResource<CsvMapping>(table.csvMapping.id)
 
   for (const columnMappingLink of table.columnMappings) {
-    const columnMapping = await store.getResource<ColumnMapping>(columnMappingLink.id)
+    const columnMapping = await store.getResource<ColumnMapping>(columnMappingLink.id, { allowMissing: true })
     if (!columnMapping) {
       continue
     }
@@ -15,7 +15,7 @@ export async function findMapping(table: Table, targetProperty: Term, store: Res
       return columnMapping
     }
 
-    const effectiveProperty = csvMapping?.createIdentifier(targetProperty)
+    const effectiveProperty = csvMapping.createIdentifier(targetProperty)
     if (columnMapping.targetProperty.equals(effectiveProperty)) {
       return columnMapping
     }

--- a/apis/core/lib/domain/column-mapping/update.ts
+++ b/apis/core/lib/domain/column-mapping/update.ts
@@ -75,7 +75,7 @@ export async function updateReferenceColumnMapping({
   // Update referencedTable
   const referencedTableId = resource.out(cc.referencedTable).term!
   const referencedTable = await store.getResource<Table>(referencedTableId)
-  if (!referencedTable) throw new NotFoundError(referencedTableId)
+
   columnMapping.referencedTable = referencedTable
 
   // Update identifierMapping
@@ -110,16 +110,8 @@ async function updateColumnMapping<T extends ColumnMapping>({
 }: UpdateColumnMappingCommand): Promise<{ columnMapping: T; table: Table }> {
   const columnMapping = await store.getResource<T>(resource.term)
 
-  if (!columnMapping || columnMapping.id.termType !== 'NamedNode') {
-    throw new NotFoundError(resource.term)
-  }
-
-  const tableId = await getTableForColumnMapping(columnMapping.id)
+  const tableId = await getTableForColumnMapping(columnMapping.id as NamedNode)
   const table = await store.getResource<Table>(tableId)
-
-  if (!table) {
-    throw new NotFoundError(tableId)
-  }
 
   const targetProperty = resource.out(cc.targetProperty).term!
 
@@ -131,14 +123,8 @@ async function updateColumnMapping<T extends ColumnMapping>({
       }
 
       const csvMapping = await store.getResource<CsvMapping>(table.csvMapping.id)
-      if (!csvMapping) {
-        throw new NotFoundError(csvMapping)
-      }
       const dimensionMetaDataCollectionPointer = await getDimensionMetaDataCollection(table.csvMapping.id)
       const dimensionMetaDataCollection = await store.getResource<DimensionMetadataCollection>(dimensionMetaDataCollectionPointer)
-      if (!dimensionMetaDataCollection) {
-        throw new NotFoundError(dimensionMetaDataCollectionPointer)
-      }
 
       const dimension = dimensionMetaDataCollection.find({ csvMapping, targetProperty: columnMapping.targetProperty })
       if (!dimension) {

--- a/apis/core/lib/domain/csv-mapping/delete.ts
+++ b/apis/core/lib/domain/csv-mapping/delete.ts
@@ -6,7 +6,7 @@ import { deleteTableWithoutSave } from '../table/delete'
 import { getTablesForMapping } from '../queries/table'
 
 export async function deleteMapping(csvMapping: NamedNode, store: ResourceStore): Promise<void> {
-  const csvMappingResource = await store.get(csvMapping)
+  const csvMappingResource = await store.get(csvMapping, { allowMissing: true })
   if (!csvMappingResource) return
 
   const sources = csvMappingResource.out(cc.csvSource).terms

--- a/apis/core/lib/domain/csv-source/delete.ts
+++ b/apis/core/lib/domain/csv-source/delete.ts
@@ -35,13 +35,13 @@ export async function deleteSourceWithoutSave({
 }: DeleteSourceCommand): Promise<void> {
   if (resource.termType !== 'NamedNode') return
 
-  const csvSource = await store.get(resource)
+  const csvSource = await store.get(resource, { allowMissing: true })
   if (!csvSource) return
 
   // Remove links from tables
   const tables = getLinkedTablesForSource(csvSource.term)
   for await (const tableId of tables) {
-    const table = await store.getResource<Table>(tableId)
+    const table = await store.getResource<Table>(tableId, { allowMissing: true })
     if (table) {
       table.csvSource = undefined
     }
@@ -57,7 +57,7 @@ export async function deleteSourceWithoutSave({
   // Delete links from in csv-mapping
   const csvMapping = csvSource.out(cc.csvMapping).term
   if (csvMapping) {
-    const csvMappingGraph = await store.get(csvMapping.value)
+    const csvMappingGraph = await store.get(csvMapping.value, { allowMissing: true })
     if (csvMappingGraph) {
       csvMappingGraph.dataset.delete($rdf.quad(csvMappingGraph.term, cc.csvSource, csvSource.term))
     }

--- a/apis/core/lib/domain/csv-source/get-head.ts
+++ b/apis/core/lib/domain/csv-source/get-head.ts
@@ -15,7 +15,7 @@ export async function getCSVHead({
   store = resourceStore(),
 }: GetCSVHeadCommand): Promise<string> {
   const csvSource = await store.get(resource)
-  const path = csvSource?.out(schema.associatedMedia).out(schema.identifier).term
+  const path = csvSource.out(schema.associatedMedia).out(schema.identifier).term
     ?.value
 
   if (!path) {

--- a/apis/core/lib/domain/csv-source/update.ts
+++ b/apis/core/lib/domain/csv-source/update.ts
@@ -5,7 +5,6 @@ import RdfResource from '@tpluscode/rdfine'
 import { schema } from '@tpluscode/rdf-ns-builders'
 import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
-import { NotFoundError } from '../../errors'
 import { error } from '../../log'
 import { Readable } from 'stream'
 import * as s3 from '../../storage/s3'
@@ -26,9 +25,6 @@ export async function update({
 }: UpdateCsvSourceCommand): Promise<GraphPointer> {
   const changed = RdfResource.factory.createEntity<CsvSource>(resource)
   const csvSource = await store.getResource<CsvSource>(resource.term)
-  if (!csvSource) {
-    throw new NotFoundError(resource)
-  }
 
   csvSource.name = changed.name
   if (csvSource.setDialect(changed.dialect) && csvSource.associatedMedia.identifierLiteral) {

--- a/apis/core/lib/domain/csv-source/upload.ts
+++ b/apis/core/lib/domain/csv-source/upload.ts
@@ -13,7 +13,6 @@ import * as CsvSourceQueries from '../queries/csv-source'
 import { Conflict } from 'http-errors'
 import { resourceStore } from '../resources'
 import { sampleValues } from '../csv/sample-values'
-import { NotFoundError } from '../../errors'
 import { CsvMapping } from '@cube-creator/model'
 
 interface UploadCSVCommand {
@@ -34,9 +33,6 @@ export async function uploadFile({
   csvSourceQueries: { sourceWithFilenameExists } = CsvSourceQueries,
 }: UploadCSVCommand): Promise<GraphPointer> {
   const csvMapping = await store.getResource<CsvMapping>(resource)
-  if (!csvMapping) {
-    throw new NotFoundError(resource)
-  }
 
   if (await sourceWithFilenameExists(csvMapping.id, fileName)) {
     throw new Conflict(`A file with ${fileName} has already been added to the project`)

--- a/apis/core/lib/domain/cube-projects/delete.ts
+++ b/apis/core/lib/domain/cube-projects/delete.ts
@@ -13,7 +13,7 @@ export async function deleteProject({
   resource,
   store = resourceStore(),
 }: DeleteProjectCommand): Promise<void> {
-  const project = await store.get(resource)
+  const project = await store.get(resource, { allowMissing: true })
   if (!project) return
 
   const csvMapping = project.out(cc.csvMapping).term

--- a/apis/core/lib/domain/cube-projects/update.ts
+++ b/apis/core/lib/domain/cube-projects/update.ts
@@ -6,7 +6,6 @@ import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
 import { rdfs } from '@tpluscode/rdf-ns-builders'
 import { CsvMapping, Project } from '@cube-creator/model'
-import { NotFoundError } from '../../errors'
 
 interface UpdateProjectCommand {
   resource: GraphPointer
@@ -20,10 +19,6 @@ export async function updateProject({
   store = resourceStore(),
 }: UpdateProjectCommand): Promise<Project> {
   const storedProject = await store.getResource<Project>(resource.term)
-
-  if (!storedProject) {
-    throw new NotFoundError(resource.term)
-  }
 
   const oldLabel = storedProject.pointer.out(rdfs.label).term as Literal
 
@@ -39,10 +34,7 @@ export async function updateProject({
   const newNamespace = resource.out(cc.csvMapping).out(cc.namespace).term as NamedNode
   if (newNamespace) {
     const csvMapping = await store.getResource<CsvMapping>(project.out(cc.csvMapping).term)
-
-    if (csvMapping) {
-      csvMapping.namespace = newNamespace
-    }
+    csvMapping.namespace = newNamespace
   }
 
   storedProject.updatePublishGraph(resource.out(cc.publishGraph).term)

--- a/apis/core/lib/domain/dataset/update.ts
+++ b/apis/core/lib/domain/dataset/update.ts
@@ -2,7 +2,6 @@ import { cc } from '@cube-creator/core/namespace'
 import { dcat, hydra, rdf, schema, _void } from '@tpluscode/rdf-ns-builders'
 import { GraphPointer } from 'clownface'
 import { NamedNode } from 'rdf-js'
-import { NotFoundError } from '../../errors'
 import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
 
@@ -19,10 +18,6 @@ export async function update({
   store = resourceStore(),
 }: AddMetaDataCommand): Promise<GraphPointer> {
   const datasetResource = await store.get(dataset.term)
-
-  if (!datasetResource) {
-    throw new NotFoundError(dataset)
-  }
 
   const hasPart = datasetResource.out(schema.hasPart)
   const dimensionMetadata = datasetResource.out(cc.dimensionMetadata)

--- a/apis/core/lib/domain/dimension/update.ts
+++ b/apis/core/lib/domain/dimension/update.ts
@@ -3,7 +3,6 @@ import { NamedNode } from 'rdf-js'
 import { DimensionMetadataCollection } from '@cube-creator/model'
 import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
-import { NotFoundError } from '../../errors'
 
 interface UpdateDimensionCommand {
   metadataCollection: NamedNode
@@ -17,9 +16,6 @@ export async function update({
   dimensionMetadata,
 }: UpdateDimensionCommand): Promise<GraphPointer> {
   const metadata = await store.getResource<DimensionMetadataCollection>(metadataCollection)
-  if (!metadata) {
-    throw new NotFoundError(metadataCollection)
-  }
 
   metadata.updateDimension(dimensionMetadata)
   await store.save()

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -22,17 +22,9 @@ export async function createTransformJob({
   resource,
   store = resourceStore(),
 }: StartTransformationCommand): Promise<GraphPointer<NamedNode>> {
-  const jobCollection = (await store.get(resource))!
+  const jobCollection = await store.get(resource)
   const project = await store.getResource<Project>(jobCollection.out(cc.project).term)
-  const csvMapping = await store?.getResource<CsvMapping>(project?.csvMapping?.id)
-
-  if (!project) {
-    throw new Error('Project not found from jobs collection')
-  }
-
-  if (!csvMapping) {
-    throw new Error('CSV Mapping not found from project')
-  }
+  const csvMapping = await store.getResource<CsvMapping>(project?.csvMapping?.id)
 
   const jobPointer = await store.createMember(jobCollection.term, id.job(jobCollection))
   Job.createTransform(jobPointer, {
@@ -57,7 +49,7 @@ export async function createPublishJob({
     throw new Error('Project not found from jobs collection')
   }
 
-  const project = (await store.getResource<Project>(projectPointer))!
+  const project = await store.getResource<Project>(projectPointer)
 
   if (!project.publishGraph) {
     throw new DomainError('Cannot publish cube. Project does not have publish graph')

--- a/apis/core/lib/domain/job/update.ts
+++ b/apis/core/lib/domain/job/update.ts
@@ -5,7 +5,6 @@ import { isPublishJob } from '@cube-creator/model/Job'
 import RdfResource from '@tpluscode/rdfine'
 import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
-import { NotFoundError } from '../../errors'
 import { schema } from '@tpluscode/rdf-ns-builders'
 
 interface JobUpdateParams {
@@ -16,9 +15,6 @@ interface JobUpdateParams {
 export async function update({ resource, store = resourceStore() }: JobUpdateParams): Promise<GraphPointer> {
   const changes = RdfResource.factory.createEntity<Job>(resource, [JobMixin])
   const job = await store.getResource<Job>(resource.term)
-  if (!job) {
-    throw new NotFoundError(resource.term)
-  }
 
   if (changes.actionStatus) {
     job.actionStatus = changes.actionStatus

--- a/apis/core/lib/domain/table/create.ts
+++ b/apis/core/lib/domain/table/create.ts
@@ -5,7 +5,6 @@ import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
 import { NamedNode } from 'rdf-js'
 import $rdf from 'rdf-ext'
-import { NotFoundError } from '../../errors'
 import { CsvColumn, CsvMapping, CsvSource, DimensionMetadataCollection } from '@cube-creator/model'
 import * as DimensionMetadataQueries from '../queries/dimension-metadata'
 
@@ -35,14 +34,8 @@ export async function createTable({
   }
 
   const csvMapping = await store.getResource<CsvMapping>(csvMappingPointer.term)
-  if (!csvMapping) {
-    throw new NotFoundError(csvMappingPointer.term)
-  }
   const csvSourceId = resource.out(cc.csvSource).term
   const csvSource = await store.getResource<CsvSource>(csvSourceId)
-  if (!csvSource) {
-    throw new NotFoundError(csvSourceId)
-  }
 
   const columns = [...csvSource.columns]
 
@@ -67,9 +60,6 @@ export async function createTable({
   // Create default column mappings for provided columns
   const dimensionMetaDataCollectionPointer = await getDimensionMetaDataCollection(csvMapping.id)
   const dimensionMetaDataCollection = await store.getResource<DimensionMetadataCollection>(dimensionMetaDataCollectionPointer)
-  if (!dimensionMetaDataCollection) {
-    throw new NotFoundError(dimensionMetaDataCollectionPointer)
-  }
 
   // Create default column mappings for provided columns
   columnsToAdd

--- a/apis/core/lib/domain/table/delete.ts
+++ b/apis/core/lib/domain/table/delete.ts
@@ -21,7 +21,7 @@ export async function deleteTable({
 export async function deleteTableWithoutSave(tableTerm: Term, store: ResourceStore): Promise<void> {
   if (tableTerm.termType !== 'NamedNode') return
 
-  const table = await store.get(tableTerm)
+  const table = await store.get(tableTerm, { allowMissing: true })
   if (!table) return
 
   // Delete in columnMappings

--- a/apis/core/lib/domain/table/update.ts
+++ b/apis/core/lib/domain/table/update.ts
@@ -2,7 +2,6 @@ import { ColumnMapping, CsvMapping, DimensionMetadataCollection, Table } from '@
 import { schema, xsd } from '@tpluscode/rdf-ns-builders'
 import $rdf from 'rdf-ext'
 import { GraphPointer } from 'clownface'
-import { NotFoundError } from '../../errors'
 import { ResourceStore } from '../../ResourceStore'
 import * as DimensionMetadataQueries from '../queries/dimension-metadata'
 import { cc } from '@cube-creator/core/namespace'
@@ -23,9 +22,6 @@ export async function updateTable({
 } : UpdateTableCommand): Promise<GraphPointer> {
   const table = await store.getResource<Table>(resource.term)
 
-  if (!table) {
-    throw new NotFoundError(resource.term)
-  }
   const label = resource.out(schema.name)
   if (!label?.value) {
     throw new Error('schema:name missing from the payload')
@@ -45,23 +41,14 @@ export async function updateTable({
   table.identifierTemplate = identifierTemplate.value
 
   const csvMapping = await store.getResource<CsvMapping>(table.csvMapping.id)
-  if (!csvMapping) {
-    throw new NotFoundError(csvMapping)
-  }
 
   const isObservationTable = trueTerm.equals(resource.out(cc.isObservationTable).term)
   if (table.isObservationTable !== isObservationTable) {
     const dimensionMetaDataCollectionPointer = await getDimensionMetaDataCollection(table.csvMapping.id)
     const dimensionMetaDataCollection = await store.getResource<DimensionMetadataCollection>(dimensionMetaDataCollectionPointer)
-    if (!dimensionMetaDataCollection) {
-      throw new NotFoundError(dimensionMetaDataCollectionPointer)
-    }
 
     for (const columnMappingPointer of table.columnMappings) {
       const columnMapping = await store.getResource<ColumnMapping>(columnMappingPointer.id)
-      if (!columnMapping) {
-        throw new NotFoundError(columnMappingPointer.id)
-      }
 
       if (isObservationTable) {
         dimensionMetaDataCollection.addDimensionMetadata({ store, columnMapping, csvMapping })

--- a/apis/core/test/domain/column-mapping/delete.test.ts
+++ b/apis/core/test/domain/column-mapping/delete.test.ts
@@ -126,7 +126,7 @@ describe('domain/column-mapping/delete', () => {
 
     await deleteColumnMapping({ resource: resourceId, store, dimensionMetadataQueries, tableQueries })
 
-    const columnMapping = await store.getResource<ColumnMapping>(resourceId)
+    const columnMapping = await store.getResource<ColumnMapping>(resourceId, { allowMissing: true })
     expect(columnMapping).to.eq(undefined)
 
     expect(dimensionMetadataCollection.out(schema.hasPart).terms).to.have.length(dimensionsCount - 1)

--- a/apis/core/test/domain/column-mapping/delete.test.ts
+++ b/apis/core/test/domain/column-mapping/delete.test.ts
@@ -9,7 +9,6 @@ import { TestResourceStore } from '../../support/TestResourceStore'
 import type * as DimensionMetadataQueries from '../../../lib/domain/queries/dimension-metadata'
 import type * as TableQueries from '../../../lib/domain/queries/table'
 import '../../../lib/domain'
-import { NotFoundError } from '../../../lib/errors'
 import { NamedNode } from 'rdf-js'
 import DatasetExt from 'rdf-ext/lib/Dataset'
 import { deleteColumnMapping } from '../../../lib/domain/column-mapping/delete'
@@ -138,6 +137,6 @@ describe('domain/column-mapping/delete', () => {
     const resource = $rdf.namedNode('columnMapping-foo')
     const promise = deleteColumnMapping({ resource, store, dimensionMetadataQueries, tableQueries })
 
-    await expect(promise).to.have.rejectedWith(NotFoundError)
+    await expect(promise).to.have.rejected
   })
 })


### PR DESCRIPTION
This changes the default of `ResourceStore` to throw when a resource is not found. A second parameter can be added where an `undefined` is acceptable. Types adjust automatically which removes the need to the repetitive `if (!resource) throw new Error()` boilerplate