### PR TITLE
fix(ui): edit table validation

### DIFF
--- a/ui/src/views/TableEdit.vue
+++ b/ui/src/views/TableEdit.vue
@@ -44,8 +44,12 @@ export default class TableCreateView extends Vue {
       this.shape = await api.fetchOperationShape(this.operation)
     }
 
-    this.resource = this.table?.pointer ?? null
-    this.resource?.addOut(cc.isObservationTable, this.table?.isObservationTable ?? false)
+    // Fetch fresh table to avoid superfluous quads in the dataset
+    if (this.table) {
+      const table = await api.fetchResource<Table>(this.table.id.value)
+      this.resource = table.pointer
+        .addOut(cc.isObservationTable, table.isObservationTable)
+    }
   }
 
   get table (): Table | null {


### PR DESCRIPTION
Reload table from API to avoid submitting a whole bunch of superfluous
quads that are already present in the collection dataset and that failes
validation.

Fixes #306 