### PR TITLE
Avoid refreshing whole UI

### DIFF
--- a/apis/core/lib/handlers/table/create.ts
+++ b/apis/core/lib/handlers/table/create.ts
@@ -1,8 +1,12 @@
 import asyncMiddleware from 'middleware-async'
 import { protectedResource } from '@hydrofoil/labyrinth/resource'
+import { loadLinkedResources } from '@hydrofoil/labyrinth/lib/query/eagerLinks'
 import { shaclValidate } from '../../middleware/shacl'
 import { createTable } from '../../domain/table/create'
+import { query } from '@cube-creator/core/namespace'
 import clownface from 'clownface'
+import $rdf from 'rdf-ext'
+import { rdf } from '@tpluscode/rdf-ns-builders'
 
 export const post = protectedResource(
   shaclValidate,
@@ -16,6 +20,13 @@ export const post = protectedResource(
 
     res.status(201)
     res.header('Location', table.value)
-    await res.dataset(table.dataset)
+
+    // Include resources defined with `query:include`
+    const types = clownface({
+      dataset: req.hydra.api.dataset,
+      term: table.out(rdf.type).terms,
+    })
+    const linkedResources = await loadLinkedResources(table, types.out(query.include).toArray(), req.app.sparql)
+    await res.dataset($rdf.dataset([...table.dataset, ...linkedResources]))
   }),
 )

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -75,6 +75,7 @@ prefixes.cube = 'http://ns.bergnet.org/cube/'
 prefixes.view = 'http://ns.bergnet.org/cube-view/'
 
 export const hashi = namespace('http://hypermedia.app/shapes#')
+export const query = namespace('http://hypermedia.app/query#')
 export const cube = namespace(prefixes.cube)
 export const view = namespace(prefixes.view)
 export const hydraBox = namespace('http://hydra-box.org/schema/')

--- a/ui/src/components/LiteralColumnMappingForm.vue
+++ b/ui/src/components/LiteralColumnMappingForm.vue
@@ -71,7 +71,6 @@ export default class extends Vue {
   }
 
   onSubmit (): void {
-    console.log(this.resource)
     this.$emit('submit', this.resource)
   }
 }

--- a/ui/src/store/modules/project.ts
+++ b/ui/src/store/modules/project.ts
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import { ActionTree, MutationTree, GetterTree } from 'vuex'
 import { api } from '@/api'
 import { RootState } from '../types'
@@ -13,9 +14,11 @@ import {
   CsvSource,
 } from '@cube-creator/model'
 import {
+  serializeColumnMapping,
   serializeDimensionMetadataCollection,
   serializeJobCollection,
   serializeSourcesCollection,
+  serializeTable,
   serializeTableCollection,
 } from '../serializers'
 import { Term } from 'rdf-js'
