### PR TITLE
fix: dimension metadata not published

### DIFF
--- a/cli/lib/cube.ts
+++ b/cli/lib/cube.ts
@@ -26,6 +26,8 @@ export function injectRevision(this: Pick<Context, 'variables' | 'log'>) {
   const revision = this.variables.get('revision')
   const previousCubes = new TermMap<Term, QuadSubject>()
   this.variables.set('previousCubes', previousCubes)
+  const mappedTerms = new TermMap<Term, Term>()
+  this.variables.set('mappedCubeTerms', mappedTerms)
 
   this.log.info(`Cube revision ${revision}`)
 
@@ -35,7 +37,9 @@ export function injectRevision(this: Pick<Context, 'variables' | 'log'>) {
 
   function rebase<T extends Term>(term: T, rev = revision): T {
     if (term.termType === 'NamedNode' && term.value.startsWith(cubeNamespace)) {
-      return $rdf.namedNode(term.value.replace(new RegExp(`^${cubeNamespace}/?`), `${cubeNamespace}/${rev}/`)) as any
+      const newTerm = $rdf.namedNode(term.value.replace(new RegExp(`^${cubeNamespace}/?`), `${cubeNamespace}/${rev}/`)) as any
+      mappedTerms.set(newTerm, term)
+      return newTerm
     }
 
     return term

--- a/cli/lib/metadata.ts
+++ b/cli/lib/metadata.ts
@@ -43,6 +43,7 @@ export async function injectMetadata(this: Context, jobUri: string) {
   const datasetTriples = dataset.pointer.dataset.match(null, null, null, dataset.id)
   const previousCubes = this.variables.get('previousCubes')
   const timestamp = this.variables.get('timestamp')
+  const mappedCubeTerms = this.variables.get('mappedCubeTerms')
 
   return obj(function (quad: Quad, _, callback) {
     const visited = new TermSet()
@@ -83,15 +84,18 @@ export async function injectMetadata(this: Context, jobUri: string) {
 
     // Dimension Metadata
     if (quad.predicate.equals(sh.path)) {
-      [...datasetTriples.match(null, schema.about, quad.object)].forEach(dim => {
-        [...datasetTriples.match(dim.subject)]
-          .filter(c => !c.predicate.equals(schema.about))
-          .forEach(item2 => {
-            this.push($rdf.triple(quad.subject, item2.predicate, item2.object))
-            visited.add(quad.subject)
-            copyChildren(item2.object)
-          })
-      })
+      const baseDimensionId = mappedCubeTerms.get(quad.object)
+      if (baseDimensionId) {
+        [...datasetTriples.match(null, schema.about, baseDimensionId)].forEach(dim => {
+          [...datasetTriples.match(dim.subject)]
+            .filter(c => !c.predicate.equals(schema.about))
+            .forEach(item2 => {
+              this.push($rdf.triple(quad.subject, item2.predicate, item2.object))
+              visited.add(quad.subject)
+              copyChildren(item2.object)
+            })
+        })
+      }
     }
 
     this.push(quad)

--- a/cli/lib/variables.ts
+++ b/cli/lib/variables.ts
@@ -18,5 +18,6 @@ declare module 'barnard59-core/lib/Pipeline' {
     previousCubes: Map<Term, QuadSubject>
     isObservationTable: boolean
     graph: string
+    mappedCubeTerms: Map<Term, Term>
   }
 }

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -207,15 +207,16 @@ describe('lib/commands/publish', function () {
         },
       })
 
-      expect(cubePointer.namedNode(targetCube('shape/')).out(sh.property).has(sh.path, ns.baseCube('dimension/year'))).to.matchShape({
+      const props = cubePointer.namedNode(targetCube('shape/')).out(sh.property)
+      expect(props.has(sh.path, targetCube('dimension/year'))).to.matchShape({
         property: {
           path: sh.path,
-          hasValue: ns.baseCube('dimension/year'),
+          hasValue: targetCube('dimension/year'),
           minCount: 1,
         },
       })
 
-      expect(cubePointer.namedNode(targetCube('shape/')).out(sh.property).has(sh.path, schema.name)).to.matchShape({
+      expect(props.has(sh.path).has(schema.name)).to.matchShape({
         property: {
           path: schema.name,
           hasValue: $rdf.literal('Jahr', 'de'),
@@ -223,7 +224,7 @@ describe('lib/commands/publish', function () {
         },
       })
 
-      expect(cubePointer.namedNode(targetCube('shape/')).out(sh.property).has(sh.path, scale.scaleOfMeasure)).to.matchShape({
+      expect(props.has(sh.path).has(scale.scaleOfMeasure)).to.matchShape({
         property: {
           path: scale.scaleOfMeasure,
           hasValue: scale.Temporal,

--- a/packages/testing/lib/chaiShapeMatcher.ts
+++ b/packages/testing/lib/chaiShapeMatcher.ts
@@ -62,6 +62,10 @@ chai.Assertion.addMethod('matchShape', function (shapeInit: Initializer<NodeShap
     throw new Error(`Cannot match given object to a SHACL Shape. Expecting a rdfine object, graph pointer or RDF/JS dataset. Got ${obj?.constructor.name}`)
   }
 
+  if (!targetNode.length) {
+    throw new Error('No nodes found to validate in data graph')
+  }
+
   const shape = new NodeShapeMixin.Class(
     clownface({ dataset: $rdf.dataset() }).blankNode(),
     { ...shapeInit, targetNode })


### PR DESCRIPTION
The problem was that the pipeline looked up metadata by wrong identifiers, because of cube revision being injected into the URIs

This went unnoticed because the shape check returned false positive when there was nothing to validate in the input pointer.