### PR TITLE
fix(cli): revert publish command's job param

### DIFF
--- a/cli/lib/commands/publish.ts
+++ b/cli/lib/commands/publish.ts
@@ -20,7 +20,7 @@ const ns = {
 
 interface RunOptions {
   debug: boolean
-  jobUri: string
+  job: string
   executionUrl?: string
   variable?: Map<string, string | undefined>
   graphStore?: {
@@ -41,7 +41,7 @@ export default function (pipelineId: NamedNode, log: Debugger) {
   const basePath = path.resolve(__dirname, '../../')
 
   return async function (command: RunOptions) {
-    const { jobUri, debug = false, enableBufferMonitor = false, variable = new Map(), graphStore, publishStore, executionUrl } = command
+    const { job: jobUri, debug = false, enableBufferMonitor = false, variable = new Map(), graphStore, publishStore, executionUrl } = command
 
     log.enabled = debug
     const authConfig = {

--- a/cli/server.ts
+++ b/cli/server.ts
@@ -55,7 +55,7 @@ async function main() {
     }
 
     if (publishJob) {
-      doPublish({ jobUri: publishJob, debug: true }).catch((e) => log(e))
+      doPublish({ job: publishJob, debug: true }).catch((e) => log(e))
     }
     return res.status(202).end()
   }))

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -37,7 +37,7 @@ describe('lib/commands/publish', function () {
       // when
       await runner({
         debug: true,
-        jobUri: `${env.API_CORE_BASE}cube-project/ubd/csv-mapping/jobs/test-publish-job`,
+        job: `${env.API_CORE_BASE}cube-project/ubd/csv-mapping/jobs/test-publish-job`,
         executionUrl,
       })
       await new Promise((resolve) =>


### PR DESCRIPTION
I recently renamed the `job` param of the publish command params but failed to realise that it directly maps to the CLI options 😊 