### PR TITLE
Store refactor

### DIFF
--- a/apis/core/lib/ChangelogDataset.ts
+++ b/apis/core/lib/ChangelogDataset.ts
@@ -1,0 +1,73 @@
+import { DatasetCore, Quad } from 'rdf-js'
+import $rdf from 'rdf-ext'
+
+interface Changes {
+  added: DatasetCore
+  deleted: DatasetCore
+}
+
+export class ChangelogDataset<D extends DatasetCore = DatasetCore> implements DatasetCore {
+  changes: Changes
+
+  constructor(private dataset: D) {
+    this.changes = {
+      added: $rdf.dataset(),
+      deleted: $rdf.dataset(),
+    }
+  }
+
+  flush(): Changes {
+    const lastChanges = this.changes
+
+    this.changes = {
+      added: $rdf.dataset(),
+      deleted: $rdf.dataset(),
+    }
+
+    return lastChanges
+  }
+
+  add(quad: Quad): this {
+    if (this.changes.deleted.has(quad)) {
+      this.changes.deleted.delete(quad)
+    } else {
+      this.changes.added.add(quad)
+    }
+
+    this.dataset.add(quad)
+
+    return this
+  }
+
+  delete(quad: Quad): this {
+    if (!this.dataset.has(quad)) {
+      return this
+    }
+
+    if (this.changes.added.has(quad)) {
+      this.changes.added.delete(quad)
+    } else {
+      this.changes.deleted.add(quad)
+    }
+
+    this.dataset.delete(quad)
+
+    return this
+  }
+
+  get size(): number {
+    return this.dataset.size
+  }
+
+  [Symbol.iterator](): Iterator<Quad> {
+    return this.dataset[Symbol.iterator]()
+  }
+
+  has(quad: Quad): boolean {
+    return this.dataset.has(quad)
+  }
+
+  match(...args: Parameters<DatasetCore['match']>): DatasetCore<Quad, Quad> {
+    return this.dataset.match(...args)
+  }
+}

--- a/apis/core/lib/ResourceStore.ts
+++ b/apis/core/lib/ResourceStore.ts
@@ -46,13 +46,6 @@ export interface ResourceStore {
   createMember(collection: Term, id: NamedNode, options?: ResourceCreationOptions): Promise<GraphPointer<NamedNode, DatasetExt>>
 
   /**
-   * Replaces the resources in the triple store by inserting default graph
-   * quads from each graph pointer into a named graph identified by that
-   * graph pointer
-   */
-  save(): Promise<void>
-
-  /**
    * Removes the named graph from the triple store
    */
   delete(id: NamedNode): void

--- a/apis/core/lib/domain/column-mapping/create.ts
+++ b/apis/core/lib/domain/column-mapping/create.ts
@@ -1,7 +1,6 @@
 import { GraphPointer } from 'clownface'
 import { cc } from '@cube-creator/core/namespace'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import { NamedNode, Term } from 'rdf-js'
 import { CsvMapping, CsvSource, DimensionMetadataCollection, LiteralColumnMapping, ReferenceColumnMapping, Table } from '@cube-creator/model'
 import * as DimensionMetadataQueries from '../queries/dimension-metadata'
@@ -13,14 +12,14 @@ import TermSet from '@rdfjs/term-set'
 interface CreateColumnMappingCommand {
   tableId: NamedNode
   resource: GraphPointer
-  store?: ResourceStore
+  store: ResourceStore
   dimensionMetadataQueries?: Pick<typeof DimensionMetadataQueries, 'getDimensionMetaDataCollection'>
 }
 
 export async function createColumnMapping({
   tableId,
   resource,
-  store = resourceStore(),
+  store,
   dimensionMetadataQueries: { getDimensionMetaDataCollection } = DimensionMetadataQueries,
 }: CreateColumnMappingCommand): Promise<GraphPointer> {
   const table = await store.getResource<Table>(tableId)
@@ -49,8 +48,6 @@ export async function createColumnMapping({
       store, columnMapping, csvMapping,
     })
   }
-
-  await store.save()
 
   return columnMapping.pointer
 }

