### PR TITLE
fix: precalculate page links

### DIFF
--- a/apis/core/lib/domain/observations/index.ts
+++ b/apis/core/lib/domain/observations/index.ts
@@ -51,7 +51,8 @@ export async function getObservations({
     observations,
     templateParams,
     template,
-    totalItems: 0,
+    totalItems: 0, // TODO: query for the total number of observations
+    pageSize,
   })
 
   // Load labels for linked resources

--- a/apis/core/lib/domain/observations/lib/index.ts
+++ b/apis/core/lib/domain/observations/lib/index.ts
@@ -59,27 +59,30 @@ interface HydraCollectionParams {
   templateParams: GraphPointer
   observations: Record<string, Term>[]
   totalItems: number
+  pageSize: number
 }
 
-function pageId(template: IriTemplate, params: GraphPointer, pageIndexOffset?: number) {
+function pageId({ offset, page, template, ...rest }: { template: IriTemplate; templateParams: GraphPointer; page?: number; offset?: number }) {
   const templateParams = clownface({
-    dataset: $rdf.dataset([...params.dataset]),
-    term: params.term,
+    dataset: $rdf.dataset([...rest.templateParams.dataset]),
+    term: rest.templateParams.term,
   })
 
-  if (pageIndexOffset) {
+  if (page) {
+    templateParams.deleteOut(hydra.pageIndex).addOut(hydra.pageIndex, page)
+  } else if (offset) {
     const pageIndex = Number.parseInt(templateParams.out(hydra.pageIndex).value || '1')
     if (pageIndex === 1) {
       return undefined
     }
 
-    templateParams.deleteOut(hydra.pageIndex).addOut(hydra.pageIndex, pageIndex + pageIndexOffset)
+    templateParams.deleteOut(hydra.pageIndex).addOut(hydra.pageIndex, pageIndex + offset)
   }
 
   return $rdf.namedNode(new URL(template.expand(templateParams), env.API_CORE_BASE).toString())
 }
 
-export function createHydraCollection({ templateParams, template, observations, totalItems }: HydraCollectionParams): Collection {
+export function createHydraCollection({ templateParams, template, observations, totalItems, pageSize }: HydraCollectionParams): Collection {
   const collectionId = template.expand(
     clownface({ dataset: $rdf.dataset() }).blankNode()
       .addOut(cc.cube, templateParams.out(cc.cube))
@@ -89,14 +92,18 @@ export function createHydraCollection({ templateParams, template, observations, 
   const collectionPointer = clownface({ dataset: $rdf.dataset() })
     .namedNode(new URL(collectionId, env.API_CORE_BASE).toString())
 
+  const lastPage = Math.ceil(totalItems / pageSize)
+
   return new CollectionMixin.Class(collectionPointer, {
     member: observations,
     totalItems,
     view: {
       types: [hydra.PartialCollectionView],
-      id: pageId(template, templateParams),
-      next: pageId(template, templateParams, 1),
-      previous: pageId(template, templateParams, -1),
+      id: pageId({ template, templateParams }),
+      first: pageId({ template, templateParams, page: 1 }),
+      next: pageId({ template, templateParams, offset: 1 }),
+      previous: pageId({ template, templateParams, offset: -1 }),
+      last: pageId({ template, templateParams, page: lastPage }),
     },
   }) as any
 }

--- a/apis/core/test/domain/observations/lib/index.test.ts
+++ b/apis/core/test/domain/observations/lib/index.test.ts
@@ -220,6 +220,7 @@ describe('lib/domain/observations/lib', () => {
         template,
         observations,
         totalItems: 10,
+        pageSize: 1,
       })
 
       // then
@@ -233,6 +234,7 @@ describe('lib/domain/observations/lib', () => {
         template,
         observations,
         totalItems: 10,
+        pageSize: 1,
       })
 
       // then


### PR DESCRIPTION
Adds `next`/`previous` links to the collection which will remove the need for UI to manage the page index