### PR TITLE
build(deps): pin barnard59-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "ts-node": "^9.0.0",
     "typescript": "^4.0.3"
   },
+  "resolutions": {
+    "barnard59-base": "0.0.5"
+  },
   "mocha": {
     "extension": "ts",
     "recursive": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3231,7 +3231,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-barnard59-base@^0.0.1, barnard59-base@^0.0.4, barnard59-base@^0.0.5:
+barnard59-base@0.0.5, barnard59-base@^0.0.1, barnard59-base@^0.0.4, barnard59-base@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/barnard59-base/-/barnard59-base-0.0.5.tgz#ae0130a4d8a547cfa4d53558ccc1b46aa5b390c0"
   integrity sha512-4E+8OODtFtCAs5i7mmuKxvu/SuToNq3nB2Cn5p0hkAxIY/NKj5NxLe9gyUG888mTvZVdZRIPY2Xy/09xjL+OQg==


### PR DESCRIPTION
I quickly realised that #286 was in fact flawed because the `0.0.x` range has different resolution rules from `1.x` and `0.x` alike 🙄 