### PR TITLE
feat(ui): use toasts for success messages

### DIFF
--- a/ui/src/components/JobForm.vue
+++ b/ui/src/components/JobForm.vue
@@ -60,7 +60,7 @@ export default class JobForm extends Vue {
         resource: this.resource,
       })
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: 'Transformation was started',
         type: 'is-success',
       })

--- a/ui/src/store/modules/api.ts
+++ b/ui/src/store/modules/api.ts
@@ -4,6 +4,7 @@ import { api } from '@/api'
 import { RootState } from '../types'
 import { GraphPointer } from 'clownface'
 import RdfResourceImpl, { ResourceIdentifier } from '@tpluscode/rdfine'
+import { ToastProgrammatic as Toast } from 'buefy'
 
 export interface APIState {
   entrypoint: null | RdfResource,
@@ -35,11 +36,10 @@ const actions: ActionTree<APIState, RootState> = {
     try {
       await api.invokeDeleteOperation(operation)
 
-      context.commit('app/pushMessage', {
-        title: operation.title,
+      Toast.open({
         message: successMessage,
         type: 'is-success',
-      }, { root: true })
+      })
 
       context.dispatch(callbackAction, {}, { root: true })
     } catch (e) {

--- a/ui/src/views/ColumnMappingCreate.vue
+++ b/ui/src/views/ColumnMappingCreate.vue
@@ -96,7 +96,7 @@ export default class CubeProjectEditView extends Vue {
 
       this.$store.dispatch('project/refreshTableCollection')
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: 'Column mapping was successfully created',
         type: 'is-success',
       })

--- a/ui/src/views/ColumnMappingEdit.vue
+++ b/ui/src/views/ColumnMappingEdit.vue
@@ -89,7 +89,7 @@ export default class CubeProjectEditView extends Vue {
 
       this.$store.dispatch('project/refreshTableCollection')
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: 'Column mapping was successfully updated',
         type: 'is-success',
       })

--- a/ui/src/views/CubeMetadataEdit.vue
+++ b/ui/src/views/CubeMetadataEdit.vue
@@ -66,7 +66,7 @@ export default class CubeMetadataEdit extends Vue {
 
       this.$store.dispatch('project/fetchCubeMetadata')
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: 'Cube metadata was saved',
         type: 'is-success',
       })

--- a/ui/src/views/CubeProjectCreate.vue
+++ b/ui/src/views/CubeProjectCreate.vue
@@ -58,7 +58,7 @@ export default class extends Vue {
         resource: this.resource,
       })
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: `Project ${project.title} successfully created`,
         type: 'is-success',
       })

--- a/ui/src/views/CubeProjectEdit.vue
+++ b/ui/src/views/CubeProjectEdit.vue
@@ -80,7 +80,7 @@ export default class CubeProjectEditView extends Vue {
 
       this.$store.commit('project/storeProject', project)
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: 'Project settings were saved',
         type: 'is-success',
       })

--- a/ui/src/views/DimensionEdit.vue
+++ b/ui/src/views/DimensionEdit.vue
@@ -74,7 +74,7 @@ export default class extends Vue {
 
       this.$store.dispatch('project/fetchDimensionMetadataCollection')
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: 'Dimension metadata was saved',
         type: 'is-success',
       })

--- a/ui/src/views/SourceEdit.vue
+++ b/ui/src/views/SourceEdit.vue
@@ -70,7 +70,7 @@ export default class CubeProjectEditView extends Vue {
 
       this.$store.dispatch('project/refreshSourcesCollection')
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: 'Settings successfully saved',
         type: 'is-success',
       })

--- a/ui/src/views/TableCreate.vue
+++ b/ui/src/views/TableCreate.vue
@@ -136,7 +136,7 @@ export default class TableCreateView extends Vue {
 
       this.$store.dispatch('project/refreshTableCollection')
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: `Table ${table.name} was successfully created`,
         type: 'is-success',
       })

--- a/ui/src/views/TableEdit.vue
+++ b/ui/src/views/TableEdit.vue
@@ -77,7 +77,7 @@ export default class TableCreateView extends Vue {
 
       this.$store.dispatch('project/refreshTableCollection')
 
-      this.$store.dispatch('app/showMessage', {
+      this.$buefy.toast.open({
         message: `Table ${table.name} was successfully created`,
         type: 'is-success',
       })

--- a/ui/tests/e2e/specs/project-mapping.spec.ts
+++ b/ui/tests/e2e/specs/project-mapping.spec.ts
@@ -19,7 +19,7 @@ describe('CSV mapping flow', () => {
 
     cy.get('form').submit()
 
-    cy.contains('.message', 'successfully created').should('be.visible')
+    cy.contains('successfully created').should('be.visible')
     cy.contains('h2', 'My project').should('be.visible')
   })
 
@@ -62,7 +62,7 @@ describe('CSV mapping flow', () => {
 
     cy.get('form').submit()
 
-    cy.contains('.message', 'Table My observations was successfully created').should('be.visible')
+    cy.contains('Table My observations was successfully created').should('be.visible')
     cy.contains('.mapper-table', 'My observations').should('be.visible')
     cy.get('[data-icon=eye]').should('be.visible')
   })
@@ -94,7 +94,7 @@ describe('CSV mapping flow', () => {
     cy.get('form')
       .submit()
 
-    cy.contains('.message', 'Column mapping was successfully created').should('be.visible')
+    cy.contains('Column mapping was successfully created').should('be.visible')
     cy.contains('.mapper-table', 'schema:identifier').should('be.visible')
   })
 
@@ -115,7 +115,7 @@ describe('CSV mapping flow', () => {
 
     cy.get('form').submit()
 
-    cy.contains('.message', 'Table My secondary table was successfully created').should('be.visible')
+    cy.contains('Table My secondary table was successfully created').should('be.visible')
     cy.contains('.mapper-table', 'My secondary table').should('be.visible')
       .find('[data-icon=eye]').should('not.be.visible')
   })
@@ -137,7 +137,7 @@ describe('CSV mapping flow', () => {
     cy.get('form')
       .submit()
 
-    cy.contains('.message', 'Column mapping was successfully created').should('be.visible')
+    cy.contains('Column mapping was successfully created').should('be.visible')
     cy.contains('.mapper-table', 'the-other').should('be.visible')
   })
 
@@ -147,7 +147,7 @@ describe('CSV mapping flow', () => {
 
     cy.contains('.button', 'Delete').click()
 
-    cy.contains('.message', 'Table My secondary table deleted successfully').should('be.visible')
+    cy.contains('Table My secondary table deleted successfully').should('be.visible')
     cy.contains('.mapper-table', 'My secondary table').should('not.be.visible')
   })
 })


### PR DESCRIPTION
Replace full-blown "message" by simple toasts for notifications after a successful operation.

Fixes #341