--- a/apis/core/lib/domain/column-mapping/delete.ts
+++ b/apis/core/lib/domain/column-mapping/delete.ts
@@ -3,20 +3,19 @@ import $rdf from 'rdf-ext'
 import { cc } from '@cube-creator/core/namespace'
 import { ColumnMapping, CsvMapping, DimensionMetadataCollection, Table } from '@cube-creator/model'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import * as DimensionMetadataQueries from '../queries/dimension-metadata'
 import * as TableQueries from '../queries/table'
 
 interface DeleteColumnMappingCommand {
   resource: NamedNode
-  store?: ResourceStore
+  store: ResourceStore
   dimensionMetadataQueries?: Pick<typeof DimensionMetadataQueries, 'getDimensionMetaDataCollection'>
   tableQueries?: Pick<typeof TableQueries, 'getTableForColumnMapping'>
 }
 
 export async function deleteColumnMapping({
   resource,
-  store = resourceStore(),
+  store,
   dimensionMetadataQueries: { getDimensionMetaDataCollection } = DimensionMetadataQueries,
   tableQueries: { getTableForColumnMapping } = TableQueries,
 }: DeleteColumnMappingCommand): Promise<void> {
@@ -40,5 +39,4 @@ export async function deleteColumnMapping({
 
   // Delete Graph
   store.delete(resource)
-  await store.save()
 }

--- a/apis/core/lib/domain/column-mapping/update.ts
+++ b/apis/core/lib/domain/column-mapping/update.ts
@@ -1,7 +1,6 @@
 import { GraphPointer } from 'clownface'
 import { cc } from '@cube-creator/core/namespace'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import { NamedNode } from 'rdf-js'
 import {
   ColumnMapping,
@@ -21,14 +20,14 @@ import { createIdentifierMapping } from '@cube-creator/model/ColumnMapping'
 
 interface UpdateColumnMappingCommand {
   resource: GraphPointer
-  store?: ResourceStore
+  store: ResourceStore
   dimensionMetadataQueries?: Pick<typeof DimensionMetadataQueries, 'getDimensionMetaDataCollection'>
   tableQueries?: Pick<typeof TableQueries, 'getTableForColumnMapping'>
 }
 
 export async function updateLiteralColumnMapping({
   resource,
-  store = resourceStore(),
+  store,
   dimensionMetadataQueries = DimensionMetadataQueries,
   tableQueries = TableQueries,
 }: UpdateColumnMappingCommand): Promise<GraphPointer> {
@@ -55,13 +54,12 @@ export async function updateLiteralColumnMapping({
   columnMapping.language = resource.out(cc.language).value
   columnMapping.defaultValue = resource.out(cc.defaultValue).term
 
-  await store.save()
   return columnMapping.pointer
 }
 
 export async function updateReferenceColumnMapping({
   resource,
-  store = resourceStore(),
+  store,
   dimensionMetadataQueries = DimensionMetadataQueries,
   tableQueries = TableQueries,
 }: UpdateColumnMappingCommand): Promise<GraphPointer> {
@@ -98,13 +96,12 @@ export async function updateReferenceColumnMapping({
       )
     }))
 
-  await store.save()
   return columnMapping.pointer
 }
 
 async function updateColumnMapping<T extends ColumnMapping>({
   resource,
-  store = resourceStore(),
+  store,
   dimensionMetadataQueries: { getDimensionMetaDataCollection } = DimensionMetadataQueries,
   tableQueries: { getTableForColumnMapping } = TableQueries,
 }: UpdateColumnMappingCommand): Promise<{ columnMapping: T; table: Table }> {

--- a/apis/core/lib/domain/csv-mapping/create.ts
+++ b/apis/core/lib/domain/csv-mapping/create.ts
@@ -2,18 +2,17 @@ import { GraphPointer } from 'clownface'
 // import { rdf, hydra, dbo } from '@tpluscode/rdf-ns-builders'
 // import { cc } from '@cube-creator/core/namespace'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 // import * as id from '../identifiers'
 // import { saveFile } from '../../storage/s3'
 
 interface CreateCSVMappingCommand {
   resource: GraphPointer
-  store?: ResourceStore
+  store: ResourceStore
 }
 
 export async function createCSVMapping({
   resource,
-  store = resourceStore(),
+  store,
 }: CreateCSVMappingCommand): Promise<GraphPointer> {
   throw new Error('Not implemented')
   /*

--- a/apis/core/lib/domain/csv-mapping/delete.ts
+++ b/apis/core/lib/domain/csv-mapping/delete.ts
@@ -1,8 +1,8 @@
 import { NamedNode } from 'rdf-js'
 import { ResourceStore } from '../../ResourceStore'
-import { deleteSourceWithoutSave } from '../csv-source/delete'
+import { deleteSource } from '../csv-source/delete'
 import { cc } from '@cube-creator/core/namespace'
-import { deleteTableWithoutSave } from '../table/delete'
+import { deleteTable } from '../table/delete'
 import { getTablesForMapping } from '../queries/table'
 
 export async function deleteMapping(csvMapping: NamedNode, store: ResourceStore): Promise<void> {
@@ -11,7 +11,7 @@ export async function deleteMapping(csvMapping: NamedNode, store: ResourceStore)
 
   const sources = csvMappingResource.out(cc.csvSource).terms
   for await (const source of sources) {
-    await deleteSourceWithoutSave({ resource: source, store })
+    await deleteSource({ resource: source, store })
   }
 
   const sourceCollection = csvMappingResource.out(cc.csvSourceCollection).term
@@ -21,7 +21,10 @@ export async function deleteMapping(csvMapping: NamedNode, store: ResourceStore)
 
   const tables = getTablesForMapping(csvMapping)
   for await (const table of tables) {
-    await deleteTableWithoutSave(table, store)
+    await deleteTable({
+      resource: table,
+      store,
+    })
   }
 
   const tableCollection = csvMappingResource.out(cc.tables).term

--- a/apis/core/lib/domain/csv-source/delete.ts
+++ b/apis/core/lib/domain/csv-source/delete.ts
@@ -1,6 +1,5 @@
 import { NamedNode, Term } from 'rdf-js'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import * as s3 from '../../storage/s3'
 import { schema } from '@tpluscode/rdf-ns-builders'
 import { cc } from '@cube-creator/core/namespace'
@@ -10,26 +9,14 @@ import { Table } from '@cube-creator/model'
 
 interface DeleteSourceCommand {
   resource: NamedNode | Term
-  store?: ResourceStore
+  store: ResourceStore
   fileStorage?: s3.FileStorage
   tableQueries?: Pick<typeof TableQueries, 'getLinkedTablesForSource'>
 }
 
 export async function deleteSource({
   resource,
-  store = resourceStore(),
-  fileStorage = s3,
-  tableQueries: { getLinkedTablesForSource } = TableQueries,
-}: DeleteSourceCommand): Promise<void> {
-  await deleteSourceWithoutSave({ resource, store, fileStorage, tableQueries: { getLinkedTablesForSource } })
-
-  // Save changes
-  await store.save()
-}
-
-export async function deleteSourceWithoutSave({
-  resource,
-  store = resourceStore(),
+  store,
   fileStorage = s3,
   tableQueries: { getLinkedTablesForSource } = TableQueries,
 }: DeleteSourceCommand): Promise<void> {

--- a/apis/core/lib/domain/csv-source/get-head.ts
+++ b/apis/core/lib/domain/csv-source/get-head.ts
@@ -3,16 +3,15 @@ import { NamedNode } from 'rdf-js'
 import { ResourceStore } from '../../ResourceStore'
 import { loadFile } from '../../storage/s3'
 import { loadFileHeadString } from '../csv/file-head'
-import { resourceStore } from '../resources'
 
 interface GetCSVHeadCommand {
   resource: NamedNode
-  store?: ResourceStore
+  store: ResourceStore
 }
 
 export async function getCSVHead({
   resource,
-  store = resourceStore(),
+  store,
 }: GetCSVHeadCommand): Promise<string> {
   const csvSource = await store.get(resource)
   const path = csvSource.out(schema.associatedMedia).out(schema.identifier).term

--- a/apis/core/lib/domain/csv-source/update.ts
+++ b/apis/core/lib/domain/csv-source/update.ts
@@ -4,7 +4,6 @@ import { CsvSource } from '@cube-creator/model'
 import RdfResource from '@tpluscode/rdfine'
 import { schema } from '@tpluscode/rdf-ns-builders'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import { error } from '../../log'
 import { Readable } from 'stream'
 import * as s3 from '../../storage/s3'
@@ -14,13 +13,13 @@ import { sampleValues } from '../csv/sample-values'
 
 interface UpdateCsvSourceCommand {
   resource: GraphPointer<NamedNode>
-  store?: ResourceStore
+  store: ResourceStore
   fileStorage?: s3.FileStorage
 }
 
 export async function update({
   resource,
-  store = resourceStore(),
+  store,
   fileStorage = s3,
 }: UpdateCsvSourceCommand): Promise<GraphPointer> {
   const changed = RdfResource.factory.createEntity<CsvSource>(resource)
@@ -52,6 +51,5 @@ export async function update({
     }
   }
 
-  await store.save()
   return csvSource.pointer
 }

--- a/apis/core/lib/domain/csv-source/upload.ts
+++ b/apis/core/lib/domain/csv-source/upload.ts
@@ -11,7 +11,6 @@ import { loadFileHeadString } from '../csv/file-head'
 import { sniffParse } from '../csv'
 import * as CsvSourceQueries from '../queries/csv-source'
 import { Conflict } from 'http-errors'
-import { resourceStore } from '../resources'
 import { sampleValues } from '../csv/sample-values'
 import { CsvMapping } from '@cube-creator/model'
 
@@ -19,7 +18,7 @@ interface UploadCSVCommand {
   file: Readable | Buffer
   fileName: string
   resource: NamedNode
-  store?: ResourceStore
+  store: ResourceStore
   fileStorage?: s3.FileStorage
   csvSourceQueries?: Pick<typeof CsvSourceQueries, 'sourceWithFilenameExists'>
 }
@@ -28,7 +27,7 @@ export async function uploadFile({
   file,
   fileName,
   resource,
-  store = resourceStore(),
+  store,
   fileStorage = s3,
   csvSourceQueries: { sourceWithFilenameExists } = CsvSourceQueries,
 }: UploadCSVCommand): Promise<GraphPointer> {
@@ -66,8 +65,6 @@ export async function uploadFile({
     error(err)
     csvSource.pointer.addOut(schema.error, err.message)
   }
-
-  await store.save()
 
   return csvSource.pointer
 }

--- a/apis/core/lib/domain/cube-projects/create.ts
+++ b/apis/core/lib/domain/cube-projects/create.ts
@@ -7,20 +7,19 @@ import * as Dataset from '@cube-creator/model/Dataset'
 import * as DimensionMetadata from '@cube-creator/model/DimensionMetadata'
 import { ResourceStore } from '../../ResourceStore'
 import * as id from '../identifiers'
-import { resourceStore } from '../resources'
 import { DomainError } from '../../errors'
 
 interface CreateProjectCommand {
   projectsCollection: GraphPointer<NamedNode>
   resource: GraphPointer
-  store?: ResourceStore
+  store: ResourceStore
   user: NamedNode
 }
 
 export async function createProject({
   projectsCollection,
   resource,
-  store = resourceStore(),
+  store,
   user,
 }: CreateProjectCommand): Promise<Project.Project> {
   const label = resource.out(rdfs.label).value
@@ -53,6 +52,5 @@ export async function createProject({
     dataset.addCube(csvMapping.namespace, user)
   }
 
-  await store.save()
   return project
 }

--- a/apis/core/lib/domain/cube-projects/delete.ts
+++ b/apis/core/lib/domain/cube-projects/delete.ts
@@ -1,17 +1,16 @@
 import { NamedNode } from 'rdf-js'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import { cc } from '@cube-creator/core/namespace'
 import { deleteMapping } from '../csv-mapping/delete'
 
 interface DeleteProjectCommand {
   resource: NamedNode
-  store?: ResourceStore
+  store: ResourceStore
 }
 
 export async function deleteProject({
   resource,
-  store = resourceStore(),
+  store,
 }: DeleteProjectCommand): Promise<void> {
   const project = await store.get(resource, { allowMissing: true })
   if (!project) return
@@ -25,5 +24,4 @@ export async function deleteProject({
 
   // delete project graph
   store.delete(project.term)
-  await store.save()
 }

--- a/apis/core/lib/domain/cube-projects/update.ts
+++ b/apis/core/lib/domain/cube-projects/update.ts
@@ -2,20 +2,19 @@ import { GraphPointer } from 'clownface'
 import { NamedNode } from 'rdf-js'
 import { cc } from '@cube-creator/core/namespace'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import { rdfs } from '@tpluscode/rdf-ns-builders'
 import { CsvMapping, Project, Dataset, DimensionMetadataCollection } from '@cube-creator/model'
 
 interface UpdateProjectCommand {
   resource: GraphPointer
   project: GraphPointer<NamedNode>
-  store?: ResourceStore
+  store: ResourceStore
 }
 
 export async function updateProject({
   resource,
   project,
-  store = resourceStore(),
+  store,
 }: UpdateProjectCommand): Promise<Project> {
   const storedProject = await store.getResource<Project>(resource.term)
 
@@ -34,8 +33,6 @@ export async function updateProject({
   }
 
   storedProject.updatePublishGraph(resource.out(cc.publishGraph).term)
-
-  await store.save()
 
   return storedProject
 }

--- a/apis/core/lib/domain/dataset/update.ts
+++ b/apis/core/lib/domain/dataset/update.ts
@@ -28,7 +28,9 @@ export async function update({
   })
   datasetResource.deleteOut()
 
-  datasetResource.dataset.addAll([...resource.dataset])
+  for (const quad of resource.dataset) {
+    datasetResource.dataset.add(quad)
+  }
 
   // Make sure the type is correct
   datasetResource.addOut(rdf.type, hydra.Resource)

--- a/apis/core/lib/domain/dataset/update.ts
+++ b/apis/core/lib/domain/dataset/update.ts
@@ -3,19 +3,18 @@ import { dcat, hydra, rdf, schema, _void } from '@tpluscode/rdf-ns-builders'
 import { GraphPointer } from 'clownface'
 import { NamedNode } from 'rdf-js'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 
 interface AddMetaDataCommand {
   dataset: GraphPointer<NamedNode>
   resource: GraphPointer
-  store?: ResourceStore
+  store: ResourceStore
 
 }
 
 export async function update({
   dataset,
   resource,
-  store = resourceStore(),
+  store,
 }: AddMetaDataCommand): Promise<GraphPointer> {
   const datasetResource = await store.get(dataset.term)
 
@@ -39,8 +38,6 @@ export async function update({
 
   hasPart.forEach(child => datasetResource.addOut(schema.hasPart, child))
   dimensionMetadata.forEach(child => datasetResource.addOut(cc.dimensionMetadata, child))
-
-  await store.save()
 
   return datasetResource
 }

--- a/apis/core/lib/domain/dimension/update.ts
+++ b/apis/core/lib/domain/dimension/update.ts
@@ -2,23 +2,21 @@ import clownface, { GraphPointer } from 'clownface'
 import { NamedNode } from 'rdf-js'
 import { DimensionMetadataCollection } from '@cube-creator/model'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 
 interface UpdateDimensionCommand {
   metadataCollection: NamedNode
   dimensionMetadata: GraphPointer
-  store?: ResourceStore
+  store: ResourceStore
 }
 
 export async function update({
   metadataCollection,
-  store = resourceStore(),
+  store,
   dimensionMetadata,
 }: UpdateDimensionCommand): Promise<GraphPointer> {
   const metadata = await store.getResource<DimensionMetadataCollection>(metadataCollection)
 
   metadata.updateDimension(dimensionMetadata)
-  await store.save()
 
   const dataset = metadata.pointer.dataset.match(dimensionMetadata.term)
   return clownface({ dataset }).node(dimensionMetadata.term)

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -4,23 +4,22 @@ import { NamedNode } from 'rdf-js'
 import * as Job from '@cube-creator/model/Job'
 import { CsvMapping, Project } from '@cube-creator/model'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import * as id from '../identifiers'
 import { DomainError } from '../../errors'
 
 interface StartTransformationCommand {
   resource: NamedNode
-  store?: ResourceStore
+  store: ResourceStore
 }
 
 interface StartPublicationCommand {
   resource: NamedNode
-  store?: ResourceStore
+  store: ResourceStore
 }
 
 export async function createTransformJob({
   resource,
-  store = resourceStore(),
+  store,
 }: StartTransformationCommand): Promise<GraphPointer<NamedNode>> {
   const jobCollection = await store.get(resource)
   const project = await store.getResource<Project>(jobCollection.out(cc.project).term)
@@ -33,14 +32,12 @@ export async function createTransformJob({
     tableCollection: csvMapping.tableCollection,
   })
 
-  await store.save()
-
   return jobPointer
 }
 
 export async function createPublishJob({
   resource,
-  store = resourceStore(),
+  store,
 }: StartPublicationCommand): Promise<GraphPointer<NamedNode>> {
   const jobCollection = (await store.get(resource))!
   const projectPointer = jobCollection.out(cc.project).term
@@ -62,8 +59,6 @@ export async function createPublishJob({
     revision: project.nextRevision,
     publishGraph: project.publishGraph,
   })
-
-  await store.save()
 
   return jobPointer
 }

--- a/apis/core/lib/domain/job/update.ts
+++ b/apis/core/lib/domain/job/update.ts
@@ -4,15 +4,14 @@ import { Job, JobMixin, Project } from '@cube-creator/model'
 import { isPublishJob } from '@cube-creator/model/Job'
 import RdfResource from '@tpluscode/rdfine'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import { schema } from '@tpluscode/rdf-ns-builders'
 
 interface JobUpdateParams {
   resource: GraphPointer<NamedNode>
-  store?: ResourceStore
+  store: ResourceStore
 }
 
-export async function update({ resource, store = resourceStore() }: JobUpdateParams): Promise<GraphPointer> {
+export async function update({ resource, store }: JobUpdateParams): Promise<GraphPointer> {
   const changes = RdfResource.factory.createEntity<Job>(resource, [JobMixin])
   const job = await store.getResource<Job>(resource.term)
 
@@ -39,6 +38,5 @@ export async function update({ resource, store = resourceStore() }: JobUpdatePar
     job.error = undefined
   }
 
-  await store.save()
   return job.pointer
 }

--- a/apis/core/lib/domain/resources.ts
+++ b/apis/core/lib/domain/resources.ts
@@ -1,6 +1,0 @@
-import ResourceStoreImpl, { ResourceStore } from '../ResourceStore'
-import { streamClient } from '../query-client'
-
-export function resourceStore(): ResourceStore {
-  return new ResourceStoreImpl(streamClient)
-}

--- a/apis/core/lib/domain/table/create.ts
+++ b/apis/core/lib/domain/table/create.ts
@@ -2,7 +2,6 @@ import { GraphPointer } from 'clownface'
 import { csvw, schema, xsd } from '@tpluscode/rdf-ns-builders'
 import { cc } from '@cube-creator/core/namespace'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import { NamedNode } from 'rdf-js'
 import $rdf from 'rdf-ext'
 import { CsvColumn, CsvMapping, CsvSource, DimensionMetadataCollection } from '@cube-creator/model'
@@ -13,14 +12,14 @@ const trueTerm = $rdf.literal('true', xsd.boolean)
 interface CreateTableCommand {
   tableCollection: GraphPointer<NamedNode>
   resource: GraphPointer
-  store?: ResourceStore
+  store: ResourceStore
   dimensionMetadataQueries?: Pick<typeof DimensionMetadataQueries, 'getDimensionMetaDataCollection'>
 }
 
 export async function createTable({
   tableCollection,
   resource,
-  store = resourceStore(),
+  store,
   dimensionMetadataQueries: { getDimensionMetaDataCollection } = DimensionMetadataQueries,
 }: CreateTableCommand): Promise<GraphPointer> {
   const label = resource.out(schema.name)
@@ -78,7 +77,6 @@ export async function createTable({
       return columnMapping
     })
 
-  await store.save()
   return table.pointer
 }
 

--- a/apis/core/lib/domain/table/csvw.ts
+++ b/apis/core/lib/domain/table/csvw.ts
@@ -1,19 +1,18 @@
 import * as Table from '@cube-creator/model/Table'
 import { NamedNode } from 'rdf-js'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import { NotFoundError } from '../../errors'
 import { buildCsvw } from '../../csvw-builder'
 import '../../domain'
 
 interface Command {
   tableResource: NamedNode
-  resources?: ResourceStore
+  resources: ResourceStore
 }
 
 export async function createCsvw({
   tableResource,
-  resources = resourceStore(),
+  resources,
 }: Command) {
   const tablePointer = await resources.get(tableResource)
   if (!tablePointer) {

--- a/apis/core/lib/domain/table/delete.ts
+++ b/apis/core/lib/domain/table/delete.ts
@@ -1,24 +1,16 @@
 import { NamedNode, Term } from 'rdf-js'
 import { ResourceStore } from '../../ResourceStore'
-import { resourceStore } from '../resources'
 import { cc } from '@cube-creator/core/namespace'
 
 interface DeleteTableCommand {
   resource: NamedNode
-  store?: ResourceStore
+  store: ResourceStore
 }
 
 export async function deleteTable({
-  resource,
-  store = resourceStore(),
+  resource: tableTerm,
+  store,
 }: DeleteTableCommand): Promise<void> {
-  await deleteTableWithoutSave(resource, store)
-
-  // Save changes
-  await store.save()
-}
-
-export async function deleteTableWithoutSave(tableTerm: Term, store: ResourceStore): Promise<void> {
   if (tableTerm.termType !== 'NamedNode') return
 
   const table = await store.get(tableTerm, { allowMissing: true })

--- a/apis/core/lib/domain/table/update.ts
+++ b/apis/core/lib/domain/table/update.ts
@@ -5,19 +5,18 @@ import { GraphPointer } from 'clownface'
 import { ResourceStore } from '../../ResourceStore'
 import * as DimensionMetadataQueries from '../queries/dimension-metadata'
 import { cc } from '@cube-creator/core/namespace'
-import { resourceStore } from '../resources'
 
 const trueTerm = $rdf.literal('true', xsd.boolean)
 
 interface UpdateTableCommand {
   resource: GraphPointer
-  store?: ResourceStore
+  store: ResourceStore
   dimensionMetadataQueries?: Pick<typeof DimensionMetadataQueries, 'getDimensionMetaDataCollection'>
 }
 
 export async function updateTable({
   resource,
-  store = resourceStore(),
+  store,
   dimensionMetadataQueries: { getDimensionMetaDataCollection } = DimensionMetadataQueries,
 } : UpdateTableCommand): Promise<GraphPointer> {
   const table = await store.getResource<Table>(resource.term)
@@ -64,6 +63,5 @@ export async function updateTable({
     isObservationTable ? table.types.add(cc.ObservationTable) : table.types.delete(cc.ObservationTable)
   }
 
-  await store.save()
   return table.pointer
 }

--- a/apis/core/lib/handlers/column-mapping.ts
+++ b/apis/core/lib/handlers/column-mapping.ts
@@ -10,7 +10,9 @@ export const postLiteral = protectedResource(shaclValidate, asyncMiddleware(asyn
   const columnMapping = await createColumnMapping({
     tableId: req.hydra.resource.term,
     resource: await req.resource(),
+    store: req.resourceStore(),
   })
+  await req.resourceStore().save()
 
   res.status(201)
   res.header('Location', columnMapping.value)
@@ -21,7 +23,9 @@ export const postReference = protectedResource(shaclValidate, asyncMiddleware(as
   const columnMapping = await createColumnMapping({
     tableId: req.hydra.resource.term,
     resource: await req.resource(),
+    store: req.resourceStore(),
   })
+  await req.resourceStore().save()
 
   res.status(201)
   res.header('Location', columnMapping.value)
@@ -31,7 +35,9 @@ export const postReference = protectedResource(shaclValidate, asyncMiddleware(as
 export const putLiteral = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const columnMapping = await updateLiteralColumnMapping({
     resource: await req.resource(),
+    store: req.resourceStore(),
   })
+  await req.resourceStore().save()
 
   await res.dataset(columnMapping.dataset)
 }))
@@ -39,7 +45,9 @@ export const putLiteral = protectedResource(shaclValidate, asyncMiddleware(async
 export const putReference = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const columnMapping = await updateReferenceColumnMapping({
     resource: await req.resource(),
+    store: req.resourceStore(),
   })
+  await req.resourceStore().save()
 
   await res.dataset(columnMapping.dataset)
 }))
@@ -47,7 +55,11 @@ export const putReference = protectedResource(shaclValidate, asyncMiddleware(asy
 export const remove = labyrinth.protectedResource(
   asyncMiddleware(async (req, res) => {
     const columnMapping = req.hydra.resource
-    await deleteColumnMapping({ resource: columnMapping.term })
+    await deleteColumnMapping({
+      resource: columnMapping.term,
+      store: req.resourceStore(),
+    })
+    await req.resourceStore().save()
     res.sendStatus(204)
   }),
 )

--- a/apis/core/lib/handlers/csv-mapping.ts
+++ b/apis/core/lib/handlers/csv-mapping.ts
@@ -6,7 +6,9 @@ import { createCSVMapping } from '../domain/csv-mapping/create'
 export const post = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const project = await createCSVMapping({
     resource: await req.resource(),
+    store: req.resourceStore(),
   })
+  await req.resourceStore().save()
 
   res.status(201)
   res.header('Location', project.value)

--- a/apis/core/lib/handlers/csv-source.ts
+++ b/apis/core/lib/handlers/csv-source.ts
@@ -31,7 +31,10 @@ export const post = labyrinth.protectedResource(
       file: req,
       fileName: fileName,
       resource: csvMapping,
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
+
     res.status(201)
     res.header('Location', fileLocation.value)
     await res.dataset(fileLocation.dataset)
@@ -43,7 +46,9 @@ export const put = labyrinth.protectedResource(
   asyncMiddleware(async (req, res) => {
     const { dataset } = await update({
       resource: await req.resource(),
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     return res.dataset(dataset)
   }),
@@ -58,6 +63,7 @@ const getCSVSource = asyncMiddleware(async (req, res, next) => {
 
   const head = await getCSVHead({
     resource: csvSource,
+    store: req.resourceStore(),
   })
 
   res.type('text/csv')
@@ -71,7 +77,10 @@ export const remove = labyrinth.protectedResource(
     const csvSource = req.hydra.resource.term
     await deleteSource({
       resource: csvSource,
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
+
     res.sendStatus(204)
   }),
 )

--- a/apis/core/lib/handlers/cube-projects.ts
+++ b/apis/core/lib/handlers/cube-projects.ts
@@ -19,7 +19,9 @@ export const post = protectedResource(
       projectsCollection: clownface(req.hydra.resource),
       resource: await req.resource(),
       user,
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     res.status(201)
     res.header('Location', project.value)
@@ -34,7 +36,9 @@ export const put = protectedResource(
     await updateProject({
       resource: await req.resource(),
       project: project,
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     res.status(201)
     res.header('Location', project.value)
@@ -45,7 +49,12 @@ export const put = protectedResource(
 export const remove = protectedResource(
   asyncMiddleware(async (req, res) => {
     const project = req.hydra.resource.term
-    await deleteProject({ resource: project })
+    await deleteProject({
+      resource: project,
+      store: req.resourceStore(),
+    })
+    await req.resourceStore().save()
+
     res.sendStatus(204)
   }),
 )

--- a/apis/core/lib/handlers/dataset.ts
+++ b/apis/core/lib/handlers/dataset.ts
@@ -17,7 +17,9 @@ export const put = protectedResource(
     const dataset = await update({
       dataset: clownface(req.hydra.resource),
       resource: await req.resource(),
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     res.status(200)
     await res.dataset(dataset.dataset)

--- a/apis/core/lib/handlers/dimension.ts
+++ b/apis/core/lib/handlers/dimension.ts
@@ -13,7 +13,9 @@ export const put = protectedResource(
     const updated = await update({
       metadataCollection: req.hydra.resource.term,
       dimensionMetadata: await req.resource(),
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     return res.dataset(updated.dataset)
   }),

--- a/apis/core/lib/handlers/jobs.ts
+++ b/apis/core/lib/handlers/jobs.ts
@@ -19,7 +19,9 @@ export const transform = protectedResource(
 
     const job = await createTransformJob({
       resource: req.hydra.resource.term,
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     await trigger(job, await req.resource())
 
@@ -38,7 +40,9 @@ export const publish = protectedResource(
 
     const job = await createPublishJob({
       resource: req.hydra.resource.term,
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     await trigger(job, await req.resource())
 
@@ -53,7 +57,9 @@ export const patch = protectedResource(
   asyncMiddleware(async (req, res) => {
     const { dataset } = await update({
       resource: await req.resource(),
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     return res.dataset(dataset)
   }),

--- a/apis/core/lib/handlers/table/create.ts
+++ b/apis/core/lib/handlers/table/create.ts
@@ -10,7 +10,9 @@ export const post = protectedResource(
     const table = await createTable({
       tableCollection: clownface(req.hydra.resource),
       resource: await req.resource(),
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     res.status(201)
     res.header('Location', table.value)

--- a/apis/core/lib/handlers/table/csvw.ts
+++ b/apis/core/lib/handlers/table/csvw.ts
@@ -5,6 +5,7 @@ import { createCsvw } from '../../domain/table/csvw'
 export const get = protectedResource(asyncMiddleware(async (req, res) => {
   const csvwTable = await createCsvw({
     tableResource: req.hydra.resource.term,
+    resources: req.resourceStore(),
   })
 
   return res.dataset(csvwTable.pointer.dataset)

--- a/apis/core/lib/handlers/table/delete.ts
+++ b/apis/core/lib/handlers/table/delete.ts
@@ -5,7 +5,11 @@ import { deleteTable } from '../../domain/table/delete'
 export const remove = protectedResource(
   asyncMiddleware(async (req, res) => {
     const project = req.hydra.resource.term
-    await deleteTable({ resource: project })
+    await deleteTable({
+      resource: project,
+      store: req.resourceStore(),
+    })
+    await req.resourceStore().save()
     res.sendStatus(204)
   }),
 )

--- a/apis/core/lib/handlers/table/update.ts
+++ b/apis/core/lib/handlers/table/update.ts
@@ -8,7 +8,9 @@ export const put = protectedResource(
   asyncMiddleware(async (req, res) => {
     const table = await updateTable({
       resource: await req.resource(),
+      store: req.resourceStore(),
     })
+    await req.resourceStore().save()
 
     return res.dataset(table.dataset)
   }),

--- a/apis/core/lib/middleware/resource.ts
+++ b/apis/core/lib/middleware/resource.ts
@@ -3,10 +3,14 @@ import clownface, { GraphPointer } from 'clownface'
 import { NamedNode } from 'rdf-js'
 import $rdf from 'rdf-ext'
 import { hydra, rdf } from '@tpluscode/rdf-ns-builders'
+import once from 'once'
+import ResourceStoreImpl from '../ResourceStore'
+import { streamClient } from '../query-client'
 
 declare module 'express-serve-static-core' {
   export interface Request {
     resource(): Promise<GraphPointer<NamedNode>>
+    resourceStore(): ResourceStoreImpl
   }
 }
 
@@ -35,6 +39,10 @@ export function resource(req: express.Request, res: unknown, next: express.NextF
 
     return pointer
   }
+
+  req.resourceStore = once(() => {
+    return new ResourceStoreImpl(streamClient)
+  })
 
   next()
 }

--- a/apis/core/lib/middleware/shacl.ts
+++ b/apis/core/lib/middleware/shacl.ts
@@ -35,7 +35,7 @@ export const shaclMiddleware = (options: ShaclMiddlewareOptions) => asyncMiddlew
   await Promise.all(req.hydra.operation.out(hydra.expects).map(async (expects) => {
     if (expects.term.termType !== 'NamedNode') return
 
-    const pointer = await resources.get(expects.term)
+    const pointer = await resources.get(expects.term, { allowMissing: true })
     if (pointer?.has(rdf.type, [sh.NodeShape]).values.length) {
       await shapes.addAll([...pointer.dataset])
 

--- a/apis/core/lib/middleware/shacl.ts
+++ b/apis/core/lib/middleware/shacl.ts
@@ -5,12 +5,13 @@ import { Term, Quad, NamedNode } from 'rdf-js'
 import { hydra, rdf, sh } from '@tpluscode/rdf-ns-builders'
 import SHACLValidator from 'rdf-validate-shacl'
 import clownface, { GraphPointer } from 'clownface'
-import { resourceStore } from '../domain/resources'
+import ResourceStoreImpl, { ResourceStore } from '../ResourceStore'
+import { streamClient } from '../query-client'
 import { ProblemDocument } from 'http-problem-details'
 import { loadResourcesTypes } from '../domain/queries/resources-types'
 
 interface ShaclMiddlewareOptions {
-  createResourceStore: typeof resourceStore
+  createResourceStore(): ResourceStore
   loadResourcesTypes(ids: Term[]): Promise<Quad[]>
   getTargetNode?(req: Request, res: Response): NamedNode
 }
@@ -82,12 +83,12 @@ export const shaclMiddleware = (options: ShaclMiddlewareOptions) => asyncMiddlew
 })
 
 export const shaclValidate = shaclMiddleware({
-  createResourceStore: resourceStore,
+  createResourceStore: () => new ResourceStoreImpl(streamClient),
   loadResourcesTypes,
 })
 
 export const shaclValidateTargetNode = ({ getTargetNode }: Pick<Required<ShaclMiddlewareOptions>, 'getTargetNode'>) => shaclMiddleware({
-  createResourceStore: resourceStore,
+  createResourceStore: () => new ResourceStoreImpl(streamClient),
   loadResourcesTypes,
   getTargetNode,
 })

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -48,6 +48,7 @@
     "middleware-async": "^1.2.7",
     "nanoid": "^3.1.16",
     "node-fetch": "^2.6.1",
+    "once": "^1.4.0",
     "rdf-cube-view-query": "zazuko/rdf-cube-view-query",
     "rdf-ext": "^1.3.0",
     "rdf-validate-shacl": "^0.2.3",

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -77,6 +77,7 @@
     "@types/merge-stream": "^1.1.2",
     "@types/mocha": "^8.0.3",
     "@types/node-fetch": "^2.5.7",
+    "@types/once": "^1.4.0",
     "@types/rdf-ext": "^1.3.8",
     "@types/rdf-js": "^4.0.0",
     "@types/rdf-transform-triple-to-quad": "^1.0.0",

--- a/apis/core/test/ChangelogDataset.test.ts
+++ b/apis/core/test/ChangelogDataset.test.ts
@@ -1,0 +1,94 @@
+import { foaf, rdf, schema } from '@tpluscode/rdf-ns-builders'
+import { expect } from 'chai'
+import { describe, it } from 'mocha'
+import * as sinon from 'sinon'
+import $rdf from 'rdf-ext'
+import { ex } from './support/namespace'
+import { ChangelogDataset } from '../lib/ChangelogDataset'
+
+describe('ChangelogDataset', () => {
+  it('does not have changes when a triple is added and removed', () => {
+    // given
+    const dataset = new ChangelogDataset($rdf.dataset())
+
+    // when
+    dataset.add($rdf.quad(ex.Foo, rdf.type, schema.Person))
+    dataset.delete($rdf.quad(ex.Foo, rdf.type, schema.Person))
+
+    // then
+    expect(dataset.changes.added).to.have.property('size', 0)
+    expect(dataset.changes.deleted).to.have.property('size', 0)
+  })
+
+  it('does not have changes when a triple is removed and added again', () => {
+    // given
+    const dataset = new ChangelogDataset($rdf.dataset([
+      $rdf.quad(ex.Foo, rdf.type, schema.Person),
+    ]))
+
+    // when
+    dataset.delete($rdf.quad(ex.Foo, rdf.type, schema.Person))
+    dataset.add($rdf.quad(ex.Foo, rdf.type, schema.Person))
+
+    // then
+    expect(dataset.changes.added).to.have.property('size', 0)
+    expect(dataset.changes.deleted).to.have.property('size', 0)
+  })
+
+  it('does not register changes when a removed triples does not exist', () => {
+    // given
+    const dataset = new ChangelogDataset($rdf.dataset())
+
+    // when
+    dataset.delete($rdf.quad(ex.Foo, rdf.type, schema.Person))
+
+    // then
+    expect(dataset.changes.deleted).to.have.property('size', 0)
+  })
+
+  describe('.has', () => {
+    it('delegates to wrapped dataset', () => {
+      // given
+      const has = sinon.spy()
+      const quad = $rdf.quad(ex.Foo, rdf.type, schema.Person)
+      const dataset = new ChangelogDataset({ has } as any)
+
+      // when
+      dataset.has(quad)
+
+      // then
+      expect(has).to.have.been.calledWith(quad)
+    })
+  })
+
+  describe('.flush', () => {
+    it('resets changes', () => {
+    // given
+      const dataset = new ChangelogDataset($rdf.dataset())
+      dataset.add($rdf.quad(ex.Foo, rdf.type, schema.Person))
+
+      // when
+      dataset.flush()
+
+      // then
+      expect(dataset.changes.added).to.have.property('size', 0)
+      expect(dataset.changes.deleted).to.have.property('size', 0)
+    })
+
+    it('returns the changes', () => {
+    // given
+      const dataset = new ChangelogDataset($rdf.dataset([
+        $rdf.quad(ex.Foo, rdf.type, foaf.Person),
+      ]))
+      dataset.delete($rdf.quad(ex.Foo, rdf.type, foaf.Person))
+      dataset.add($rdf.quad(ex.Foo, rdf.type, schema.Person))
+
+      // when
+      const changes = dataset.flush()
+
+      // then
+      expect(changes.added).to.have.property('size', 1)
+      expect(changes.deleted).to.have.property('size', 1)
+    })
+  })
+})

--- a/apis/core/test/ResourceStore.test.ts
+++ b/apis/core/test/ResourceStore.test.ts
@@ -66,6 +66,30 @@ describe('ResourceStore', () => {
       expect(actual).to.eq(expected)
       expect(client.query.construct).to.not.have.been.called
     })
+
+    it('returns "undefined" when it is allowed resource comes back empty', async () => {
+      // given
+      const store = new ResourceStore(client)
+      query.construct.resolves($rdf.dataset().toStream())
+
+      // when
+      const resource = await store.get('foo', { allowMissing: true })
+
+      // then
+      expect(resource).to.be.undefined
+    })
+
+    it('throws if resource comes back empty', async () => {
+      // given
+      const store = new ResourceStore(client)
+      query.construct.resolves($rdf.dataset().toStream())
+
+      // when
+      const promise = store.get('foo')
+
+      // then
+      await expect(promise).to.be.rejected
+    })
   })
 
   describe('create', () => {

--- a/apis/core/test/__snapshots__/ResourceStore.test.ts.snap
+++ b/apis/core/test/__snapshots__/ResourceStore.test.ts.snap
@@ -1,4 +1,8 @@
-exports["ResourceStore save stores resources in individual named graphs"] = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX hydra: <http://www.w3.org/ns/hydra/core#>\n\nDROP SILENT GRAPH <http://example.com/Foo>;\nDROP SILENT GRAPH <http://example.com/Bar>;\n\nINSERT DATA {\n  \n  \nGRAPH <http://example.com/Foo> {\n        \n<http://example.com/Foo> rdf:type hydra:Resource .\n<http://example.com/Foo> <http://example.com/foo> \"foo\" .\n      }\n  \nGRAPH <http://example.com/Bar> {\n        \n<http://example.com/Bar> rdf:type hydra:Resource .\n<http://example.com/Bar> <http://example.com/bar> \"bar\" .\n      }\n}";
+exports["ResourceStore save stores resources in individual named graphs"] = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX hydra: <http://www.w3.org/ns/hydra/core#>\n\nDROP SILENT GRAPH <http://example.com/Foo>;\nDROP SILENT GRAPH <http://example.com/Bar>;\n\nINSERT DATA {\n  \n  \nGRAPH <http://example.com/Foo> {\n          \n<http://example.com/Foo> rdf:type hydra:Resource .\n<http://example.com/Foo> <http://example.com/foo> \"foo\" .\n        }\n  \nGRAPH <http://example.com/Bar> {\n          \n<http://example.com/Bar> rdf:type hydra:Resource .\n<http://example.com/Bar> <http://example.com/bar> \"bar\" .\n        }\n}";
+
+exports["ResourceStore save only saves changed resources"] = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n\nDROP SILENT GRAPH <baz>;\n\nINSERT DATA {\n  \n  \nGRAPH <baz> {\n          \n<baz> rdfs:label \"Baz changed\" .\n        }\n}";
 
 exports["ResourceStore delete delete is adding DROP SILENT GRAPH statement and removes from inserts"] = "DROP SILENT GRAPH <http://example.com/Foo>;\n\nINSERT DATA {\n  \n}";
+
+exports["ResourceStore save only deletes graph if all resource triples were removed"] = "DROP SILENT GRAPH <baz>;\n\nINSERT DATA {\n  \n}";
 

--- a/apis/core/test/domain/column-mapping/delete.test.ts
+++ b/apis/core/test/domain/column-mapping/delete.test.ts
@@ -124,6 +124,7 @@ describe('domain/column-mapping/delete', () => {
     const dimensionMetadataCount = dimensionMetadataCollection.node($rdf.namedNode('myDimension')).out().values.length
 
     await deleteColumnMapping({ resource: resourceId, store, dimensionMetadataQueries, tableQueries })
+    await store.save()
 
     const columnMapping = await store.getResource<ColumnMapping>(resourceId, { allowMissing: true })
     expect(columnMapping).to.eq(undefined)

--- a/apis/core/test/domain/cube-projects/update.test.ts
+++ b/apis/core/test/domain/cube-projects/update.test.ts
@@ -83,7 +83,7 @@ describe('domain/cube-projects/update', () => {
     it('does not touch cube if namespace does not change', async () => {
       // given
       const resource = projectPointer(project.term)
-      const datasetBefore = (await store.get(project.out(cc.dataset).term)).dataset.toCanonical()
+      const datasetBefore = $rdf.dataset([...(await store.get(project.out(cc.dataset).term)).dataset]).toCanonical()
 
       // when
       const editedProject = await updateProject({
@@ -93,7 +93,7 @@ describe('domain/cube-projects/update', () => {
       })
 
       // then
-      const datasetAfter = (await store.get(editedProject.dataset.id)).dataset.toCanonical()
+      const datasetAfter = $rdf.dataset([...(await store.get(editedProject.dataset.id)).dataset]).toCanonical()
       expect(datasetAfter).to.eq(datasetBefore)
     })
 
@@ -111,8 +111,8 @@ describe('domain/cube-projects/update', () => {
       })
 
       // then
-      const metadataAfter = (await store.get(dataset?.dimensionMetadata.id)).dataset.toCanonical()
-      expect(metadataAfter).to.eq(metadataBefore.dataset.toCanonical())
+      const metadataAfter = $rdf.dataset([...(await store.get(dataset?.dimensionMetadata.id)).dataset]).toCanonical()
+      expect(metadataAfter).to.eq($rdf.dataset([...metadataBefore.dataset]).toCanonical())
     })
 
     it('renames cube if namespace changes', async () => {

--- a/apis/core/test/support/TestResourceStore.ts
+++ b/apis/core/test/support/TestResourceStore.ts
@@ -1,11 +1,12 @@
 import { NamedNode, Term } from 'rdf-js'
 import DatasetExt from 'rdf-ext/lib/Dataset'
-import { GraphPointer } from 'clownface'
+import clownface, { GraphPointer } from 'clownface'
 import TermMap from '@rdfjs/term-map'
 import ResourceStore from '../../lib/ResourceStore'
+import { ChangelogDataset } from '../../lib/ChangelogDataset'
 
 class InMemoryStorage {
-  private readonly __resources: TermMap<NamedNode, GraphPointer<NamedNode, DatasetExt>>
+  private readonly __resources: TermMap<NamedNode, GraphPointer<NamedNode, ChangelogDataset<DatasetExt>>>
 
   constructor(pointers: GraphPointer<NamedNode, DatasetExt>[]) {
     this.__resources = new TermMap()
@@ -14,7 +15,7 @@ class InMemoryStorage {
     }
   }
 
-  async loadResource(term: NamedNode): Promise<GraphPointer<NamedNode, DatasetExt> | undefined> {
+  async loadResource(term: NamedNode): Promise<GraphPointer<NamedNode, ChangelogDataset<DatasetExt>> | undefined> {
     return this.__resources.get(term)
   }
 
@@ -25,8 +26,9 @@ class InMemoryStorage {
     return Promise.resolve()
   }
 
-  push(pointer: GraphPointer<NamedNode, any>) {
-    this.__resources.set(pointer.term, pointer)
+  push(pointer: GraphPointer<NamedNode, DatasetExt>) {
+    const changelogPointer = clownface({ dataset: new ChangelogDataset(pointer.dataset) }).node(pointer.term)
+    this.__resources.set(pointer.term, changelogPointer)
   }
 }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - apis/core/lib/handlers

--- a/yarn.lock
+++ b/yarn.lock
@@ -3327,34 +3327,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-barnard59-base@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/barnard59-base/-/barnard59-base-0.0.1.tgz#25dc0e52632357c913e361736e271eeccd196390"
-  integrity sha512-nerc7N7xBMVKGOajbSi1yNXGawS6z02UAo79UhLOaA7/Nn9LbUF/IzxTivXc4fatb7dE4qM8yKaaeYTj+sbjNQ==
-  dependencies:
-    "@rdfjs/formats-common" "^2.0.0"
-    duplexify "^3.6.1"
-    nodeify-fetch "^2.0.0"
-    rdf-ext "^1.1.2"
-    rdf-transform-triple-to-quad "^1.0.1"
-    readable-stream "^3.0.6"
-    through2 "^2.0.3"
-
-barnard59-base@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/barnard59-base/-/barnard59-base-0.0.4.tgz#71ca9c8ef1e6018fb758af12bd74ae14397624e8"
-  integrity sha512-u7m8A9Mjq+O4iLjB4FbLwjTnGh+fAsIc5c5W1XpHMYLzgYcQhVjYPIjPOEb9QycbuzmoYS3Bvsx89k9K4ADBMQ==
-  dependencies:
-    "@rdfjs/formats-common" "^2.0.0"
-    duplexify "^3.6.1"
-    lodash "^4.17.15"
-    nodeify-fetch "^2.0.0"
-    rdf-ext "^1.1.2"
-    rdf-transform-triple-to-quad "^1.0.1"
-    readable-stream "^3.0.6"
-    through2 "^2.0.3"
-
-barnard59-base@^0.0.5:
+barnard59-base@0.0.5, barnard59-base@^0.0.1, barnard59-base@^0.0.4, barnard59-base@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/barnard59-base/-/barnard59-base-0.0.5.tgz#ae0130a4d8a547cfa4d53558ccc1b46aa5b390c0"
   integrity sha512-4E+8OODtFtCAs5i7mmuKxvu/SuToNq3nB2Cn5p0hkAxIY/NKj5NxLe9gyUG888mTvZVdZRIPY2Xy/09xjL+OQg==
@@ -10450,6 +10423,14 @@ rdf-data-factory@^1.0.2:
   integrity sha512-ZIIwEkLcV7cTc+atvQFzAETFVRHz1BRe/MhdkZqYse8vxskErj8/bF/Ittc3B5c0GTyw6O3jVF2V7xBRGyRoSQ==
   dependencies:
     "@types/rdf-js" "^4.0.0"
+
+rdf-dataset-changelog@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-dataset-changelog/-/rdf-dataset-changelog-1.0.0.tgz#8c07e657da9e6db1d3861e41be06aedaa9559def"
+  integrity sha512-kWEbjWPKgm57uFsyX81iS2kJqUY6qH7HCpZFzaOYlrNhYQetG+ZLr/f8ppZu131rzAX0RpdMoVmfvqr5yGcigA==
+  dependencies:
+    "@rdfjs/data-model" "^1.1.2"
+    "@rdfjs/dataset" "^1.0.1"
 
 rdf-dataset-ext@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Two important refactoring, before the resource store bites back:

1. move `store.save` to the handlers so that domain code does not have to care about it.
2. store will not write back unchanged graphs. this will reduce the risk for potential graphs being overwritten as we don't have optimistic locking