### PR TITLE
fix: rename cube when namespace changes

### DIFF
--- a/apis/core/lib/domain/csv-mapping/CsvMapping.ts
+++ b/apis/core/lib/domain/csv-mapping/CsvMapping.ts
@@ -9,6 +9,7 @@ import * as Table from '@cube-creator/model/Table'
 import { ResourceStore } from '../../ResourceStore'
 import * as id from '../identifiers'
 import { NamedNode } from 'rdf-js'
+import { DomainError } from '../../errors'
 
 RdfResource.factory.addMixin(...Object.values(Hydra))
 
@@ -29,6 +30,7 @@ interface ApiCsvMapping {
   initializeTableCollection(store: ResourceStore): void
   addSource(store: ResourceStore, params: AddSource): CsvSource.CsvSource
   addTable(store: ResourceStore, params: AddTable): Promise<Table.Table>
+  updateNamespace(newNamespace: NamedNode | undefined): NamedNode
 }
 
 declare module '@cube-creator/model' {
@@ -102,6 +104,20 @@ export default function Mixin<Base extends Constructor<Omit<CsvMapping, keyof Ap
         identifierTemplate,
         color,
       })
+    }
+
+    updateNamespace(newNamespace: NamedNode | undefined) {
+      if (!newNamespace) {
+        throw new DomainError('Namespace cannot be empty')
+      }
+
+      if (!this.namespace.equals(newNamespace)) {
+        const current = this.namespace
+        this.namespace = newNamespace
+        return current
+      }
+
+      return this.namespace
     }
   }
 }

--- a/apis/core/lib/domain/cube-projects/Project.ts
+++ b/apis/core/lib/domain/cube-projects/Project.ts
@@ -18,6 +18,7 @@ interface ApiProject {
   initializeJobCollection(store: ResourceStore): void
   incrementPublishedRevision(): void
   updatePublishGraph(publishGraph: Term | undefined): void
+  rename(name: string | undefined): void
 }
 
 declare module '@cube-creator/model' {
@@ -88,6 +89,14 @@ export default function Mixin<Base extends Constructor<Omit<Project, keyof ApiPr
       }
 
       this.publishGraph = publishGraph
+    }
+
+    rename(label: string | undefined): void {
+      if (!label) {
+        throw new DomainError('Label cannot be empty')
+      }
+
+      this.label = label
     }
   }
 

--- a/apis/core/lib/domain/cube-projects/update.ts
+++ b/apis/core/lib/domain/cube-projects/update.ts
@@ -4,7 +4,7 @@ import { cc } from '@cube-creator/core/namespace'
 import { ResourceStore } from '../../ResourceStore'
 import { resourceStore } from '../resources'
 import { rdfs } from '@tpluscode/rdf-ns-builders'
