### PR TITLE
fix: more selectively accept dataset metadata

### DIFF
--- a/apis/core/lib/domain/dataset/update.ts
+++ b/apis/core/lib/domain/dataset/update.ts
@@ -1,14 +1,31 @@
 import { cc } from '@cube-creator/core/namespace'
 import { dcat, hydra, rdf, schema, _void } from '@tpluscode/rdf-ns-builders'
 import { GraphPointer } from 'clownface'
-import { NamedNode } from 'rdf-js'
+import { DatasetCore, NamedNode, Term } from 'rdf-js'
+import TermSet from '@rdfjs/term-set'
 import { ResourceStore } from '../../ResourceStore'
 
 interface AddMetaDataCommand {
   dataset: GraphPointer<NamedNode>
   resource: GraphPointer
   store: ResourceStore
+}
 
+/**
+ * Copies quads of given subject and its blank node children
+ */
+function copySubgraph({ from, to, subject, alreadyAdded = new TermSet() }: { from: DatasetCore; to: DatasetCore; subject: Term; alreadyAdded?: TermSet }) {
+  if (alreadyAdded.has(subject)) {
+    return
+  }
+  alreadyAdded.add(subject)
+
+  for (const quad of from.match(subject)) {
+    to.add(quad)
+    if (quad.object.termType === 'BlankNode') {
+      copySubgraph({ from, to, alreadyAdded, subject: quad.object })
+    }
+  }
 }
 
 export async function update({
@@ -28,9 +45,11 @@ export async function update({
   })
   datasetResource.deleteOut()
 
-  for (const quad of resource.dataset) {
-    datasetResource.dataset.add(quad)
-  }
+  copySubgraph({
+    from: resource.dataset,
+    to: datasetResource.dataset,
+    subject: datasetResource.term,
+  })
 
   // Make sure the type is correct
   datasetResource.addOut(rdf.type, hydra.Resource)

--- a/apis/core/test/domain/dataset/update.test.ts
+++ b/apis/core/test/domain/dataset/update.test.ts
@@ -1,22 +1,25 @@
 import { describe, it, beforeEach } from 'mocha'
 import { expect } from 'chai'
-import clownface from 'clownface'
+import clownface, { GraphPointer } from 'clownface'
 import $rdf from 'rdf-ext'
-import { dcat, dcterms, rdf, schema, sh, _void } from '@tpluscode/rdf-ns-builders'
+import { NamedNode } from 'rdf-js'
+import DatasetExt from 'rdf-ext/lib/Dataset'
+import { dcat, dcterms, hydra, rdf, schema, sh, _void, xsd } from '@tpluscode/rdf-ns-builders'
+import { cc, cube } from '@cube-creator/core/namespace'
 import { TestResourceStore } from '../../support/TestResourceStore'
 import { update } from '../../../lib/domain/dataset/update'
-import { cube } from '@cube-creator/core/namespace'
 
 describe('domain/dataset/update', () => {
   let store: TestResourceStore
-  const dataset = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('dataset') })
-    .addOut(dcterms.title, 'My Title')
-    .addOut(dcat.keyword, 'Test')
-  const cubeNode = dataset.namedNode('cube')
-    .addOut(rdf.type, cube.Cube)
-    .addIn(schema.hasPart, dataset)
+  let dataset: GraphPointer<NamedNode, DatasetExt>
 
   beforeEach(() => {
+    dataset = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('dataset') })
+      .addOut(dcterms.title, 'My Title')
+      .addOut(dcat.keyword, 'Test')
+    dataset.namedNode('cube')
+      .addOut(rdf.type, cube.Cube)
+      .addIn(schema.hasPart, dataset)
     store = new TestResourceStore([
       dataset,
     ])
@@ -46,6 +49,72 @@ describe('domain/dataset/update', () => {
         minCount: 1,
       }],
     })
-    expect(cubeNode.value).to.eq('cube')
+  })
+
+  it('replaces blank node children', async () => {
+    // given
+    dataset.addOut(dcterms.temporal, temporal => {
+      temporal
+        .addOut(dcterms.startDate, $rdf.literal('2010-10-10', xsd.date))
+        .addOut(dcterms.endDate, $rdf.literal('2020-10-10', xsd.date))
+    })
+    const updatedResource = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('dataset') })
+      .addOut(dcterms.title, 'title')
+      .addOut(dcterms.temporal, temporal => {
+        temporal
+          .addOut(dcterms.startDate, $rdf.literal('2000-10-10', xsd.date))
+          .addOut(dcterms.endDate, $rdf.literal('2010-10-10', xsd.date))
+      })
+
+    // when
+    const result = await update({ dataset, resource: updatedResource, store })
+
+    // then
+    expect(result).to.matchShape({
+      property: [{
+        path: dcterms.title,
+        hasValue: 'title',
+        minCount: 1,
+        maxCount: 1,
+      }, {
+        path: dcterms.temporal,
+        maxCount: 1,
+        minCount: 1,
+        node: {
+          property: [{
+            path: dcterms.startDate,
+            hasValue: $rdf.literal('2000-10-10', xsd.date),
+            minCount: 1,
+            maxCount: 1,
+          }, {
+            path: dcterms.endDate,
+            hasValue: $rdf.literal('2010-10-10', xsd.date),
+            minCount: 1,
+            maxCount: 1,
+          }],
+        },
+      }],
+    })
+  })
+
+  it('excludes named node children from stored resource', async () => {
+    // given
+    const updatedResource = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('dataset') })
+      .addOut(dcterms.title, 'title')
+      .addOut(schema.hasPart, dataset.namedNode('cube'), cube => {
+        cube.addOut(cc.observations, template => {
+          template.addOut(rdf.type, hydra.IriTemplate)
+          template.addOut(hydra.mapping, mapping => {
+            mapping.addOut(hydra.variable, 'foo')
+          })
+        })
+      })
+
+    // when
+    const result = await update({ dataset, resource: updatedResource, store })
+
+    // then
+    const cubeTriples = result.dataset.match(dataset.namedNode('cube').term)
+    expect(cubeTriples.size).to.eq(1, 'Got: \n' + cubeTriples.toString())
   })
 })


### PR DESCRIPTION
The dataset metadata update endpoint was all too eager to save anything it received.

This PR changes this so that only saved quads will be those which has the dataset for subject and blank node children.

Specifically, any pre-existing triples about `<dataset> schema:hasPart ?cube` will be left intact