### PR TITLE
fix(cli): process.exit blocks sentry logs

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -65,8 +65,9 @@ async function main() {
 }
 
 main()
-  .catch(e => {
+  .catch(async e => {
     Sentry.captureException(e)
     log(e)
+    await Sentry.close(2000)
     process.exit(1)
   })


### PR DESCRIPTION
We've stopped seeing CLI logs in Sentry, likely due to a the process ending too abruptly, according to @sandhose. (see https://docs.sentry.io/platforms/node/configuration/draining/)

This adds a timeout to give sentry time to write the logs before `process.exit`