-import { CsvMapping, Project, Dataset } from '@cube-creator/model'
+import { CsvMapping, Project, Dataset, DimensionMetadataCollection } from '@cube-creator/model'
 
 interface UpdateProjectCommand {
   resource: GraphPointer
@@ -28,6 +28,8 @@ export async function updateProject({
     if (!currentNamespace.equals(newNamespace)) {
       const dataset = await store.getResource<Dataset>(storedProject.dataset?.id)
       dataset.renameCube(currentNamespace, newNamespace)
+      const metadata = await store.getResource<DimensionMetadataCollection>(dataset.dimensionMetadata.id)
+      metadata.renameDimensions(currentNamespace, newNamespace)
     }
   }
 

--- a/apis/core/lib/domain/dataset/Dataset.ts
+++ b/apis/core/lib/domain/dataset/Dataset.ts
@@ -1,4 +1,5 @@
-import { NamedNode } from 'rdf-js'
+import { NamedNode, Term } from 'rdf-js'
+import $rdf from 'rdf-ext'
 import { Constructor } from '@tpluscode/rdfine'
 import { _void, schema } from '@tpluscode/rdf-ns-builders'
 import { Dataset } from '@cube-creator/model'
@@ -6,6 +7,7 @@ import * as Cube from '@cube-creator/model/Cube'
 
 interface ApiDataset {
   addCube(cube: NamedNode, creator: NamedNode): void
+  renameCube(cube: NamedNode, newId: NamedNode): void
 }
 
 declare module '@cube-creator/model' {
@@ -14,11 +16,27 @@ declare module '@cube-creator/model' {
 }
 
 export default function Mixin<Base extends Constructor<Omit<Dataset, keyof ApiDataset>>>(Resource: Base) {
-  return class extends Resource {
+  return class extends Resource implements ApiDataset {
     addCube(cube: NamedNode, creator: NamedNode) {
       Cube.create(this.pointer.node(cube), { creator })
 
       this.pointer.addOut(schema.hasPart, cube)
+    }
+
+    renameCube(cube: NamedNode, newId: NamedNode): void {
+      if (!newId) return
+
+      const rename = <T extends Term>(term: Term): T => (term.equals(cube) ? newId : term) as T
+
+      for (const quad of [...this.pointer.dataset]) {
+        this.pointer.dataset.delete(quad)
+        this.pointer.dataset.add($rdf.quad(
+          rename(quad.subject),
+          quad.predicate,
+          rename(quad.object),
+          quad.graph,
+        ))
+      }
     }
   }
 }

--- a/apis/core/test/domain/cube-projects/update.test.ts
+++ b/apis/core/test/domain/cube-projects/update.test.ts
@@ -2,21 +2,22 @@ import { describe, it, beforeEach } from 'mocha'
 import { expect } from 'chai'
 import clownface, { GraphPointer } from 'clownface'
 import $rdf from 'rdf-ext'
+import DatasetExt from 'rdf-ext/lib/Dataset'
 import { NamedNode } from 'rdf-js'
 import { ResourceIdentifier } from '@tpluscode/rdfine'
-import { rdfs } from '@tpluscode/rdf-ns-builders'
+import { rdfs, schema } from '@tpluscode/rdf-ns-builders'
 import { cc, shape } from '@cube-creator/core/namespace'
 import { createProject } from '../../../lib/domain/cube-projects/create'
 import { TestResourceStore } from '../../support/TestResourceStore'
 import '../../../lib/domain'
-import { CsvMapping, Project } from '@cube-creator/model'
+import { CsvMapping } from '@cube-creator/model'
 import { updateProject } from '../../../lib/domain/cube-projects/update'
 
 describe('domain/cube-projects/update', () => {
   let store: TestResourceStore
   const user = $rdf.namedNode('userId')
   const projectsCollection = clownface({ dataset: $rdf.dataset() }).namedNode('projects')
-  let project: Project
+  let project: GraphPointer<NamedNode, DatasetExt>
 
   function projectPointer(id: ResourceIdentifier = $rdf.namedNode('')) {
     return clownface({ dataset: $rdf.dataset() })
@@ -34,19 +35,22 @@ describe('domain/cube-projects/update', () => {
 
     const resource = projectPointer()
 
-    project = await createProject({ resource, store, projectsCollection, user })
+    project = (await createProject({ resource, store, projectsCollection, user })).pointer as any
   })
 
   describe('CSV project', () => {
     it('updates publishGraph', async () => {
-      const resource = projectPointer(project.id)
+      const resource = projectPointer(project.term)
       resource
         .deleteOut(cc.publishGraph)
         .addOut(cc.publishGraph, $rdf.namedNode('http://published.cubes/changed'))
+        .addOut(cc.csvMapping, mapping => {
+          mapping.addOut(cc.namespace, $rdf.namedNode('http://created.namespace/'))
+        })
 
       const editedProject = await updateProject({
         resource,
-        project: project.pointer as GraphPointer<NamedNode>,
+        project,
         store,
       })
 
@@ -61,14 +65,16 @@ describe('domain/cube-projects/update', () => {
     })
 
     it('edits a CSV Mapping resource', async () => {
-      project.pointer.deleteOut(rdfs.label)
-      project.pointer.addOut(rdfs.label, 'Edited name')
-      project.pointer.out(cc.csvMapping).deleteOut(cc.namespace)
-      project.pointer.out(cc.csvMapping).addOut(cc.namespace, $rdf.namedNode('http://edited.namespace/'))
+      const resource = projectPointer(project.term)
+        .deleteOut(rdfs.label)
+        .addOut(rdfs.label, 'Edited name')
+        .addOut(cc.csvMapping, mapping => {
+          mapping.addOut(cc.namespace, $rdf.namedNode('http://edited.namespace/'))
+        })
 
       const editedProject = await updateProject({
-        resource: project.pointer,
-        project: project.pointer as GraphPointer<NamedNode>,
+        resource,
+        project,
         store,
       })
 
@@ -76,6 +82,63 @@ describe('domain/cube-projects/update', () => {
 
       const namespace = await store.getResource<CsvMapping>(editedProject.pointer.out(cc.csvMapping).term)
       expect(namespace?.pointer.out(cc.namespace).term?.value).to.eq('http://edited.namespace/')
+    })
+
+    it('does not touch cube if namespace does not change', async () => {
+      // given
+      const resource = projectPointer(project.term)
+        .addOut(cc.csvMapping, mapping => {
+          mapping.addOut(cc.namespace, $rdf.namedNode('http://created.namespace/'))
+        })
+      const datasetBefore = (await store.get(project.out(cc.dataset).term)).dataset.toCanonical()
+
+      // when
+      const editedProject = await updateProject({
+        resource,
+        project,
+        store,
+      })
+
+      // then
+      const datasetAfter = (await store.get(editedProject.dataset.id)).dataset.toCanonical()
+      expect(datasetAfter).to.eq(datasetBefore)
+    })
+
+    it('renames cube if namespace changes', async () => {
+      // given
+      const datasetBefore = await store.get(project.out(cc.dataset).term)
+      datasetBefore.out(schema.hasPart)
+        .addOut(rdfs.label, 'Cube')
+      const namespace = $rdf.namedNode('http://edited.namespace/')
+      const resource = projectPointer(project.term)
+        .addOut(cc.csvMapping, mapping => {
+          mapping.addOut(cc.namespace, namespace)
+        })
+
+      // when
+      const editedProject = await updateProject({
+        resource,
+        project,
+        store,
+      })
+
+      // then
+      const datasetAfter = await store.get(editedProject.dataset.id)
+      expect(datasetAfter).to.matchShape({
+        property: {
+          path: schema.hasPart,
+          minCount: 1,
+          hasValue: namespace,
+          node: {
+            property: {
+              path: rdfs.label,
+              hasValue: $rdf.literal('Cube'),
+              minCount: 1,
+              maxCount: 1,
+            },
+          },
+        },
+      })
     })
   })
 })


### PR DESCRIPTION
When a project update changes the `cc:namespace` the cube should also be updated