@@ -25,9 +28,9 @@ export interface ProjectState {
   project: null | Project,
   csvMapping: null | CsvMapping,
   sourcesCollection: null | SourcesCollection,
-  sources: null | Map<string, CsvSource>,
+  sources: Record<string, CsvSource>,
   tableCollection: null | TableCollection,
-  tables: null | Map<string, Table>,
+  tables: Record<string, Table>,
   cubeMetadata: null | Dataset,
   dimensionMetadataCollection: null | DimensionMetadataCollection,
   jobCollection: null | JobCollection,
@@ -37,9 +40,9 @@ const initialState = {
   project: null,
   csvMapping: null,
   sourcesCollection: null,
-  sources: null,
+  sources: {},
   tableCollection: null,
-  tables: null,
+  tables: {},
   cubeMetadata: null,
   dimensionMetadataCollection: null,
   jobCollection: null,
@@ -47,11 +50,11 @@ const initialState = {
 
 const getters: GetterTree<ProjectState, RootState> = {
   sources (state) {
-    return [...(state.sources?.values() ?? [])]
+    return Object.values(state.sources)
   },
 
   tables (state) {
-    return [...(state.tables?.values() ?? [])]
+    return Object.values(state.tables)
   },
 
   dimensions (state) {
@@ -65,7 +68,7 @@ const getters: GetterTree<ProjectState, RootState> = {
 
   getSource (state) {
     return (uri: Term): CsvSource => {
-      const source = state.sources?.get(uri.value)
+      const source = state.sources[uri.value]
       if (!source) throw new Error(`Source not found: ${uri.value}`)
       return source
     }
@@ -78,8 +81,8 @@ const getters: GetterTree<ProjectState, RootState> = {
 
   getTable (state) {
     return (uri: Term): Table => {
-      const table = state.tables?.get(uri.value)
-      if (!table) throw new Error(`Source not found: ${uri.value}`)
+      const table = state.tables[uri.value]
+      if (!table) throw new Error(`Table not found: ${uri.value}`)
       return table
     }
   },
@@ -255,6 +258,27 @@ const mutations: MutationTree<ProjectState> = {
     state.tables = indexResources(state.tableCollection?.member || [], ({ id }: Table) => id.value)
   },
 
+  storeTable (state, table) {
+    Vue.set(state.tables, table.id.value, serializeTable(table))
+  },
+
+  storeNewColumnMapping (state, { table, columnMapping }) {
+    const storedTable = state.tables[table.id.value]
+    if (!storedTable) throw new Error(`Table not found: ${table.id.value}`)
+
+    const serializedColumnMapping = serializeColumnMapping(columnMapping)
+    storedTable.columnMappings.push(serializedColumnMapping)
+  },
+
+  storeUpdatedColumnMapping (state, { table, columnMapping }) {
+    const storedTable = state.tables[table.id.value]
+    if (!storedTable) throw new Error(`Table not found: ${table.id.value}`)
+
+    const serializedColumnMapping = serializeColumnMapping(columnMapping)
+    const index = storedTable.columnMappings.findIndex(({ id }) => id.equals(columnMapping.id))
+    Vue.set(storedTable.columnMappings, index, serializedColumnMapping)
+  },
+
   storeCubeMetadata (state, cubeMetadata) {
     state.cubeMetadata = Object.freeze(cubeMetadata)
   },
@@ -276,9 +300,11 @@ export default {
   mutations,
 }
 
-function indexResources<T extends RdfResource> (array: T[], indexFunction: (item: T) => string): Map<string, T> {
+function indexResources<T extends RdfResource> (array: T[], indexFunction: (item: T) => string): Record<string, T> {
   return array.reduce((acc, item) => {
-    acc.set(indexFunction(item), item)
-    return acc
-  }, new Map<string, T>())
+    return {
+      ...acc,
+      [indexFunction(item)]: item,
+    }
+  }, {})
 }

--- a/ui/src/store/serializers.ts
+++ b/ui/src/store/serializers.ts
@@ -56,7 +56,7 @@ export function serializeTableCollection (collection: TableCollection): TableCol
 }
 
 export function serializeTable (table: Table): Table {
-  return Object.freeze({
+  return {
     ...serializeResource(table),
     actions: {
       ...serializeActions(table.actions),
@@ -71,7 +71,7 @@ export function serializeTable (table: Table): Table {
     columnMappings: table.columnMappings.map(serializeColumnMapping),
     csvMapping: table.csvMapping,
     csvw: table.csvw,
-  })
+  }
 }
 
 export function serializeColumnMapping (columnMapping: ColumnMapping): ReferenceColumnMapping | LiteralColumnMapping {

--- a/ui/src/views/ColumnMappingCreate.vue
+++ b/ui/src/views/ColumnMappingCreate.vue
@@ -91,12 +91,12 @@ export default class CubeProjectEditView extends Vue {
     this.isSubmitting = true
 
     try {
-      await this.$store.dispatch('api/invokeSaveOperation', {
+      const columnMapping = await this.$store.dispatch('api/invokeSaveOperation', {
         operation: this.operation,
         resource,
       })
 
-      this.$store.dispatch('project/refreshTableCollection')
+      this.$store.commit('project/storeNewColumnMapping', { table: this.table, columnMapping })
 
       this.$buefy.toast.open({
         message: 'Column mapping was successfully created',

--- a/ui/src/views/ColumnMappingEdit.vue
+++ b/ui/src/views/ColumnMappingEdit.vue
@@ -84,12 +84,12 @@ export default class CubeProjectEditView extends Vue {
     this.isSubmitting = true
 
     try {
-      await this.$store.dispatch('api/invokeSaveOperation', {
+      const columnMapping = await this.$store.dispatch('api/invokeSaveOperation', {
         operation: this.operation,
         resource,
       })
 
-      this.$store.dispatch('project/refreshTableCollection')
+      this.$store.commit('project/storeUpdatedColumnMapping', { table: this.table, columnMapping })
 
       this.$buefy.toast.open({
         message: 'Column mapping was successfully updated',

--- a/ui/src/views/TableCreate.vue
+++ b/ui/src/views/TableCreate.vue
@@ -134,7 +134,7 @@ export default class TableCreateView extends Vue {
         resource: this.resource,
       })
 
-      this.$store.dispatch('project/refreshTableCollection')
+      this.$store.commit('project/storeTable', table)
 
       this.$buefy.toast.open({
         message: `Table ${table.name} was successfully created`,

--- a/ui/src/views/TableEdit.vue
+++ b/ui/src/views/TableEdit.vue
@@ -76,7 +76,7 @@ export default class TableCreateView extends Vue {
         resource: this.resource,
       })
 
-      this.$store.dispatch('project/refreshTableCollection')
+      this.$store.commit('project/storeTable', table)
 
       this.$buefy.toast.open({
         message: `Table ${table.name} was successfully created`,


### PR DESCRIPTION
Do not refresh whole UI when adding/updating stuff. Currently only implemented for critical operations: add/update table and add/update column mapping.

Fixes #335