### PR TITLE
Publish cube revisions

### DIFF
--- a/apis/core/bootstrap/shapes/cube-project.ts
+++ b/apis/core/bootstrap/shapes/cube-project.ts
@@ -37,6 +37,16 @@ ${shape('cube-project/create')} {
       ${sh.nodeKind} ${sh.IRI} ;
       ${sh.order} 30 ;
     ] ;
+    ${sh.property} [
+      ${sh.name} "Publish graph" ;
+      ${sh.description} "A named graph URI where cubes will be published from this project" ;
+      ${sh.path} ${cc.publishGraph} ;
+      ${sh.minLength} 1 ;
+      ${sh.minCount} 1 ;
+      ${sh.maxCount} 1 ;
+      ${sh.nodeKind} ${sh.IRI} ;
+      ${sh.order} 40 ;
+    ] ;
   .
 
   ${shape('cube-project/create#CSV')}

--- a/apis/core/lib/domain/cube-projects/Project.ts
+++ b/apis/core/lib/domain/cube-projects/Project.ts
@@ -12,8 +12,10 @@ import { childResource } from '@cube-creator/model/lib/resourceIdentifiers'
 
 interface ApiProject {
   identifier: string
+  nextRevision: number
   initializeCsvMapping(store: ResourceStore, namespace: NamedNode): CsvMapping
   initializeJobCollection(store: ResourceStore): void
+  incrementPublishedRevision(): void
 }
 
 declare module '@cube-creator/model' {
@@ -26,6 +28,10 @@ export default function Mixin<Base extends Constructor<Omit<Project, keyof ApiPr
   class Project extends Resource implements ApiProject {
     get identifier() {
       return this.id.value.substring(this.id.value.lastIndexOf('/') + 1)
+    }
+
+    get nextRevision() {
+      return this.publishedRevision ? this.publishedRevision + 1 : 1
     }
 
     initializeCsvMapping(store: ResourceStore, namespace: NamedNode) {
@@ -64,6 +70,10 @@ export default function Mixin<Base extends Constructor<Omit<Project, keyof ApiPr
           property: cc.project,
         }],
       })
+    }
+
+    incrementPublishedRevision() {
+      this.publishedRevision = this.nextRevision
     }
   }
 

--- a/apis/core/lib/domain/cube-projects/create.ts
+++ b/apis/core/lib/domain/cube-projects/create.ts
@@ -8,6 +8,7 @@ import * as DimensionMetadata from '@cube-creator/model/DimensionMetadata'
 import { ResourceStore } from '../../ResourceStore'
 import * as id from '../identifiers'
 import { resourceStore } from '../resources'
