### PR TITLE
fix: dcterms:descritption instead of comment

### DIFF
--- a/apis/core/bootstrap/shapes/dataset.ts
+++ b/apis/core/bootstrap/shapes/dataset.ts
@@ -39,7 +39,7 @@ ${shapeId} {
     ] ;
     ${sh.property} [
       ${sh.name} "Description" ;
-      ${sh.path} ${dcterms.comment} ;
+      ${sh.path} ${dcterms.description} ;
       ${sh.minCount} 0 ;
       ${sh.minLength} 1 ;
       ${sh.datatype} ${rdf.langString} ;


### PR DESCRIPTION
Jeremy Stucky found an error 

There was `dcterms:comment` instead of `dcterms:description`

Don't ask me where this came from...