### PR TITLE
fix: performance of /dataset

### DIFF
--- a/apis/core/lib/domain/queries/cube.ts
+++ b/apis/core/lib/domain/queries/cube.ts
@@ -3,7 +3,7 @@ import { CONSTRUCT } from '@tpluscode/sparql-builder'
 import StreamClient from 'sparql-http-client/StreamClient'
 import { cc, cube } from '@cube-creator/core/namespace'
 import { Stream } from 'rdf-js'
-import { schema } from '@tpluscode/rdf-ns-builders'
+import { csvw, schema } from '@tpluscode/rdf-ns-builders'
 import { Readable } from 'stream'
 
 export function loadCubeShapes(dataset: GraphPointer, client: StreamClient): Promise<Stream & Readable> {
@@ -26,6 +26,11 @@ export function loadCubeShapes(dataset: GraphPointer, client: StreamClient): Pro
       ?s ?p ?o .
       ?cube ${cube.observationConstraint} ?shape .
 
+      # Exclude non-observation resources mapped from CSV rows
+      MINUS { ?s ${csvw.describes} ?o }
+      MINUS { ?s ^${csvw.describes} ?row }
+
+      # Exclude cube details from result
       MINUS { ?s a ${cube.Observation} }
       MINUS { ?s a ${cube.Cube} }
       MINUS { ?s a ${cube.ObservationSet} }

--- a/cli/lib/output-filter.ts
+++ b/cli/lib/output-filter.ts
@@ -3,9 +3,14 @@ import { csvw, rdf } from '@tpluscode/rdf-ns-builders'
 import { cc } from '@cube-creator/core/namespace'
 
 const csvwNs = csvw().value
+const csvwDescribes = csvw.describes
 
-function removeCsvwTriples(quad: Quad): boolean {
+function removeCsvwTriples(quad: Quad, keepCsvwDescribes: boolean): boolean {
   if (quad.predicate.value.startsWith(csvwNs)) {
+    if (quad.predicate.equals(csvwDescribes)) {
+      return keepCsvwDescribes
+    }
+
     return false
   }
   if (rdf.type.equals(quad.predicate) && quad.object.value.startsWith(csvwNs)) {
@@ -22,6 +27,10 @@ function removeDefaultProperties(quad: Quad): boolean {
   return !quad.predicate.value.startsWith('#')
 }
 
-export default function (quad: Quad): boolean {
-  return removeCsvwTriples(quad) && removeDefaultProperties(quad)
+export function fromTransformed(quad: Quad): boolean {
+  return removeCsvwTriples(quad, true) && removeDefaultProperties(quad)
+}
+
+export function fromPublished(quad: Quad): boolean {
+  return removeCsvwTriples(quad, false)
 }

--- a/cli/pipelines/main.ttl
+++ b/cli/pipelines/main.ttl
@@ -112,7 +112,7 @@
   a                  :Step ;
   code:implementedBy [ a         code:EcmaScript ;
                        code:link <node:barnard59-base#filter> ] ;
-  code:arguments     ( [ code:link <file:../lib/output-filter#default> ;
+  code:arguments     ( [ code:link <file:../lib/output-filter#fromTransformed> ;
                          a         code:EcmaScript ] ) .
 
 <#toDataset> a :Step;

--- a/cli/pipelines/publish.ttl
+++ b/cli/pipelines/publish.ttl
@@ -4,7 +4,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 <#Main> a :Pipeline ;
-  :steps [ :stepList ( <#loadGraphStep> <#injectCubeRevision> <#injectMetadata> <#streamOutputStep> ) ] .
+  :steps [ :stepList ( <#loadGraphStep> <#injectCubeRevision> <#injectMetadata> <#filter> <#streamOutputStep> ) ] .
 
 <#loadGraphStep>
   a                  :Step ;
@@ -43,6 +43,13 @@ _:get
   code:implementedBy [ code:link <file:../lib/metadata#injectMetadata> ;
                        a         code:EcmaScript ] ;
   code:arguments     ( "jobUri"^^:VariableName ) .
+
+<#filter>
+  a                  :Step ;
+  code:implementedBy [ a         code:EcmaScript ;
+  code:link <node:barnard59-base#filter> ] ;
+  code:arguments     ( [ code:link <file:../lib/output-filter#fromPublished> ;
+  a         code:EcmaScript ] ) .
 
 <#StreamOutput>
   a :Pipeline, :WritableObjectMode .

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai'
 import $rdf from 'rdf-ext'
 import { CONSTRUCT, SELECT } from '@tpluscode/sparql-builder'
 import debug from 'debug'
-import { dcat, dcterms, rdf, schema, sh, vcard, xsd } from '@tpluscode/rdf-ns-builders'
+import { csvw, dcat, dcterms, rdf, schema, sh, vcard, xsd } from '@tpluscode/rdf-ns-builders'
 import { setupEnv } from '../../support/env'
 import { client, parsingClient, insertTestData } from '@cube-creator/testing/lib'
 import { cc, cube, scale } from '@cube-creator/core/namespace'
@@ -230,6 +230,18 @@ describe('lib/commands/publish', function () {
           minCount: 1,
         },
       })
+    })
+
+    it('removes all csvw triples', async () => {
+      const distinctCsvwProps = await SELECT.DISTINCT`(count(distinct ?p) as ?count)`
+        .FROM($rdf.namedNode(`${env.API_CORE_BASE}cube-project/ubd/cube-data`))
+        .WHERE`
+          ?s ?p ?o .
+          filter (regex(str(?p), str(${csvw()})))
+        `
+        .execute(parsingClient.query)
+
+      expect(distinctCsvwProps[0].count.value).to.eq('0')
     })
   })
 })


### PR DESCRIPTION
If we don't find a better query to improve `loadCubeShapes`, this would fix #402 

**Problem**

The problem is that we want to fetch only the shapes from the generated cube graph but that graph contains many more triples: other cube metadata, observations, and mapped resources which are not observations

To exclude everything but the shape is not trivial because the shapes is heavy with blank nodes and rdf lists. A property path would work to get shape's subgraphs but support in Stardog appears buggy.

**Solution**

The way around it is to keep the `[] csvw:describes ?row` triples which allow removing everything which was mapped from CSV. That triple will then be removed for good when publishing.