### PR TITLE
feat: cube resource preview

### DIFF
--- a/apis/core/hydra/projects.ttl
+++ b/apis/core/hydra/projects.ttl
@@ -5,6 +5,7 @@ prefix code:   <https://code.described.at/>
 prefix query:  <http://hypermedia.app/query#>
 prefix sh:     <http://www.w3.org/ns/shacl#>
 PREFIX schema: <http://schema.org/>
+prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 cc:CubeProject
   a
@@ -51,7 +52,15 @@ cc:CubeProject
           code:link
             <file:handlers/cube-projects#remove> ;
         ] ;
-    ] .
+    ] ;
+  hydra:supportedProperty
+    [
+      a
+        hydra:SupportedProperty ;
+      hydra:property
+        cc:cubeGraph ;
+    ] ;
+.
 
 cc:csvMapping
   a
@@ -92,3 +101,25 @@ cc:ProjectsCollection
 <shape/cube-project/update>
   a
     sh:Shape .
+
+cc:cubeGraph
+  a
+    rdf:Property,
+    hydra:Link ;
+  hydra:supportedOperation
+    [
+      a
+        hydra:Operation ;
+      hydra:title
+        "Describe a resource inside the cube data" ;
+      hydra:method
+        "GET" ;
+      code:implementedBy
+        [
+          a
+            code:EcmaScript ;
+          code:link
+            <file:handlers/cube-data#get> ;
+        ] ;
+    ] ;
+.

--- a/apis/core/lib/domain/queries/cube-data.ts
+++ b/apis/core/lib/domain/queries/cube-data.ts
@@ -1,0 +1,9 @@
+import { NamedNode, Quad } from 'rdf-js'
+import { DESCRIBE } from '@tpluscode/sparql-builder'
+import { parsingClient } from '../../query-client'
+
+export async function describeResource(graph: NamedNode, resourceId: NamedNode, client = parsingClient): Promise<Quad[]> {
+  return DESCRIBE`${resourceId}`
+    .FROM(graph)
+    .execute(client.query)
+}

--- a/apis/core/lib/handlers/cube-data.ts
+++ b/apis/core/lib/handlers/cube-data.ts
@@ -1,0 +1,19 @@
+import * as error from 'http-errors'
+import { protectedResource } from '@hydrofoil/labyrinth/resource'
+import asyncMiddleware from 'middleware-async'
+import $rdf from 'rdf-ext'
+import { describeResource } from '../domain/queries/cube-data'
+
+export const get = protectedResource(asyncMiddleware(async (req, res, next) => {
+  const resourceUri = req.query.resource
+  if (!resourceUri || typeof resourceUri !== 'string') {
+    return next(new error.BadRequest("Missing 'resource' query parameter"))
+  }
+
+  const graph = req.hydra.term
+  const resourceId = $rdf.namedNode(resourceUri)
+
+  const quads = await describeResource(graph, resourceId)
+
+  return res.dataset($rdf.dataset(quads))
+}))

--- a/ui/src/components/TermDisplay.vue
+++ b/ui/src/components/TermDisplay.vue
@@ -1,6 +1,6 @@
 <template>
   <b-tooltip :label="displayFull" :active="displayShort !== displayFull">
-    {{ displayShort }}
+    {{ displayShort }}<span v-if="showLanguage && term.language" class="has-text-grey-light">@{{ term.language }}</span>
   </b-tooltip>
 </template>
 
@@ -12,6 +12,7 @@ import { shrink } from '@/rdf-properties'
 @Component
 export default class extends Vue {
   @Prop({ required: true }) term!: Term
+  @Prop({ default: false }) showLanguage!: boolean
 
   get displayShort (): string {
     if (this.term.termType === 'NamedNode') {

--- a/ui/src/views/ResourcePreview.vue
+++ b/ui/src/views/ResourcePreview.vue
@@ -15,7 +15,13 @@
         </td>
       </tr>
     </table>
-    <loading-block v-else />
+    <div v-else class="is-flex is-flex-direction-column has-text-grey is-align-items-center">
+      <loading-block />
+      <p>
+        We are aware that it is <em>really</em> slow at the moment.
+        It will get faster in a future version :)
+      </p>
+    </div>
   </side-pane>
 </template>
 


### PR DESCRIPTION
Display properties of a resource in Cube Preview.

One thing left to fix: the endpoint seems to load all cube data in memory, which makes it really slow. It's not related to the code of the handler (I tried with an empty handler).

Will close #358 