### PR TITLE
Support multi-level linked resources in cube preview

### DIFF
--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -16,7 +16,7 @@
                 </div>
               </div>
               <div class="level-right">
-                <b-select v-model="selectedLanguage" class="level-item" title="Language">
+                <b-select :value="selectedLanguage" @input="$emit('selectLanguage', $event)" class="level-item" title="Language">
                   <option v-for="language in languages" :key="language" :value="language">
                     {{ language }}
                   </option>
@@ -127,11 +127,11 @@ const languages = ['en', 'fr', 'de', 'it']
   },
 })
 export default class extends Vue {
-  @Prop() cubeMetadata!: Dataset
-  @Prop() dimensions!: DimensionMetadata[]
+  @Prop({ required: true }) cubeMetadata!: Dataset
+  @Prop({ required: true }) dimensions!: DimensionMetadata[]
+  @Prop({ required: true }) selectedLanguage!: string
 
   languages = languages
-  selectedLanguage = 'en'
   pageSize = 10
   page = 1
   pageSizes = [10, 20, 50, 100]

--- a/ui/src/components/CubePreviewValue.vue
+++ b/ui/src/components/CubePreviewValue.vue
@@ -8,7 +8,7 @@
     </term-with-language>
   </router-link>
   <span v-else-if="isTerm">
-    <term-display :term="value" :base="cubeUri" />
+    <term-display :term="value" :base="cubeUri" :show-language="showLanguage" />
   </span>
   <span v-else class="has-background-danger-light">
     Cannot display value
@@ -33,6 +33,7 @@ export default class extends Vue {
   @Prop({ default: '' }) missingValue?: string
   @Prop({ required: true }) selectedLanguage!: string
   @Prop({ required: true }) cubeUri!: string
+  @Prop({ default: false }) showLanguage!: boolean
 
   get label (): Term[] {
     if (!isResource(this.value)) return []

--- a/ui/src/store/modules/project.ts
+++ b/ui/src/store/modules/project.ts
@@ -43,6 +43,7 @@ export interface ProjectState {
   cubeMetadata: null | Dataset,
   dimensionMetadataCollection: null | DimensionMetadataCollection,
   jobCollection: null | JobCollection,
+  selectedLanguage: string,
 }
 
 const initialState = {
@@ -56,6 +57,7 @@ const initialState = {
   cubeMetadata: null,
   dimensionMetadataCollection: null,
   jobCollection: null,
+  selectedLanguage: 'en',
 }
 
 const getters: GetterTree<ProjectState, RootState> = {
@@ -262,6 +264,10 @@ const actions: ActionTree<ProjectState, RootState> = {
 
     return collection
   },
+
+  selectLanguage (context, language) {
+    context.commit('storeSelectedLanguage', language)
+  },
 }
 
 const mutations: MutationTree<ProjectState> = {
@@ -326,6 +332,10 @@ const mutations: MutationTree<ProjectState> = {
   storeJobCollection (state, collection) {
     state.jobCollection = collection ? serializeJobCollection(collection) : null
   },
+
+  storeSelectedLanguage (state, language) {
+    state.selectedLanguage = language
+  }
 }
 
 export default {

--- a/ui/src/views/CubeDesigner.vue
+++ b/ui/src/views/CubeDesigner.vue
@@ -3,6 +3,8 @@
     <CubePreview
       :cube-metadata="cubeMetadata"
       :dimensions="dimensions"
+      :selected-language="selectedLanguage"
+      @selectLanguage="selectLanguage"
     />
 
     <router-view :key="$route.fullPath" />
@@ -24,12 +26,17 @@ const projectNS = namespace('project')
 })
 export default class CubeDesignerView extends Vue {
   @projectNS.State('cubeMetadata') cubeMetadata!: Dataset | null
+  @projectNS.State('selectedLanguage') selectedLanguage!: string
   @projectNS.State('dimensionMetadataCollection') dimensionMetadataCollection!: DimensionMetadataCollection | null
   @projectNS.Getter('dimensions') dimensions!: DimensionMetadata[]
 
   async mounted (): Promise<void> {
     await this.$store.dispatch('project/fetchCubeMetadata')
     this.$store.dispatch('project/fetchDimensionMetadataCollection')
+  }
+
+  selectLanguage (language: string): void {
+    this.$store.dispatch('project/selectLanguage', language)
   }
 }
 </script>

--- a/ui/src/views/ResourcePreview.vue
+++ b/ui/src/views/ResourcePreview.vue
@@ -53,7 +53,7 @@ const projectNS = namespace('project')
 export default class ResourcePreview extends Vue {
   @projectNS.State('project') project!: Project | null
   @projectNS.State('cubeMetadata') cubeMetadata!: Dataset | null
-  selectedLanguage = 'en' // TODO: Get from store
+  @projectNS.State('selectedLanguage') selectedLanguage!: string
 
   get cubeUri (): string | undefined {
     return this.cubeMetadata?.hasPart[0]?.id.value

--- a/ui/src/views/ResourcePreview.vue
+++ b/ui/src/views/ResourcePreview.vue
@@ -10,7 +10,12 @@
         </td>
         <td>
           <p v-for="(object, objectIndex) in objects" :key="objectIndex">
-            <term-display :term="object" :show-language="true" :base="cubeUri" />
+            <cube-preview-value
+              :value="object"
+              :cube-uri="cubeUri"
+              :selected-language="selectedLanguage"
+              :show-language="true"
+            />
           </p>
         </td>
       </tr>
@@ -36,16 +41,19 @@ import { Dataset, Project } from '@cube-creator/model'
 import SidePane from '@/components/SidePane.vue'
 import LoadingBlock from '@/components/LoadingBlock.vue'
 import TermDisplay from '@/components/TermDisplay.vue'
+import CubePreviewValue from '@/components/CubePreviewValue.vue'
 import { api } from '@/api'
+import RdfResource from '@tpluscode/rdfine/RdfResource'
 
 const projectNS = namespace('project')
 
 @Component({
-  components: { LoadingBlock, SidePane, TermDisplay },
+  components: { CubePreviewValue, LoadingBlock, SidePane, TermDisplay },
 })
 export default class ResourcePreview extends Vue {
   @projectNS.State('project') project!: Project | null
   @projectNS.State('cubeMetadata') cubeMetadata!: Dataset | null
+  selectedLanguage = 'en' // TODO: Get from store
 
   get cubeUri (): string | undefined {
     return this.cubeMetadata?.hasPart[0]?.id.value
@@ -53,7 +61,7 @@ export default class ResourcePreview extends Vue {
 
   resourceId = $rdf.namedNode(this.$route.params.resourceId)
   resource: GraphPointer | null = null
-  properties: [Term, Term[]][] = []
+  properties: [Term, (Term | RdfResource)[]][] = []
 
   async mounted (): Promise<void> {
     const cubeGraph = this.project?.cubeGraph
@@ -68,7 +76,17 @@ export default class ResourcePreview extends Vue {
     const resourcePredicates = new TermSet(resourceQuads.map(({ predicate }) => predicate))
 
     this.resource = resource
-    this.properties = [...resourcePredicates].map((predicate) => [predicate, resource.out(predicate).terms])
+    this.properties = [...resourcePredicates].map((predicate) => {
+      const values = resource.out(predicate).map((pointer: GraphPointer) => {
+        if (pointer.term.termType === 'NamedNode') {
+          return RdfResource.factory.createEntity(pointer)
+        } else {
+          return pointer.term
+        }
+      })
+
+      return [predicate, values]
+    })
   }
 
   onCancel (): void {


### PR DESCRIPTION
When clicking on a linked resource in the cube preview, it opens up a pane to preview the resource properties. If these properties contain links to other resources, it is now possible to also click on them to preview the linked resource.

As a side-effect, this will also fix #289