### PR TITLE
Main "transform" button

### DIFF
--- a/ui/src/components/JobForm.vue
+++ b/ui/src/components/JobForm.vue
@@ -24,7 +24,7 @@ import type { Shape } from '@rdfine/shacl'
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
 import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
-import { rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
+import { rdf, sh } from '@tpluscode/rdf-ns-builders'
 import { NamedNode } from 'rdf-js'
 
 @Component({
@@ -33,10 +33,10 @@ import { NamedNode } from 'rdf-js'
 export default class JobForm extends Vue {
   @Prop() operation!: RuntimeOperation
 
-  resource: GraphPointer = Object.freeze(clownface({ dataset: dataset() }).namedNode('').addOut(schema.name, 'test')).addOut(rdf.type, this.resourceType);
-  shape: Shape | null = null;
-  error: ErrorDetails | null = null;
-  isSubmitting = false;
+  resource: GraphPointer = Object.freeze(clownface({ dataset: dataset() }).namedNode('').addOut(rdf.type, this.resourceType))
+  shape: Shape | null = null
+  error: ErrorDetails | null = null
+  isSubmitting = false
 
   get resourceType (): NamedNode {
     const type = this.operation.expects.find((expect) => !expect.types.has(sh.Shape))

--- a/ui/src/components/JobIcon.vue
+++ b/ui/src/components/JobIcon.vue
@@ -1,0 +1,51 @@
+<template>
+  <span class="job-icon">
+    <b-icon :icon="icon" :class="color" />
+  </span>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Job } from '@cube-creator/model'
+import { schema } from '@tpluscode/rdf-ns-builders'
+import { cc } from '@cube-creator/core/namespace'
+
+@Component
+export default class extends Vue {
+  @Prop({ required: true }) job!: Job
+
+  get icon (): string {
+    if (this.job.types.has(cc.PublishJob)) {
+      return 'upload'
+    } else if (this.job.types.has(cc.TransformJob)) {
+      return 'random'
+    } else {
+      return 'circle'
+    }
+  }
+
+  get color (): string {
+    const status = this.job.actionStatus?.value ?? 'unknown'
+
+    return {
+      [schema.CompletedActionStatus.value]: 'has-text-success',
+      [schema.PotentialActionStatus.value]: 'has-text-grey-light',
+      [schema.ActiveActionStatus.value]: 'has-text-info blink',
+      [schema.FailedActionStatus.value]: 'has-text-danger',
+      unknown: 'has-text-dark',
+    }[status]
+  }
+}
+</script>
+
+<style scoped>
+.blink {
+  animation: blinker 1s linear infinite;
+}
+
+@keyframes blinker {
+  50% {
+    opacity: 0;
+  }
+}
+</style>

--- a/ui/src/components/JobItem.vue
+++ b/ui/src/components/JobItem.vue
@@ -1,8 +1,6 @@
 <template>
   <div class="panel-block job">
-    <span class="job-icon">
-      <b-icon :icon="icon" :class="color" />
-    </span>
+    <job-icon :job="job" />
     <div class="ml-3 is-flex-grow-1">
       <span>{{ job.name }}</span><br>
       <span class="has-text-grey">{{ job.created | format-date }}</span>
@@ -16,45 +14,12 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator'
 import { Job } from '@cube-creator/model'
-import { schema } from '@tpluscode/rdf-ns-builders'
-import { cc } from '@cube-creator/core/namespace'
+import JobIcon from './JobIcon.vue'
 
-@Component
+@Component({
+  components: { JobIcon },
+})
 export default class extends Vue {
   @Prop() job!: Job
-
-  get icon (): string {
-    if (this.job.types.has(cc.PublishJob)) {
-      return 'upload'
-    } else if (this.job.types.has(cc.TransformJob)) {
-      return 'random'
-    } else {
-      return 'circle'
-    }
-  }
-
-  get color (): string {
-    const status = this.job.actionStatus?.value ?? 'unknown'
-
-    return {
-      [schema.CompletedActionStatus.value]: 'has-text-success',
-      [schema.PotentialActionStatus.value]: 'has-text-grey-light',
-      [schema.ActiveActionStatus.value]: 'has-text-info blink',
-      [schema.FailedActionStatus.value]: 'has-text-danger',
-      unknown: 'has-text-dark',
-    }[status]
-  }
 }
 </script>
-
-<style scoped>
-.blink {
-  animation: blinker 1s linear infinite;
-}
-
-@keyframes blinker {
-  50% {
-    opacity: 0;
-  }
-}
-</style>

--- a/ui/src/components/PageContent.vue
+++ b/ui/src/components/PageContent.vue
@@ -1,11 +1,5 @@
 <template>
-  <div class="page-content">
+  <div class="px-4 pt-4 pb-0">
     <slot />
   </div>
 </template>
-
-<style scoped>
-.page-content {
-  padding: 1.5rem 1.5rem 0 1.5rem
-}
-</style>

--- a/ui/src/components/TransformJobButton.vue
+++ b/ui/src/components/TransformJobButton.vue
@@ -1,0 +1,72 @@
+<template>
+  <span class="field" :class="{ 'has-addons': transformJobs.length > 0 }">
+    <b-button v-if="jobCollection.actions.createTransform" class="control" icon-left="play" size="is-small" @click="transform" :loading="isTransforming">
+      Transform
+    </b-button>
+    <b-dropdown v-if="transformJobs.length > 0" position="is-bottom-left" class="control">
+      <b-tooltip label="Previous jobs" slot="trigger" position="is-left">
+        <button class="button is-small">
+          <job-icon :job="transformJobs[0]" />
+        </button>
+      </b-tooltip>
+      <b-dropdown-item :focusable="false" custom paddingless>
+        <job-item v-for="job in transformJobs" :key="job.clientPath" :job="job" />
+      </b-dropdown-item>
+    </b-dropdown>
+  </span>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Job, JobCollection } from '@cube-creator/model'
+import JobItem from './JobItem.vue'
+import JobIcon from './JobIcon.vue'
+import { rdf, sh } from '@tpluscode/rdf-ns-builders'
+import clownface from 'clownface'
+import { dataset } from '@rdf-esm/dataset'
+
+@Component({
+  components: { JobItem, JobIcon },
+})
+export default class TransformJobButton extends Vue {
+  @Prop({ required: true }) jobCollection!: JobCollection
+  @Prop({ required: true }) transformJobs!: Job[]
+
+  isTransforming = false
+
+  async transform (): Promise<void> {
+    // Artifically disable the button for a while
+    // Not using the latest job status to avoid preventing starting new jobs
+    // if a job stays blocked in "running" state
+    this.isTransforming = true
+    setTimeout(() => { this.isTransforming = false }, 3000)
+
+    const operation = this.jobCollection.actions.createTransform
+    if (!operation) throw new Error('Transform operation not found')
+
+    const resourceType = operation.expects.find((expect: any) => !expect.types.has(sh.Shape))
+    if (!resourceType) throw new Error('Operation expected type not found')
+
+    const resource = clownface({ dataset: dataset() })
+      .namedNode('')
+      .addOut(rdf.type, resourceType.id)
+
+    try {
+      await this.$store.dispatch('api/invokeSaveOperation', { operation, resource })
+
+      this.$buefy.toast.open({
+        message: 'Transformation was started',
+        type: 'is-success',
+      })
+
+      this.$store.dispatch('project/fetchJobCollection')
+    } catch (e) {
+      this.$store.dispatch('app/showMessage', {
+        title: 'An error occurred',
+        message: e.toString(),
+        type: 'is-danger',
+      })
+    }
+  }
+}
+</script>

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -21,7 +21,7 @@ import ColumnMappingCreate from '@/views/ColumnMappingCreate.vue'
 import CubeDesigner from '@/views/CubeDesigner.vue'
 import CubeMetadataEdit from '@/views/CubeMetadataEdit.vue'
 import DimensionEdit from '@/views/DimensionEdit.vue'
-import Pipeline from '@/views/Pipeline.vue'
+import Publication from '@/views/Publication.vue'
 import PageNotFound from '@/views/PageNotFound.vue'
 import Logout from '@/views/Logout.vue'
 import NotAuthorized from '@/views/NotAuthorized.vue'
@@ -117,9 +117,9 @@ const routes: Array<RouteConfig> = [
             ],
           },
           {
-            path: 'pipeline',
-            name: 'Pipeline',
-            component: Pipeline,
+            path: 'publication',
+            name: 'Publication',
+            component: Publication,
           },
         ],
       },