+import { DomainError } from '../../errors'
 
 interface CreateProjectCommand {
   projectsCollection: GraphPointer<NamedNode>
@@ -26,10 +27,15 @@ export async function createProject({
   if (!label) {
     throw new Error('Missing project name')
   }
+  const publishGraph = resource.out(cc.publishGraph).term
+  if (!publishGraph || publishGraph.termType !== 'NamedNode') {
+    throw new DomainError('Missing publish graph or not a named node')
+  }
 
   const project = Project.create(await store.createMember(projectsCollection.term, id.cubeProject(label)), {
     creator: user,
     label,
+    publishGraph,
   })
 
   project.initializeJobCollection(store)

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -56,10 +56,13 @@ export async function createPublishJob({
     throw new Error('Project not found from jobs collection')
   }
 
+  const project = (await store.getResource<Project>(projectPointer))!
+
   const jobPointer = await store.createMember(jobCollection.term, id.job(jobCollection))
   Job.createPublish(jobPointer, {
     project: projectPointer,
     name: 'Publish job',
+    revision: project.nextRevision,
   })
 
   await store.save()

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -6,6 +6,7 @@ import { CsvMapping, Project } from '@cube-creator/model'
 import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
 import * as id from '../identifiers'
+import { DomainError } from '../../errors'
 
 interface StartTransformationCommand {
   resource: NamedNode
@@ -57,6 +58,10 @@ export async function createPublishJob({
   }
 
   const project = (await store.getResource<Project>(projectPointer))!
+
+  if (!project.publishGraph) {
+    throw new DomainError('Cannot publish cube. Project does not have publish graph')
+  }
 
   const jobPointer = await store.createMember(jobCollection.term, id.job(jobCollection))
   Job.createPublish(jobPointer, {

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -68,6 +68,7 @@ export async function createPublishJob({
     project: projectPointer,
     name: 'Publish job',
     revision: project.nextRevision,
+    publishGraph: project.publishGraph,
   })
 
   await store.save()

--- a/apis/core/lib/domain/job/update.ts
+++ b/apis/core/lib/domain/job/update.ts
@@ -1,20 +1,16 @@
 import { NamedNode } from 'rdf-js'
 import { GraphPointer } from 'clownface'
-import { Job, JobMixin, Project, PublishJob } from '@cube-creator/model'
+import { Job, JobMixin, Project } from '@cube-creator/model'
+import { isPublishJob } from '@cube-creator/model/Job'
 import RdfResource from '@tpluscode/rdfine'
 import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
 import { NotFoundError } from '../../errors'
 import { schema } from '@tpluscode/rdf-ns-builders'
-import { cc } from '@cube-creator/core/namespace'
 
 interface JobUpdateParams {
   resource: GraphPointer<NamedNode>
   store?: ResourceStore
-}
-
-function isPublishJob(job: Job): job is PublishJob {
-  return job.types.has(cc.PublishJob)
 }
 
 export async function update({ resource, store = resourceStore() }: JobUpdateParams): Promise<GraphPointer> {

--- a/apis/core/test/domain/cube-projects/create.test.ts
+++ b/apis/core/test/domain/cube-projects/create.test.ts
@@ -27,6 +27,7 @@ describe('domain/cube-projects/create', () => {
     const resource = clownface({ dataset: $rdf.dataset() })
       .namedNode('')
       .addOut(rdfs.label, 'Foo bar project')
+      .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
     // when
     const project = await createProject({ resource, store, projectsCollection, user })
@@ -43,6 +44,7 @@ describe('domain/cube-projects/create', () => {
       .namedNode('')
       .addOut(rdfs.label, 'Foo bar project')
       .addOut(cc.projectSourceKind, 'Existing Cube')
+      .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
     // when
     const project = await createProject({ resource, store, projectsCollection, user })
@@ -56,6 +58,7 @@ describe('domain/cube-projects/create', () => {
     const resource = clownface({ dataset: $rdf.dataset() })
       .namedNode('')
       .addOut(rdfs.label, 'Foo bar project')
+      .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
     // when
     const project = await createProject({ resource, store, projectsCollection, user })
@@ -78,6 +81,7 @@ describe('domain/cube-projects/create', () => {
     const resource = clownface({ dataset: $rdf.dataset() })
       .namedNode('')
       .addOut(rdfs.label, 'Foo bar project')
+      .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
     // when
     const project = await createProject({ resource, store, projectsCollection, user })
@@ -100,6 +104,7 @@ describe('domain/cube-projects/create', () => {
     const resource = clownface({ dataset: $rdf.dataset() })
       .namedNode('')
       .addOut(rdfs.label, 'Foo bar project')
+      .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
     // when
     const project = await createProject({ resource, store, projectsCollection, user })
@@ -148,6 +153,7 @@ describe('domain/cube-projects/create', () => {
         .namedNode('')
         .addOut(rdfs.label, 'Foo bar project')
         .addOut(cc.namespace, $rdf.namedNode('http://example.com'))
+        .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
         .addOut(cc.projectSourceKind, shape('cube-project/create#CSV'))
 
       // when
@@ -164,6 +170,7 @@ describe('domain/cube-projects/create', () => {
         .addOut(rdfs.label, 'Foo bar project')
         .addOut(cc.namespace, $rdf.namedNode('http://example.com'))
         .addOut(cc.projectSourceKind, shape('cube-project/create#CSV'))
+        .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
       // when
       const project = await createProject({ resource, store, projectsCollection, user })
@@ -193,6 +200,7 @@ describe('domain/cube-projects/create', () => {
         .addOut(cc.namespace, $rdf.namedNode('http://example.com'))
         .addOut(rdfs.label, 'Foo bar project')
         .addOut(cc.projectSourceKind, shape('cube-project/create#CSV'))
+        .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
       // when
       const project = await createProject({ resource, store, projectsCollection, user })
@@ -228,6 +236,7 @@ describe('domain/cube-projects/create', () => {
         .namedNode('')
         .addOut(rdfs.label, 'Foo bar project')
         .addOut(cc.projectSourceKind, shape('cube-project/create#CSV'))
+        .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
       // when
       const project = await createProject({ resource, store, projectsCollection, user })
@@ -252,6 +261,7 @@ describe('domain/cube-projects/create', () => {
         .addOut(cc.namespace, $rdf.namedNode('http://example.com'))
         .addOut(rdfs.label, 'Foo bar project')
         .addOut(cc.projectSourceKind, shape('cube-project/create#CSV'))
+        .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
       // when
       const project = await createProject({ resource, store, projectsCollection, user })
@@ -288,6 +298,7 @@ describe('domain/cube-projects/create', () => {
         .namedNode('')
         .addOut(rdfs.label, 'Foo bar project')
         .addOut(cc.projectSourceKind, shape('cube-project/create#CSV'))
+        .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
       // when
       const project = await createProject({ resource, store, projectsCollection, user })
@@ -333,6 +344,7 @@ describe('domain/cube-projects/create', () => {
         .namedNode('')
         .addOut(rdfs.label, 'Foo bar project')
         .addOut(cc.projectSourceKind, shape('cube-project/create#CSV'))
+        .addOut(cc.publishGraph, $rdf.namedNode('http://example.com/published-cube'))
 
       // when
       const project = await createProject({ resource, store, projectsCollection, user })

--- a/apis/core/test/domain/job/create.test.ts
+++ b/apis/core/test/domain/job/create.test.ts
@@ -7,12 +7,14 @@ import { cc } from '@cube-creator/core/namespace'
 import '../../../lib/domain'
 import { TestResourceStore } from '../../support/TestResourceStore'
 import { createPublishJob, createTransformJob } from '../../../lib/domain/job/create'
+import { DomainError } from '../../../lib/errors'
 
 describe('domain/job/create', () => {
   let store: TestResourceStore
   const project = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('myProject') })
     .addOut(cc.csvMapping, $rdf.namedNode('myCsvMapping'))
     .addOut(cc.cubeGraph, $rdf.namedNode('myCubeGraph'))
+    .addOut(cc.publishGraph, $rdf.namedNode('publishGraph'))
     .addOut(rdf.type, cc.CubeProject)
   const tableCollection = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('myTables') })
   const csvMapping = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('myCsvMapping') })
@@ -71,6 +73,17 @@ describe('domain/job/create', () => {
 
       // then
       expect(job.out(cc.revision).term).to.deep.eq($rdf.literal('4', xsd.integer))
+    })
+
+    it('throws when project has no publish graph', async () => {
+      // given
+      project.deleteOut(cc.publishGraph)
+
+      // when
+      const promise = createPublishJob({ resource: jobCollection.term, store })
+
+      // then
+      await expect(promise).rejectedWith(DomainError)
     })
   })
 })

--- a/apis/core/test/domain/job/create.test.ts
+++ b/apis/core/test/domain/job/create.test.ts
@@ -62,6 +62,7 @@ describe('domain/job/create', () => {
       expect(job.out(schema.actionStatus).term).to.deep.eq(schema.PotentialActionStatus)
       expect(job.out(rdf.type).values).to.contain(cc.Job.value)
       expect(job.out(rdf.type).values).to.contain(cc.PublishJob.value)
+      expect(job.out(cc.publishGraph).term).to.deep.eq($rdf.namedNode('publishGraph'))
     })
 
     it('sets next revision to job resource', async () => {

--- a/apis/core/test/domain/job/create.test.ts
+++ b/apis/core/test/domain/job/create.test.ts
@@ -2,7 +2,7 @@ import { describe, it, beforeEach } from 'mocha'
 import { expect } from 'chai'
 import clownface from 'clownface'
 import $rdf from 'rdf-ext'
-import { dcterms, rdf, schema } from '@tpluscode/rdf-ns-builders'
+import { dcterms, rdf, schema, xsd } from '@tpluscode/rdf-ns-builders'
 import { cc } from '@cube-creator/core/namespace'
 import '../../../lib/domain'
 import { TestResourceStore } from '../../support/TestResourceStore'
@@ -31,35 +31,46 @@ describe('domain/job/create', () => {
     ])
   })
 
-  it('creates a transformation job', async () => {
-    // given
+  describe('createTransformJob', () => {
+    it('creates a job resource', async () => {
+      // when
+      const job = await createTransformJob({ resource: jobCollection.term, store })
 
-    // when
-    const job = await createTransformJob({ resource: jobCollection.term, store })
-
-    // then
-    expect(job.out(cc.cubeGraph).value).to.eq('myCubeGraph')
-    expect(job.out(cc.tables).value).to.eq('myTables')
-    expect(job.out(schema.name).value).to.be.ok
-    expect(job.out(dcterms.created).value).to.be.ok
-    expect(job.out(schema.actionStatus).term).to.deep.eq(schema.PotentialActionStatus)
-    expect(job.out(rdf.type).values).to.contain(cc.Job.value)
-    expect(job.out(rdf.type).values).to.contain(cc.TransformJob.value)
+      // then
+      expect(job.out(cc.cubeGraph).value).to.eq('myCubeGraph')
+      expect(job.out(cc.tables).value).to.eq('myTables')
+      expect(job.out(schema.name).value).to.be.ok
+      expect(job.out(dcterms.created).value).to.be.ok
+      expect(job.out(schema.actionStatus).term).to.deep.eq(schema.PotentialActionStatus)
+      expect(job.out(rdf.type).values).to.contain(cc.Job.value)
+      expect(job.out(rdf.type).values).to.contain(cc.TransformJob.value)
+    })
   })
 
-  it('creates a publish job', async () => {
-    // given
+  describe('createPublishJob', () => {
+    it('creates a job resource', async () => {
+      // when
+      const job = await createPublishJob({ resource: jobCollection.term, store })
 
-    // when
-    const job = await createPublishJob({ resource: jobCollection.term, store })
+      // then
+      expect(job.has(rdf.type, cc.PublishJob).values.length).to.eq(1)
+      expect(job.out(cc.project).value).to.eq('myProject')
+      expect(job.out(schema.name).value).to.be.ok
+      expect(job.out(dcterms.created).value).to.be.ok
+      expect(job.out(schema.actionStatus).term).to.deep.eq(schema.PotentialActionStatus)
+      expect(job.out(rdf.type).values).to.contain(cc.Job.value)
+      expect(job.out(rdf.type).values).to.contain(cc.PublishJob.value)
+    })
 
-    // then
-    expect(job.has(rdf.type, cc.PublishJob).values.length).to.eq(1)
-    expect(job.out(cc.project).value).to.eq('myProject')
-    expect(job.out(schema.name).value).to.be.ok
-    expect(job.out(dcterms.created).value).to.be.ok
-    expect(job.out(schema.actionStatus).term).to.deep.eq(schema.PotentialActionStatus)
-    expect(job.out(rdf.type).values).to.contain(cc.Job.value)
-    expect(job.out(rdf.type).values).to.contain(cc.PublishJob.value)
+    it('sets next revision to job resource', async () => {
+      // given
+      project.addOut(cc.latestPublishedRevision, 3)
+
+      // when
+      const job = await createPublishJob({ resource: jobCollection.term, store })
+
+      // then
+      expect(job.out(cc.revision).term).to.deep.eq($rdf.literal('4', xsd.integer))
+    })
   })
 })

--- a/cli/lib/cube.ts
+++ b/cli/lib/cube.ts
@@ -34,7 +34,7 @@ export function injectRevision(this: Context) {
   return map(({ subject, predicate, object, graph }: Quad) => {
     return rdf.quad(
       rebase(subject),
-      rebase(predicate),
+      predicate,
       rebase(object),
       graph)
   })

--- a/cli/lib/cube.ts
+++ b/cli/lib/cube.ts
@@ -1,7 +1,9 @@
 import rdf from 'rdf-ext'
-import { DatasetCore } from 'rdf-js'
+import { DatasetCore, Quad, Term } from 'rdf-js'
 import { cc } from '@cube-creator/core/namespace'
 import { GraphPointer } from 'clownface'
+import type { Context } from 'barnard59-core/lib/Pipeline'
+import map from 'barnard59-base/lib/map'
 
 export const getObservationSetId = ({ dataset }: { dataset: DatasetCore }) => {
   const cubeId = [...dataset.match(null, cc.cube)][0].object.value
@@ -15,4 +17,25 @@ export const getObservationSetId = ({ dataset }: { dataset: DatasetCore }) => {
 
 export function getCubeId({ ptr }: { ptr: GraphPointer }) {
   return ptr.out(cc.cube).term || ''
+}
+
+export function injectRevision(this: Context) {
+  const cubeNamespace = this.variables.get('namespace')
+  const revision = this.variables.get('revision')
+
+  function rebase<T extends Term>(term: T): T {
+    if (term.termType === 'NamedNode') {
+      return rdf.namedNode(term.value.replace(new RegExp(`^${cubeNamespace}`), `${cubeNamespace}${revision}/`)) as any
+    }
+
+    return term
+  }
+
+  return map(({ subject, predicate, object, graph }: Quad) => {
+    return rdf.quad(
+      rebase(subject),
+      rebase(predicate),
+      rebase(object),
+      graph)
+  })
 }

--- a/cli/pipelines/publish.ttl
+++ b/cli/pipelines/publish.ttl
@@ -4,9 +4,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 <#Main> a :Pipeline ;
-  :steps [ :stepList ( <#loadGraphStep> <#injectMetadata> <#streamOutputStep> ) ] .
-
-
+  :steps [ :stepList ( <#loadGraphStep> <#injectCubeRevision> <#injectMetadata> <#streamOutputStep> ) ] .
 
 <#loadGraphStep>
   a                  :Step ;
@@ -31,6 +29,14 @@ _:get
                        code:value "graph-store-user"^^:VariableName ] ;
   code:arguments     [ code:name  "password" ;
                        code:value "graph-store-password"^^:VariableName ] .
+
+<#injectCubeRevision>
+  a :Step ;
+  code:implementedBy [ code:link <file:../lib/cube#injectRevision> ;
+                       a         code:EcmaScript ] ;
+  code:arguments ( [ a code:EcmaScript ;
+                     code:link <file:../lib/cube#injectRevision> ] ) ;
+  .
 
 <#injectMetadata>
   a                  :Step ;
@@ -60,7 +66,7 @@ _:setGraph
 _:upload
   a                  :Step ;
   code:implementedBy [ a         code:EcmaScript ;
-                       code:link <node:barnard59-graph-store#put> ] ;
+                       code:link <node:barnard59-graph-store#post> ] ;
   code:arguments     [ code:name  "endpoint" ;
                        code:value "publish-graph-store-endpoint"^^:VariableName ] ;
   code:arguments     [ code:name  "user" ;

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -55,7 +55,7 @@ async function main() {
     }
 
     if (publishJob) {
-      doPublish({ job: publishJob, debug: true }).catch((e) => log(e))
+      doPublish({ jobUri: publishJob, debug: true }).catch((e) => log(e))
     }
     return res.status(202).end()
   }))

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -120,25 +120,25 @@ describe('lib/commands/publish', function () {
           path: cube.observedBy,
           minCount: 1,
         }, {
-          path: targetCube('dimension/year'),
+          path: ns.baseCube('dimension/year'),
           hasValue: $rdf.literal('2002', xsd.gYear),
           minCount: 1,
           maxCount: 1,
         }, {
-          path: targetCube('dimension/value'),
+          path: ns.baseCube('dimension/value'),
           hasValue: $rdf.literal('6.1', xsd.float),
           minCount: 1,
           maxCount: 1,
         }, {
-          path: targetCube('station'),
+          path: ns.baseCube('station'),
           minCount: 1,
           maxCount: 1,
         }, {
-          path: targetCube('pollutant'),
+          path: ns.baseCube('pollutant'),
           minCount: 1,
           maxCount: 1,
         }, {
-          path: targetCube('unit-id'),
+          path: ns.baseCube('unit-id'),
           hasValue: $rdf.literal('µg/m3'),
           minCount: 1,
           maxCount: 1,
@@ -157,10 +157,10 @@ describe('lib/commands/publish', function () {
         },
       })
 
-      expect(cubePointer.namedNode(targetCube('shape/')).out(sh.property).has(sh.path, targetCube('dimension/year'))).to.matchShape({
+      expect(cubePointer.namedNode(targetCube('shape/')).out(sh.property).has(sh.path, ns.baseCube('dimension/year'))).to.matchShape({
         property: {
           path: sh.path,
-          hasValue: targetCube('dimension/year'),
+          hasValue: ns.baseCube('dimension/year'),
           minCount: 1,
         },
       })

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -1,23 +1,23 @@
-
 import env from '@cube-creator/core/env'
 import { before, describe, it } from 'mocha'
 import { expect } from 'chai'
 import $rdf from 'rdf-ext'
-import { CONSTRUCT } from '@tpluscode/sparql-builder'
+import { CONSTRUCT, SELECT } from '@tpluscode/sparql-builder'
 import debug from 'debug'
 import { dcat, dcterms, rdf, schema, sh, vcard, xsd } from '@tpluscode/rdf-ns-builders'
 import { setupEnv } from '../../support/env'
-import { client, insertTestData } from '@cube-creator/testing/lib'
-import { cube, scale } from '@cube-creator/core/namespace'
+import { client, parsingClient, insertTestData } from '@cube-creator/testing/lib'
+import { cc, cube, scale } from '@cube-creator/core/namespace'
 import clownface, { AnyPointer } from 'clownface'
 import publish from '../../../lib/commands/publish'
-import namespace from '@rdfjs/namespace'
+import namespace, { NamespaceBuilder } from '@rdfjs/namespace'
+import { NamedNode } from 'rdf-js'
 
 describe('lib/commands/publish', function () {
   this.timeout(200000)
 
   const ns = {
-    targetCube: namespace('https://environment.ld.admin.ch/foen/ubd/28/'),
+    baseCube: namespace('https://environment.ld.admin.ch/foen/ubd/28/'),
   }
 
   const executionUrl = 'http://example.com/transformation-test'
@@ -29,14 +29,15 @@ describe('lib/commands/publish', function () {
 
   describe('produces triples', async function () {
     let cubePointer: AnyPointer
+    let targetCube: NamespaceBuilder
     before(async () => {
-    // given
+      // given
       const runner = publish($rdf.namedNode('urn:pipeline:cube-creator#Main'), debug('test'))
 
       // when
       await runner({
         debug: true,
-        job: `${env.API_CORE_BASE}cube-project/ubd/csv-mapping/jobs/test-publish-job`,
+        jobUri: `${env.API_CORE_BASE}cube-project/ubd/csv-mapping/jobs/test-publish-job`,
         executionUrl,
       })
       await new Promise((resolve) =>
@@ -44,17 +45,39 @@ describe('lib/commands/publish', function () {
       )
 
       // then
-      const expectedGraph = ns.targetCube()
+      const project = $rdf.namedNode('https://cube-creator.lndo.site/cube-project/ubd')
+      const [{ expectedGraph }] = await SELECT`?expectedGraph ?revision`
+        .FROM(project)
+        .WHERE`
+          ${project} ${cc.publishGraph} ?expectedGraph .
+        `
+        .execute(parsingClient.query)
+
+      targetCube = namespace(ns.baseCube('2/').value)
+
       const dataset = await $rdf.dataset().import(await CONSTRUCT`?s ?p ?o`
-        .FROM(expectedGraph)
+        .FROM(expectedGraph as NamedNode)
         .WHERE`?s ?p ?o`
         .execute(client.query))
 
       cubePointer = clownface({ dataset })
     })
 
+    it('does not remove previously published triples', () => {
+      const prevCube = cubePointer.namedNode(ns.baseCube('1'))
+
+      expect(prevCube.out().terms).to.have.length(1)
+      expect(prevCube).to.matchShape({
+        property: {
+          path: rdf.type,
+          hasValue: cube.Cube,
+          minCount: 1,
+        },
+      })
+    })
+
     it('cube meta data has been copied', async function () {
-      expect(cubePointer.namedNode(ns.targetCube())).to.matchShape({
+      expect(cubePointer.namedNode(targetCube())).to.matchShape({
         property: [{
           path: dcterms.identifier,
           hasValue: $rdf.literal('UBD28@BAFU'),
@@ -73,7 +96,7 @@ describe('lib/commands/publish', function () {
         }],
       })
 
-      expect(cubePointer.namedNode(ns.targetCube()).out(dcat.contactPoint)).to.matchShape({
+      expect(cubePointer.namedNode(targetCube()).out(dcat.contactPoint)).to.matchShape({
         property: [{
           path: vcard.fn,
           hasValue: $rdf.literal('Test Name'),
@@ -88,7 +111,7 @@ describe('lib/commands/publish', function () {
     })
 
     it('observation data has been copied', async function () {
-      expect(cubePointer.namedNode(ns.targetCube('observation/blBAS-2002-annualmean'))).to.matchShape({
+      expect(cubePointer.namedNode(targetCube('observation/blBAS-2002-annualmean'))).to.matchShape({
         property: [{
           path: rdf.type,
           hasValue: cube.Observation,
@@ -97,25 +120,25 @@ describe('lib/commands/publish', function () {
           path: cube.observedBy,
           minCount: 1,
         }, {
-          path: ns.targetCube('dimension/year'),
+          path: targetCube('dimension/year'),
           hasValue: $rdf.literal('2002', xsd.gYear),
           minCount: 1,
           maxCount: 1,
         }, {
-          path: ns.targetCube('dimension/value'),
+          path: targetCube('dimension/value'),
           hasValue: $rdf.literal('6.1', xsd.float),
           minCount: 1,
           maxCount: 1,
         }, {
-          path: ns.targetCube('station'),
+          path: targetCube('station'),
           minCount: 1,
           maxCount: 1,
         }, {
-          path: ns.targetCube('pollutant'),
+          path: targetCube('pollutant'),
           minCount: 1,
           maxCount: 1,
         }, {
-          path: ns.targetCube('unit-id'),
+          path: targetCube('unit-id'),
           hasValue: $rdf.literal('µg/m3'),
           minCount: 1,
           maxCount: 1,
@@ -124,9 +147,9 @@ describe('lib/commands/publish', function () {
     })
 
     it('dimension meta data has been copied', async function () {
-      expect(cubePointer.has(rdf.type, sh.NodeShape).term).to.deep.eq(ns.targetCube('shape/'))
+      expect(cubePointer.has(rdf.type, sh.NodeShape).term).to.deep.eq(targetCube('shape/'))
       expect(cubePointer.has(rdf.type, sh.NodeShape).terms.length).to.eq(1)
-      expect(cubePointer.namedNode(ns.targetCube('shape/'))).to.matchShape({
+      expect(cubePointer.namedNode(targetCube('shape/'))).to.matchShape({
         property: {
           path: rdf.type,
           hasValue: cube.Constraint,
@@ -134,15 +157,15 @@ describe('lib/commands/publish', function () {
         },
       })
 
-      expect(cubePointer.namedNode(ns.targetCube('shape/')).out(sh.property).has(sh.path, ns.targetCube('dimension/year'))).to.matchShape({
+      expect(cubePointer.namedNode(targetCube('shape/')).out(sh.property).has(sh.path, targetCube('dimension/year'))).to.matchShape({
         property: {
           path: sh.path,
-          hasValue: ns.targetCube('dimension/year'),
+          hasValue: targetCube('dimension/year'),
           minCount: 1,
         },
       })
 
-      expect(cubePointer.namedNode(ns.targetCube('shape/')).out(sh.property).has(sh.path, schema.name)).to.matchShape({
+      expect(cubePointer.namedNode(targetCube('shape/')).out(sh.property).has(sh.path, schema.name)).to.matchShape({
         property: {
           path: schema.name,
           hasValue: $rdf.literal('Jahr', 'de'),
@@ -150,7 +173,7 @@ describe('lib/commands/publish', function () {
         },
       })
 
-      expect(cubePointer.namedNode(ns.targetCube('shape/')).out(sh.property).has(sh.path, scale.scaleOfMeasure)).to.matchShape({
+      expect(cubePointer.namedNode(targetCube('shape/')).out(sh.property).has(sh.path, scale.scaleOfMeasure)).to.matchShape({
         property: {
           path: scale.scaleOfMeasure,
           hasValue: scale.Temporal,

--- a/e2e-tests/csv-source/delete.hydra
+++ b/e2e-tests/csv-source/delete.hydra
@@ -24,7 +24,8 @@ With Class api:EntryPoint {
 
                 <> cc:projectSourceKind <https://cube-creator.lndo.site/shape/cube-project/create#CSV> ;
                    rdfs:label "Test Project" ;
-                   cc:namespace <http://example.com/test-cube/> .
+                   cc:namespace <http://example.com/test-cube/> ;
+                   cc:publishGraph <http://example.com/> .
                 ```
             } => {
                 Expect Status 201

--- a/e2e-tests/csv-source/get-csv.hydra
+++ b/e2e-tests/csv-source/get-csv.hydra
@@ -24,7 +24,8 @@ With Class api:EntryPoint {
 
                 <> cc:projectSourceKind <https://cube-creator.lndo.site/shape/cube-project/create#CSV> ;
                    rdfs:label "Test Project" ;
-                   cc:namespace <http://example.com/test-cube/> .
+                   cc:namespace <http://example.com/test-cube/> ;
+                   cc:publishGraph <http://example.com/> .
                 ```
             } => {
                 Expect Status 201

--- a/e2e-tests/csv-source/upload.hydra
+++ b/e2e-tests/csv-source/upload.hydra
@@ -24,7 +24,8 @@ With Class api:EntryPoint {
 
                 <> cc:projectSourceKind <https://cube-creator.lndo.site/shape/cube-project/create#CSV> ;
                    rdfs:label "Test Project" ;
-                   cc:namespace <http://example.com/test-cube/> .
+                   cc:namespace <http://example.com/test-cube/> ;
+                   cc:publishGraph <http://example.com/>.
                 ```
             } => {
                 Expect Status 201

--- a/e2e-tests/cube-projects/create.hydra
+++ b/e2e-tests/cube-projects/create.hydra
@@ -22,7 +22,8 @@ With Class api:EntryPoint {
 
                 <> cc:projectSourceKind <https://cube-creator.lndo.site/shape/cube-project/create#CSV> ;
                    rdfs:label "Test Project" ;
-                   cc:namespace <http://example.com/test-cube/> .
+                   cc:namespace <http://example.com/test-cube/> ;
+                   cc:publishGraph <http://data.zazuko.com/> .
                 ```
             } => {
                 Expect Status 201
@@ -34,6 +35,7 @@ With Class api:EntryPoint {
                 }
                 Expect Property dcterms:creator
                 Expect Property cc:cubeGraph
+                Expect Property cc:publishGraph
 
                 // Project dataset
                 Expect Link cc:dataset {

--- a/e2e-tests/cube-projects/delete.hydra
+++ b/e2e-tests/cube-projects/delete.hydra
@@ -22,7 +22,8 @@ With Class api:EntryPoint {
 
                 <> cc:projectSourceKind <https://cube-creator.lndo.site/shape/cube-project/create#CSV> ;
                    rdfs:label "Test Project" ;
-                   cc:namespace <http://example.com/test-cube/> .
+                   cc:namespace <http://example.com/test-cube/> ;
+                   cc:publishGraph <http://example.com/> .
                 ```
             } => {
                 Expect Status 201

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -31,6 +31,11 @@ graph <cube-project/ubd> {
   .
 }
 
+<https://lindas.admin.ch/foen/cube> void:inDataset <ubd-example> .
+graph <https://lindas.admin.ch/foen/cube> {
+  <https://environment.ld.admin.ch/foen/ubd/28/1> a cube:Cube .
+}
+
 <cube-project/ubd/dataset> void:inDataset <ubd-example> .
 graph <cube-project/ubd/dataset> {
   <cube-project/ubd/dataset>
@@ -482,5 +487,7 @@ graph <cube-project/ubd/csv-mapping/jobs/test-publish-job> {
     dcterms:created "2020-10-29T12:01:70"^^xsd:dateTime ;
     rdfs:seeAlso <https://github.com/zazuko/cube-creator/actions/runs/345020889> ;
     schema:actionStatus schema:PotentialActionStatus ;
+    cc:publishGraph <https://lindas.admin.ch/foen/cube> ;
+    cc:revision 2 ;
   .
 }

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -23,6 +23,7 @@ graph <cube-project/ubd> {
     a cc:CubeProject, hydra:Resource ;
     cc:dataset  <cube-project/ubd/dataset> ;
     cc:cubeGraph  <cube-project/ubd/cube-data> ;
+    cc:publishGraph  <https://lindas.admin.ch/foen/cube> ;
     cc:csvMapping <cube-project/ubd/csv-mapping> ;
     dcterms:creator <user> ;
     rdfs:label "UBD28 Project" ;

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -24,6 +24,7 @@ graph <cube-project/ubd> {
     cc:dataset  <cube-project/ubd/dataset> ;
     cc:cubeGraph  <cube-project/ubd/cube-data> ;
     cc:publishGraph  <https://lindas.admin.ch/foen/cube> ;
+    cc:latestPublishedRevision 1 ;
     cc:csvMapping <cube-project/ubd/csv-mapping> ;
     dcterms:creator <user> ;
     rdfs:label "UBD28 Project" ;

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -55,7 +55,9 @@ type CubeCreatorProperty =
   'cube' |
   'jobCollection' |
   'dimensionMetadata' |
-  'observations'
+  'observations' |
+  'latestPublishedRevision' |
+  'revision'
 
 type OtherTerms =
   'dash'

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -56,6 +56,7 @@ type CubeCreatorProperty =
   'jobCollection' |
   'dimensionMetadata' |
   'observations' |
+  'publishGraph' |
   'latestPublishedRevision' |
   'revision'
 

--- a/packages/model/Job.ts
+++ b/packages/model/Job.ts
@@ -28,6 +28,10 @@ export interface PublishJob extends Job {
   publishGraph: NamedNode
 }
 
+export function isPublishJob(job: Job): job is PublishJob {
+  return job.types.has(cc.PublishJob)
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface JobCollection extends Collection<Job> {
 

--- a/packages/model/Job.ts
+++ b/packages/model/Job.ts
@@ -24,6 +24,7 @@ export interface TransformJob extends Job {
 
 export interface PublishJob extends Job {
   project: NamedNode
+  revision: number
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -73,6 +74,9 @@ export function PublishJobMixin<Base extends Constructor<RdfResource>>(base: Bas
   class Impl extends ResourceMixin(ActionMixin(base)) implements Partial<PublishJob> {
     @property({ path: cc.project })
     project!: NamedNode
+
+    @property.literal({ path: cc.revision, type: Number })
+    revision!: number
   }
 
   return Impl
@@ -80,7 +84,7 @@ export function PublishJobMixin<Base extends Constructor<RdfResource>>(base: Bas
 
 PublishJobMixin.appliesTo = cc.PublishJob
 
-type RequiredPropertiesPublish = 'name' | 'project'
+type RequiredPropertiesPublish = 'name' | 'project' | 'revision'
 
 export const createPublish = initializer<PublishJob, RequiredPropertiesPublish>(PublishJobMixin, {
   types: [cc.Job, cc.PublishJob],

--- a/packages/model/Job.ts
+++ b/packages/model/Job.ts
@@ -25,6 +25,7 @@ export interface TransformJob extends Job {
 export interface PublishJob extends Job {
   project: NamedNode
   revision: number
+  publishGraph: NamedNode
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -77,6 +78,9 @@ export function PublishJobMixin<Base extends Constructor<RdfResource>>(base: Bas
 
     @property.literal({ path: cc.revision, type: Number })
     revision!: number
+
+    @property({ path: cc.publishGraph })
+    publishGraph!: NamedNode
   }
 
   return Impl
@@ -84,7 +88,7 @@ export function PublishJobMixin<Base extends Constructor<RdfResource>>(base: Bas
 
 PublishJobMixin.appliesTo = cc.PublishJob
 
-type RequiredPropertiesPublish = 'name' | 'project' | 'revision'
+type RequiredPropertiesPublish = 'name' | 'project' | 'revision' | 'publishGraph'
 
 export const createPublish = initializer<PublishJob, RequiredPropertiesPublish>(PublishJobMixin, {
   types: [cc.Job, cc.PublishJob],

--- a/packages/model/Project.ts
+++ b/packages/model/Project.ts
@@ -58,6 +58,6 @@ export function ProjectMixin<Base extends Constructor>(base: Base): Mixin {
 
 ProjectMixin.appliesTo = cc.CubeProject
 
-type MandatoryFields = 'creator' | 'label'
+type MandatoryFields = 'creator' | 'label' | 'publishGraph'
 
 export const create = initializer<Project, MandatoryFields>(ProjectMixin)

--- a/packages/model/Project.ts
+++ b/packages/model/Project.ts
@@ -19,6 +19,7 @@ export interface Project extends RdfResource {
   creator: NamedNode
   label: string
   jobCollection: Link<JobCollection>
+  publishGraph: NamedNode
   publishedRevision: number
 }
 
@@ -38,6 +39,9 @@ export function ProjectMixin<Base extends Constructor>(base: Base): Mixin {
 
     @property({ initial: childResource('cube-data') })
     cubeGraph!: NamedNode
+
+    @property()
+    publishGraph!: NamedNode
 
     @property.literal({ path: cc.latestPublishedRevision, type: Number })
     publishedRevision?: number

--- a/packages/model/Project.ts
+++ b/packages/model/Project.ts
@@ -19,6 +19,7 @@ export interface Project extends RdfResource {
   creator: NamedNode
   label: string
   jobCollection: Link<JobCollection>
+  publishedRevision: number
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -37,6 +38,9 @@ export function ProjectMixin<Base extends Constructor>(base: Base): Mixin {
 
     @property({ initial: childResource('cube-data') })
     cubeGraph!: NamedNode
+
+    @property.literal({ path: cc.latestPublishedRevision, type: Number })
+    publishedRevision?: number
 
     @property({ path: dcterms.creator })
     creator!: NamedNode

--- a/packages/testing/lib/index.ts
+++ b/packages/testing/lib/index.ts
@@ -15,7 +15,7 @@ export const client = new StreamClient({
   storeUrl: 'http://db.cube-creator.lndo.site/cube-creator/data',
 })
 
-const parsingClient = new ParsingClient({
+export const parsingClient = new ParsingClient({
   updateUrl: 'http://db.cube-creator.lndo.site/cube-creator/update',
   endpointUrl: 'http://db.cube-creator.lndo.site/cube-creator/query',
   storeUrl: 'http://db.cube-creator.lndo.site/cube-creator/data',

--- a/typings/barnard59-base/index.d.ts
+++ b/typings/barnard59-base/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'barnard59-base/lib/map' {
+  import * as stream from 'stream'
+
+  function map<T>(cb: (chunk: T, encoding: string) => T): stream.Transform
+
+  export = map
+}

--- a/ui/tests/e2e/specs/project-mapping.spec.ts
+++ b/ui/tests/e2e/specs/project-mapping.spec.ts
@@ -18,6 +18,11 @@ describe('CSV mapping flow', () => {
       .find('input')
       .type('My project')
 
+    cy.contains('.label', 'Publish graph')
+      .next()
+      .find('input')
+      .type('http://example.com/published-cube')
+
     cy.get('form').submit()
 
     cy.contains('.message', 'successfully created').should('be.visible')

--- a/ui/tests/e2e/specs/project-mapping.spec.ts
+++ b/ui/tests/e2e/specs/project-mapping.spec.ts
@@ -13,13 +13,11 @@ describe('CSV mapping flow', () => {
   it('Creates a new project', () => {
     cy.contains('.button', 'New project').click()
 
-    cy.contains('.label', 'Project name')
-      .next()
+    cy.contains('.form-property', 'Project name')
       .find('input')
       .type('My project')
 
-    cy.contains('.label', 'Publish graph')
-      .next()
+    cy.contains('.form-property', 'Publish graph')
       .find('input')
       .type('http://example.com/published-cube')
 


### PR DESCRIPTION
This PR should pretty much complete the publishing feature:

1. A "revision" number is appended to cube URIs.
2. When a job completes, the last published revision is incremented on project
3. Cube data is stored at a predefined named graph, stored by project. 
   - append and not replace
4. Both the output graph as well the revision are stored with job to allow consistent re-runs