### PR TITLE
fix: assume BOM when parsing to get header names

### DIFF
--- a/apis/core/lib/domain/csv/index.ts
+++ b/apis/core/lib/domain/csv/index.ts
@@ -21,6 +21,7 @@ export function parse(csv: string, options: CSVparse.Options): Promise<{ header:
 export async function sniffParse(csv: string): Promise<{ dialect: {delimiter: string; quote: string}; header: any[]; rows: any[] }> {
   const detectedCsvFormat = sniffer.sniff(csv)
   const csvDialect = {
+    bom: true,
     delimiter: detectedCsvFormat.delimiter,
     quote: detectedCsvFormat.quoteChar || '',
   }

--- a/apis/core/test/domain/csv/parse.test.ts
+++ b/apis/core/test/domain/csv/parse.test.ts
@@ -12,7 +12,7 @@ describe('domain/csv/parse', () => {
     const { dialect, header, rows } = await sniffParse(input.toString())
     const [lastRow] = rows.slice(-1)
 
-    expect(dialect).to.deep.eq({ delimiter: ',', quote: '"' })
+    expect(dialect).to.contain({ delimiter: ',', quote: '"' })
     expect(header).to.deep.eq(['aggregation_id', 'aggregation_name_de', 'aggregation_name_fr', 'aggregation_name_it', 'aggregation_name_en'])
     expect(lastRow).to.deep.eq(['dosisaot40f', 'Dosis AOT40f', 'Dose AOT40f', 'Dose AOT40f', 'Dosis AOT40f'])
   })


### PR DESCRIPTION
fixes #255

BOM was not parsed correctly when extracting column names from CSV, and it ended up as an invisible character in the first column name. Hence, it would not match those coming from `csv-parser`