--- a/ui/src/views/Publication.vue
+++ b/ui/src/views/Publication.vue
@@ -1,30 +1,18 @@
 <template>
   <div v-if="jobCollection">
-    <div class="columns container-narrow">
-      <div class="column">
-        <job-form
-          v-if="jobCollection.actions.createTransform"
-          :operation="jobCollection.actions.createTransform"
-          class="box"
-        />
-      </div>
-      <div class="column">
-        <job-form
-          v-if="jobCollection.actions.createPublish"
-          :operation="jobCollection.actions.createPublish"
-          class="box"
-        />
-      </div>
+    <div class="container-narrow">
+      <job-form
+        v-if="jobCollection.actions.createPublish"
+        :operation="jobCollection.actions.createPublish"
+        class="box"
+      />
     </div>
 
     <div class="jobs content">
       <div class="is-flex is-align-items-center mb-3">
         <h3 class="title is-5 mb-0">
-          Previous jobs
+          Previous publications
         </h3>
-        <b-tooltip label="Refresh">
-          <b-button @click="fetchJobs" icon-left="sync" type="is-text" size="is-small" />
-        </b-tooltip>
       </div>
       <div v-if="jobs.length > 0" class="panel container-narrow">
         <job-item v-for="job in jobs" :key="job.clientPath" :job="job" />
@@ -50,23 +38,9 @@ const projectNS = namespace('project')
 @Component({
   components: { LoadingBlock, JobForm, JobItem },
 })
-export default class CubeDesignerView extends Vue {
+export default class PublicationView extends Vue {
   @projectNS.State('jobCollection') jobCollection!: JobCollection | null;
-
-  mounted (): void {
-    this.fetchJobs()
-  }
-
-  get jobs (): Job[] {
-    if (!this.jobCollection) return []
-
-    const jobs = this.jobCollection.member
-    return jobs.sort(({ created: created1 }, { created: created2 }) => created2.getTime() - created1.getTime())
-  }
-
-  fetchJobs (): void {
-    this.$store.dispatch('project/fetchJobCollection')
-  }
+  @projectNS.Getter('publishJobs') jobs!: Job[]
 }
 </script>
 


### PR DESCRIPTION
Will fix #378 

- Adds a main, always visible, "transform" button
- Adds a way to see previous transform jobs
- Polls jobs to display "real-time" status of jobs
- Transform "Pipeline" page into "Publication" page: shows only publication-related jobs

Warning: it will break dev because the new button doesn't allow providing the required Github Token when starting a job