### PR TITLE
Update hydra-box and labyrinth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ There are two types of e2e tests:
 
 Running the E2E tests can be done using: `docker-compose run --rm e2e-tests`, and `docker-compose run --rm e2e-tests -- --grep pattern` lets you select which tests to run.
 
+For brevity, use npm script `npm run test:e2e --grep pattern`
+
 ### UI e2e tests
 
 We use Cypress to run UI e2e tests.

--- a/apis/core/lib/handlers/cube-projects.ts
+++ b/apis/core/lib/handlers/cube-projects.ts
@@ -1,5 +1,4 @@
 import asyncMiddleware from 'middleware-async'
-import clownface from 'clownface'
 import { protectedResource } from '@hydrofoil/labyrinth/resource'
 import { shaclValidate } from '../middleware/shacl'
 import { createProject } from '../domain/cube-projects/create'
@@ -16,7 +15,7 @@ export const post = protectedResource(
     }
 
     const { pointer: project } = await createProject({
-      projectsCollection: clownface(req.hydra.resource),
+      projectsCollection: await req.hydra.resource.clownface(),
       resource: await req.resource(),
       user,
       store: req.resourceStore(),
@@ -32,7 +31,7 @@ export const post = protectedResource(
 export const put = protectedResource(
   shaclValidate,
   asyncMiddleware(async (req, res) => {
-    const project = clownface(req.hydra.resource)
+    const project = await req.hydra.resource.clownface()
     await updateProject({
       resource: await req.resource(),
       store: req.resourceStore(),

--- a/apis/core/lib/handlers/dataset.ts
+++ b/apis/core/lib/handlers/dataset.ts
@@ -15,7 +15,7 @@ export const put = protectedResource(
   shaclValidate,
   asyncMiddleware(async (req, res) => {
     const dataset = await update({
-      dataset: clownface(req.hydra.resource),
+      dataset: await req.hydra.resource.clownface(),
       resource: await req.resource(),
       store: req.resourceStore(),
     })
@@ -42,7 +42,7 @@ export const loadCubes: Enrichment = async (req, dataset) => {
     return
   }
 
-  dataset.any().has(rdf.type, cube.Cube).forEach(cube => {
+  clownface(dataset).any().has(rdf.type, cube.Cube).forEach(cube => {
     cube.addOut(cc.observations, template => {
       return new IriTemplateMixin.Class(template, {
         template: `${env.API_CORE_BASE}observations?cube=${encodeURIComponent(cube.value)}&graph=${encodeURIComponent(graph)}{&view,pageSize,page}`,

--- a/apis/core/lib/handlers/dimension.ts
+++ b/apis/core/lib/handlers/dimension.ts
@@ -4,7 +4,7 @@ import { shaclValidate } from '../middleware/shacl'
 import { update } from '../domain/dimension/update'
 
 export const get = protectedResource(asyncMiddleware((req, res) => {
-  return res.dataset(req.hydra.resource.dataset)
+  return res.quadStream(req.hydra.resource.quadStream())
 }))
 
 export const put = protectedResource(

--- a/apis/core/lib/handlers/table/create.ts
+++ b/apis/core/lib/handlers/table/create.ts
@@ -12,7 +12,7 @@ export const post = protectedResource(
   shaclValidate,
   asyncMiddleware(async (req, res) => {
     const table = await createTable({
-      tableCollection: clownface(req.hydra.resource),
+      tableCollection: await req.hydra.resource.clownface(),
       resource: await req.resource(),
       store: req.resourceStore(),
     })

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@cube-creator/core": "*",
     "@cube-creator/model": "*",
-    "@hydrofoil/labyrinth": "^0.2",
+    "@hydrofoil/labyrinth": "^0.3",
     "@rdfine/csvw": "^0.6.3",
     "@rdfine/hydra": "^0.6.4",
     "@rdfine/schema": "^0.6.3",
@@ -42,7 +42,7 @@
     "http-errors": "^1.8.0",
     "http-problem-details": "^0.1.5",
     "http-problem-details-mapper": "^0.1.6",
-    "hydra-box": "zazuko/hydra-box",
+    "hydra-box": "^0.6.1",
     "is-stream": "^2",
     "is-uri": "^1.2.0",
     "jwks-rsa": "^1.9.0",

--- a/apis/core/test/middleware/operations.test.ts
+++ b/apis/core/test/middleware/operations.test.ts
@@ -19,8 +19,13 @@ describe('lib/middleware/operations', () => {
   }
 
   beforeEach(() => {
+    const dataset = $rdf.dataset()
     resource = {
-      dataset: $rdf.dataset(),
+      prefetchDataset: dataset,
+      dataset: async () => dataset,
+      quadStream() {
+        return dataset.toStream()
+      },
       term: ex.resource,
       types: new TermSet(),
     }

--- a/apis/core/test/middleware/resource.test.ts
+++ b/apis/core/test/middleware/resource.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai'
 import request from 'supertest'
 import express from 'express'
 import $rdf from 'rdf-ext'
+import clownface from 'clownface'
 import { turtle } from '@tpluscode/rdf-string'
 import { cc } from '@cube-creator/core/namespace'
 import { rdfs } from '@tpluscode/rdf-ns-builders'
@@ -13,11 +14,19 @@ describe('middleware/resource', () => {
   it('returns pointer to empty named node if the request term does not appear in body', async function () {
     // given
     const app = express()
+    const dataset = $rdf.dataset()
     app.use(appMock(hydra => {
       hydra.resource = {
         term: $rdf.namedNode('http://example.com/foo/bar'),
         types: new Set(),
-        dataset: $rdf.dataset(),
+        prefetchDataset: dataset,
+        dataset: async () => dataset,
+        quadStream() {
+          return dataset.toStream()
+        },
+        async clownface() {
+          return clownface({ dataset }).node(this.term)
+        },
       }
     }))
     app.use(resource)

--- a/apis/core/types/hydra-box/index.d.ts
+++ b/apis/core/types/hydra-box/index.d.ts
@@ -1,13 +1,15 @@
 declare module 'hydra-box' {
   import { Request, RequestHandler, Router } from 'express'
   import Api = require('hydra-box/Api');
-  import { DatasetCore, Term, NamedNode } from 'rdf-js'
+  import { DatasetCore, Term, NamedNode, Stream } from 'rdf-js'
   import type { GraphPointer } from 'clownface'
 
   namespace hydraBox {
     interface ObjectResource {
-      term: Term
-      dataset: DatasetCore
+      term: NamedNode
+      prefetchDataset: DatasetCore
+      dataset(): Promise<DatasetCore>
+      quadStream(): Stream
       types: Set<Term>
     }
 
@@ -21,16 +23,17 @@ declare module 'hydra-box' {
       forPropertyOperation (term: Term, req: Request): Promise<Array<PropertyResource>>
     }
 
+    interface PotentialOperation {
+      resource: ObjectResource | PropertyResource
+      operation: GraphPointer
+    }
+
     interface HydraBox {
       api: Api
       term: NamedNode
-      resource: {
-        term: NamedNode
-        dataset: DatasetCore
-        types: Set<NamedNode>
-      }
+      resource: ObjectResource & { clownface(): Promise<GraphPointer<NamedNode>> }
       operation: GraphPointer
-      operations: { resource: ObjectResource; operation: GraphPointer }[]
+      operations: PotentialOperation[]
     }
 
     interface Options {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "lint": "eslint . --ext .ts,.vue,.tsx --quiet --ignore-path .gitignore",
     "test": "c8 -o coverage/apis mocha --recursive apis/**/*.test.ts",
     "test:cli": "c8 -o coverage/cli mocha --recursive cli/**/*.test.ts",
+    "test:e2e": "docker-compose run --rm e2e-tests --",
     "seed-data": "dotenv -e .local.env -- bash -c \"ts-node packages/testing/index.ts -i fuseki/sample-ubd.trig\""
   },
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,10 +1169,10 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@hydrofoil/labyrinth@^0.2":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@hydrofoil/labyrinth/-/labyrinth-0.2.0.tgz#1cc72d7cf1007fd58d4f154c019e7cee9ddf8d62"
-  integrity sha512-0WELTDT4QQXE9O0yQIuxVhQ8sVUQxFKGsO9LqHe5Z5HS27UO//AgaLyUYFsvCujsFIvmQxYYjM4ogwdF4cRW3g==
+"@hydrofoil/labyrinth@^0.3":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@hydrofoil/labyrinth/-/labyrinth-0.3.0.tgz#4d4cb9c35f04757843f39855c8d7cc69e5628fa3"
+  integrity sha512-480Oxg+glMbZXtJnOIKHQy9xfUtbkSTVUHH4USB5ToA4lpsQRrkNSm2+n8TcFqwBZEX1Orv1Zq/diOVDaK/hmQ==
   dependencies:
     "@fcostarodrigo/walk" "^5.0.0"
     "@rdfine/hydra" "^0.6"
@@ -1194,6 +1194,7 @@
     http-problem-details "^0.1.5"
     http-problem-details-mapper "^0.1.7"
     middleware-async "^1.2.7"
+    once "^1.4.0"
     rdf-ext "^1.3.0"
     rdf-loader-code "^0.3.1"
     rdf-loaders-registry "^0.2.0"
@@ -7267,9 +7268,10 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-hydra-box@zazuko/hydra-box:
-  version "0.5.1"
-  resolved "https://codeload.github.com/zazuko/hydra-box/tar.gz/14cdcee86662c0c59eea1ab0f0bddaffca7e264b"
+hydra-box@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/hydra-box/-/hydra-box-0.6.1.tgz#a43aab80feffbde5a38d8888b6439558ee9e4472"
+  integrity sha512-dazD3Y7N0yMoFUTNwdL9ROCcVH/ioxz0HFcL7bzW5xzxOtsJI9HGSHW5k8u45VxQ7fGD//jFr29mf0G2FUQEmg==
   dependencies:
     "@rdfjs/data-model" "^1.1.2"
     "@rdfjs/dataset" "^1.0.1"


### PR DESCRIPTION
This will improve the performance of API requests by optimising the loading of resources:

1. `hydra-box`/`labyrinth` only loads minimal triples necessary to find operations and not entire graphs
   - complete representation available as `async req.hydra.resource.dataset()`, `req.hydra.resource.quadStream()` and `async req.hydra.resource.clownface()`
2. `labyrinth` combines what previously was multiple queries into a single SELECT to reduce SPARQL round-trips