### PR TITLE
Feat/overwrite csv

### DIFF
--- a/apis/core/hydra/csv-source.ttl
+++ b/apis/core/hydra/csv-source.ttl
@@ -74,6 +74,7 @@ cc:CSVSource
       a
         hydra:Operation,
         schema:UpdateAction ;
+        
       hydra:title
         "Edit CSV settings" ;
       hydra:method
@@ -87,6 +88,22 @@ cc:CSVSource
             code:EcmaScript ;
           code:link
             <file:handlers/csv-source#put> ;
+        ]
+    ],
+    [
+      a
+        hydra:Operation,
+          cc:ReplaceCSVAction ;
+      hydra:title
+        "Replace CSV-File" ;
+      hydra:method
+        "PATCH" ;
+      code:implementedBy
+        [
+          a
+            code:EcmaScript ;
+          code:link
+            <file:handlers/csv-source#replace> ;
         ]
     ] ;
 .

--- a/apis/core/lib/domain/csv-source/replace.ts
+++ b/apis/core/lib/domain/csv-source/replace.ts
@@ -1,0 +1,70 @@
+import { GraphPointer } from 'clownface'
+import { Readable } from 'stream'
+import { NamedNode } from 'rdf-js'
+import * as s3 from '../../storage/s3'
+import { ResourceStore } from '../../ResourceStore'
+import { loadFileHeadString } from '../csv/file-head'
+import { parse } from '../csv'
+import { CsvSource } from '@cube-creator/model'
+import { nanoid } from 'nanoid'
+import { updateColumns } from './update'
+import { DomainError } from '../../errors'
+
+interface ReplaceCSVCommand {
+  file: Readable | Buffer
+  resource: NamedNode
+  store: ResourceStore
+  fileStorage?: s3.FileStorage
+}
+
+export async function replaceFile({
+  file,
+  resource,
+  store,
+  fileStorage = s3,
+}: ReplaceCSVCommand): Promise<GraphPointer> {
+  const csvSource = await store.getResource<CsvSource>(resource)
+
+  const key = csvSource.associatedMedia.identifierLiteral
+  if (!key) {
+    throw new DomainError('S3 key is missing for')
+  }
+
+  const tempKey = `temp/${nanoid()}`
+
+  // Upload file to temp location
+  await fileStorage.saveFile(tempKey, file)
+
+  try {
+    // Check header
+    const fileStream = await fileStorage.loadFile(tempKey) as Readable
+    const head = await loadFileHeadString(fileStream)
+
+    const parserOptions = {
+      to: 1,
+      ...csvSource.dialect,
+    }
+
+    const { header } = await parse(head, parserOptions)
+
+    csvSource.columns.forEach(column => {
+      if (!header.includes(column.name)) {
+        throw new DomainError(`The column ${column.name} is missing!`)
+      }
+    })
+
+    // copy new
+    const tempFile = await fileStorage.loadFile(tempKey)
+    if (!tempFile) {
+      throw new Error('File not found')
+    }
+    await fileStorage.saveFile(key, tempFile)
+  } finally {
+    await fileStorage.deleteFile(tempKey)
+  }
+
+  // call update
+  await updateColumns(csvSource, fileStorage)
+
+  return csvSource.pointer
+}

--- a/apis/core/lib/domain/csv-source/replace.ts
+++ b/apis/core/lib/domain/csv-source/replace.ts
@@ -7,7 +7,7 @@ import { loadFileHeadString } from '../csv/file-head'
 import { parse } from '../csv'
 import { CsvSource } from '@cube-creator/model'
 import { nanoid } from 'nanoid'
-import { updateColumns } from './update'
+import { createOrUpdateColumns } from './update'
 import { DomainError } from '../../errors'
 
 interface ReplaceCSVCommand {
@@ -27,7 +27,7 @@ export async function replaceFile({
 
   const key = csvSource.associatedMedia.identifierLiteral
   if (!key) {
-    throw new DomainError('S3 key is missing for')
+    throw new DomainError(`S3 key is missing for ${resource}`)
   }
 
   const tempKey = `temp/${nanoid()}`
@@ -65,7 +65,7 @@ export async function replaceFile({
   }
 
   // call update
-  await updateColumns(csvSource, fileStorage)
+  await createOrUpdateColumns(csvSource, fileStorage)
 
   return csvSource.pointer
 }

--- a/apis/core/lib/domain/csv-source/replace.ts
+++ b/apis/core/lib/domain/csv-source/replace.ts
@@ -42,16 +42,17 @@ export async function replaceFile({
 
     const parserOptions = {
       to: 1,
-      ...csvSource.dialect,
+      bom: true,
+      delimiter: csvSource.dialect.delimiter,
+      quote: csvSource.dialect.quoteChar,
     }
 
     const { header } = await parse(head, parserOptions)
 
-    csvSource.columns.forEach(column => {
-      if (!header.includes(column.name)) {
-        throw new DomainError(`The column ${column.name} is missing!`)
-      }
-    })
+    const missingColumns = csvSource.columns.filter((column) => !header.includes(column.name)).map((column) => column.name)
+    if (missingColumns.length > 0) {
+      throw new DomainError(`The columns "${missingColumns.toString()}" are missing in this file`)
+    }
 
     // copy new
     const tempFile = await fileStorage.loadFile(tempKey)

--- a/apis/core/lib/domain/csv-source/update.ts
+++ b/apis/core/lib/domain/csv-source/update.ts
@@ -27,29 +27,37 @@ export async function update({
 
   csvSource.name = changed.name
   if (csvSource.setDialect(changed.dialect) && csvSource.associatedMedia.identifierLiteral) {
-    try {
-      csvSource.pointer.deleteOut(schema.error)
-      csvSource.columns = []
-
-      const fileStream = await fileStorage.loadFile(csvSource.associatedMedia.identifierLiteral) as Readable
-      const head = await loadFileHeadString(fileStream, 500)
-      const { header, rows } = await parse(head, {
-        delimiter: csvSource.dialect.delimiter,
-        quote: csvSource.dialect.quoteChar,
-      })
-
-      const sampleCol = sampleValues(header, rows)
-
-      for (let index = 0; index < header.length; index++) {
-        const name = header[index]
-        const column = csvSource.appendColumn({ name })
-        column.samples = sampleCol[index]
-      }
-    } catch (err) {
-      error(err)
-      csvSource.pointer.addOut(schema.error, err.message)
-    }
+    await updateColumns(csvSource, fileStorage)
   }
 
   return csvSource.pointer
+}
+
+export async function updateColumns(csvSource: CsvSource, fileStorage: s3.FileStorage): Promise<void> {
+  try {
+    if (!csvSource.associatedMedia.identifierLiteral) {
+      throw new Error('Key to file missing')
+    }
+
+    csvSource.pointer.deleteOut(schema.error)
+    csvSource.columns = []
+
+    const fileStream = await fileStorage.loadFile(csvSource.associatedMedia.identifierLiteral) as Readable
+    const head = await loadFileHeadString(fileStream, 500)
+    const { header, rows } = await parse(head, {
+      delimiter: csvSource.dialect.delimiter,
+      quote: csvSource.dialect.quoteChar,
+    })
+
+    const sampleCol = sampleValues(header, rows)
+
+    for (let index = 0; index < header.length; index++) {
+      const name = header[index]
+      const column = csvSource.appendColumn({ name })
+      column.samples = sampleCol[index]
+    }
+  } catch (err) {
+    error(err)
+    csvSource.pointer.addOut(schema.error, err.message)
+  }
 }

--- a/apis/core/lib/domain/csv-source/update.ts
+++ b/apis/core/lib/domain/csv-source/update.ts
@@ -45,6 +45,7 @@ export async function updateColumns(csvSource: CsvSource, fileStorage: s3.FileSt
     const fileStream = await fileStorage.loadFile(csvSource.associatedMedia.identifierLiteral) as Readable
     const head = await loadFileHeadString(fileStream, 500)
     const { header, rows } = await parse(head, {
+      bom: true,
       delimiter: csvSource.dialect.delimiter,
       quote: csvSource.dialect.quoteChar,
     })

--- a/apis/core/lib/domain/csv-source/update.ts
+++ b/apis/core/lib/domain/csv-source/update.ts
@@ -27,20 +27,20 @@ export async function update({
 
   csvSource.name = changed.name
   if (csvSource.setDialect(changed.dialect) && csvSource.associatedMedia.identifierLiteral) {
-    await updateColumns(csvSource, fileStorage)
+    csvSource.pointer.deleteOut(schema.error)
+    csvSource.columns = []
+
+    await createOrUpdateColumns(csvSource, fileStorage)
   }
 
   return csvSource.pointer
 }
 
-export async function updateColumns(csvSource: CsvSource, fileStorage: s3.FileStorage): Promise<void> {
+export async function createOrUpdateColumns(csvSource: CsvSource, fileStorage: s3.FileStorage): Promise<void> {
   try {
     if (!csvSource.associatedMedia.identifierLiteral) {
       throw new Error('Key to file missing')
     }
-
-    csvSource.pointer.deleteOut(schema.error)
-    csvSource.columns = []
 
     const fileStream = await fileStorage.loadFile(csvSource.associatedMedia.identifierLiteral) as Readable
     const head = await loadFileHeadString(fileStream, 500)
@@ -54,7 +54,7 @@ export async function updateColumns(csvSource: CsvSource, fileStorage: s3.FileSt
 
     for (let index = 0; index < header.length; index++) {
       const name = header[index]
-      const column = csvSource.appendColumn({ name })
+      const column = csvSource.appendOrUpdateColumn({ name, order: index })
       column.samples = sampleCol[index]
     }
   } catch (err) {

--- a/apis/core/lib/domain/csv-source/upload.ts
+++ b/apis/core/lib/domain/csv-source/upload.ts
@@ -58,7 +58,7 @@ export async function uploadFile({
 
     for (let index = 0; index < header.length; index++) {
       const name = header[index]
-      const column = csvSource.appendColumn({ name })
+      const column = csvSource.appendOrUpdateColumn({ name, order: index })
       column.samples = sampleCol[index]
     }
   } catch (err) {

--- a/apis/core/lib/handlers/csv-source.ts
+++ b/apis/core/lib/handlers/csv-source.ts
@@ -9,6 +9,7 @@ import { cc } from '@cube-creator/core/namespace'
 import { deleteSource } from '../domain/csv-source/delete'
 import { update } from '../domain/csv-source/update'
 import { getPresignedLink, setPresignedLink } from '../domain/csv-source/lib/getDownloadLink'
+import { replaceFile } from '../domain/csv-source/replace'
 
 export const post = labyrinth.protectedResource(
   shaclValidate,
@@ -89,5 +90,21 @@ export const remove = labyrinth.protectedResource(
     await req.resourceStore().save()
 
     res.sendStatus(204)
+  }),
+)
+
+export const replace = labyrinth.protectedResource(
+  shaclValidate,
+  asyncMiddleware(async (req, res) => {
+    const csvSource = await replaceFile({
+      file: req,
+      resource: req.hydra.resource.term,
+      store: req.resourceStore(),
+    })
+    await req.resourceStore().save()
+
+    setPresignedLink(csvSource)
+
+    await res.dataset(csvSource.dataset)
   }),
 )

--- a/apis/core/test/domain/csv-source/replace.test.ts
+++ b/apis/core/test/domain/csv-source/replace.test.ts
@@ -54,7 +54,7 @@ describe('domain/csv-sources/replace', () => {
             .addOut(schema.name, 'unit_id')
             .addOut(dtype.order, 0)
         })
-        .addOut(csvw.column, $rdf.namedNode('column/unit_name_de') ,column => {
+        .addOut(csvw.column, $rdf.namedNode('column/unit_name_de'), column => {
           column.addOut(rdf.type, csvw.Column)
             .addOut(schema.name, 'unit_name_de')
             .addOut(dtype.order, 1)

--- a/apis/core/test/domain/csv-source/replace.test.ts
+++ b/apis/core/test/domain/csv-source/replace.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, beforeEach } from 'mocha'
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+import $rdf from 'rdf-ext'
+import * as fs from 'fs'
+import * as path from 'path'
+import { cc } from '@cube-creator/core/namespace'
+import { NamedNode } from 'rdf-js'
+import DatasetExt from 'rdf-ext/lib/Dataset'
+import { csvw, dtype, rdf, schema, sh, xsd } from '@tpluscode/rdf-ns-builders'
+import { TestResourceStore } from '../../support/TestResourceStore'
+import clownface, { GraphPointer } from 'clownface'
+import type { FileStorage } from '../../../lib/storage/s3'
+import { replaceFile } from '../../../lib/domain/csv-source/replace'
+import { DomainError } from '../../../lib/errors'
+
+describe('domain/csv-sources/upload', () => {
+  let fileStorage: FileStorage
+  let csvSource: GraphPointer<NamedNode, DatasetExt>
+  let csvMapping: GraphPointer<NamedNode, DatasetExt>
+
+  beforeEach(() => {
+    const getfileStream = () => fs.createReadStream(path.resolve(__dirname, '../../fixtures/CH_yearly_air_immission_unit_id.csv'))
+    fileStorage = {
+      loadFile: sinon.stub().callsFake(getfileStream),
+      saveFile: sinon.stub().resolves({ Location: 'file-location' }),
+      deleteFile: sinon.spy(),
+    }
+
+    csvMapping = clownface({ dataset: $rdf.dataset() })
+      .namedNode('csv-mapping')
+      .addOut(rdf.type, cc.CsvMapping)
+  })
+
+  describe('when source is successfully parsed', () => {
+    let csvSourceUpdate: GraphPointer
+    beforeEach(async () => {
+      // given
+      csvSource = clownface({ dataset: $rdf.dataset() })
+        .namedNode('source')
+        .addOut(rdf.type, cc.CSVSource)
+        .addOut(schema.name, 'Name')
+        .addOut(csvw.dialect, dialect => {
+          dialect.addOut(csvw.quoteChar, '"')
+          dialect.addOut(csvw.delimiter, ',')
+        })
+        .addOut(cc.csvMapping, csvMapping)
+        .addOut(schema.associatedMedia, file => {
+          file.addOut(schema.identifier, 'file.csv')
+            .addOut(schema.contentUrl, $rdf.namedNode('url.to.file'))
+        })
+        .addOut(csvw.column, column => {
+          column.addOut(schema.name, 'unit_id')
+            .addOut(dtype.order, 0)
+        })
+        .addOut(csvw.column, column => {
+          column.addOut(schema.name, 'unit_name_de')
+            .addOut(dtype.order, 1)
+        })
+        .addOut(csvw.column, column => {
+          column.addOut(schema.name, 'unit_name_fr')
+            .addOut(dtype.order, 2)
+        })
+
+      const file = Buffer.alloc(0)
+      const store = new TestResourceStore([
+        csvSource,
+      ])
+
+      // when
+      csvSourceUpdate = await replaceFile({
+        resource: csvSource.term,
+        store,
+        file,
+        fileStorage,
+      })
+    })
+
+    it('source graph is not touched', () => {
+      expect(csvSourceUpdate).to.matchShape({
+        property: [{
+          path: rdf.type,
+          [sh.hasValue.value]: [cc.CSVSource],
+          minCount: 1,
+        }, {
+          path: schema.name,
+          hasValue: 'Name',
+          minCount: 1,
+        }, {
+          path: cc.csvMapping,
+          hasValue: csvMapping,
+          minCount: 1,
+        }, {
+          path: schema.associatedMedia,
+          minCount: 1,
+          node: {
+            property: [
+              {
+                path: schema.identifier,
+                datatype: xsd.string,
+                hasValue: 'file.csv',
+                minCount: 1,
+                maxCount: 1,
+              }, {
+                path: schema.contentUrl,
+                nodeKind: sh.IRI,
+                hasValue: $rdf.namedNode('url.to.file'),
+                minCount: 1,
+                maxCount: 1,
+              }],
+          },
+        }],
+      })
+    })
+
+    it('File handler have been called', () => {
+      // save temp and save permanant
+      expect(fileStorage.saveFile).has.been.calledTwice
+      // read temp, copy file, read columns and sample
+      expect(fileStorage.loadFile).has.been.calledThrice
+      // delete old file, delete temp
+      expect(fileStorage.deleteFile).has.been.calledOnce
+    })
+
+    it('creates columns with samples', () => {
+      expect(csvSource).to.matchShape({
+        property: {
+          path: csvw.column,
+          minCount: 4,
+          maxCount: 4,
+          node: {
+            property: [{
+              path: rdf.type,
+              hasValue: csvw.Column,
+              minCount: 1,
+            }, {
+              path: schema.name,
+              minCount: 1,
+              maxCount: 1,
+            }, {
+              path: dtype.order,
+              datatype: xsd.integer,
+              minCount: 1,
+              maxCount: 1,
+            }, {
+              path: cc.csvColumnSample,
+              nodeKind: sh.Literal,
+              minCount: 1,
+              maxCount: 3,
+            }],
+          },
+        },
+      })
+    })
+  })
+
+  describe('when columns are missing', () => {
+    it('throws', () => {
+      // given
+      csvSource = clownface({ dataset: $rdf.dataset() })
+        .namedNode('source')
+        .addOut(rdf.type, cc.CSVSource)
+        .addOut(schema.name, 'Name')
+        .addOut(csvw.dialect, dialect => {
+          dialect.addOut(csvw.quoteChar, '"')
+          dialect.addOut(csvw.delimiter, ',')
+        })
+        .addOut(cc.csvMapping, csvMapping)
+        .addOut(schema.associatedMedia, file => {
+          file.addOut(schema.identifier, 'file.csv')
+        })
+        .addOut(csvw.column, column => {
+          column.addOut(schema.name, 'unit_id')
+            .addOut(dtype.order, 0)
+        })
+        .addOut(csvw.column, column => {
+          column.addOut(schema.name, 'column2')
+            .addOut(dtype.order, 1)
+        })
+        .addOut(csvw.column, column => {
+          column.addOut(schema.name, 'column3')
+            .addOut(dtype.order, 2)
+        })
+
+      const file = Buffer.alloc(0)
+      const store = new TestResourceStore([
+        csvSource,
+      ])
+
+      // when
+      const csvSourceUpdate = replaceFile({
+        resource: csvSource.term,
+        store,
+        file,
+        fileStorage,
+      })
+
+      // then
+      expect(csvSourceUpdate).to.be.rejectedWith(DomainError)
+    })
+  })
+})

--- a/e2e-tests/csv-source/replace.hydra
+++ b/e2e-tests/csv-source/replace.hydra
@@ -1,0 +1,57 @@
+PREFIX cc: <https://cube-creator.zazuko.com/vocab#>
+PREFIX schema: <http://schema.org/>
+
+ENTRYPOINT "cube-project/ubd/csv-mapping/sources"
+
+HEADERS {
+  x-user "john-doe"
+  x-permission "pipelines:write"
+}
+
+With Class cc:CSVSourceCollection {
+    Expect Operation cc:UploadCSVAction {
+        Invoke {
+            Content-Type "text/csv"
+            Content-Disposition "file; filename=replace_test.csv"
+
+            ```
+            column1,column2,column3
+            1,2,test
+            1,2,test
+            1,2,test1
+            1,2,test2
+            ```
+        } => {
+            Expect Status 201
+        }
+    }
+}
+
+With Class cc:CSVSource {
+    Expect Operation cc:ReplaceCSVAction {
+        Invoke {
+            Content-Type "text/csv"
+            ```
+            column1,column4
+            2010,1
+            ```
+        } => {
+            Expect Status 400
+        }
+    
+        Invoke {
+            Content-Type "text/csv"
+            ```
+            column1,column2,column3,column4
+            1,2,test,a
+            1,2,test,b
+            1,2,test1,c
+            1,2,test2,a
+            ```
+        } => {
+            Expect Status 200
+
+            Expect Type <https://cube-creator.zazuko.com/vocab#CSVSource>
+        }
+    }
+}

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -11,6 +11,7 @@ type CubeCreatorClass =
   'CSVSource' |
   'CSVSourceCollection' |
   'UploadCSVAction' |
+  'ReplaceCSVAction' |
   'Table' |
   'TableCollection' |
   'ObservationTable' |

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -26,7 +26,8 @@ type CubeCreatorClass =
   'DimensionMetadataCollection' |
   'Observations' |
   'TransformJob' |
-  'PublishJob'
+  'PublishJob' |
+  'ReplaceCSVAction'
 
 type CubeCreatorProperty =
   'projectSourceKind' |

--- a/ui/src/api/mixins/CSVSource.ts
+++ b/ui/src/api/mixins/CSVSource.ts
@@ -2,13 +2,20 @@ import { Constructor } from '@tpluscode/rdfine'
 import { Mixin } from '@tpluscode/rdfine/lib/ResourceFactory'
 import * as ns from '@cube-creator/core/namespace'
 import { csvw } from '@tpluscode/rdf-ns-builders'
-import { CsvSource, CsvColumn } from '@cube-creator/model'
+import { CsvColumn } from '@cube-creator/model'
+import { AdditionalActions } from '@/api/mixins/ApiResource'
 
-export default function mixin<Base extends Constructor<CsvSource>> (base: Base): Mixin {
-  return class extends base {
+export default function mixin<Base extends Constructor> (base: Base): Mixin {
+  return class extends base implements AdditionalActions {
     get columns (): CsvColumn[] {
       return this.getArray<CsvColumn>(csvw.column)
         .sort((c1, c2) => c1.order - c2.order)
+    }
+
+    get _additionalActions () {
+      return {
+        replace: ns.cc.ReplaceCSVAction,
+      }
     }
   }
 }

--- a/ui/src/components/CsvSourceMapping.vue
+++ b/ui/src/components/CsvSourceMapping.vue
@@ -15,7 +15,8 @@
                 />
                 <hydra-operation-button
                   :operation="source.actions.replace"
-                  :to="{ name: 'CSVReplace', params: { sourceId: source.clientPath } }"
+                  icon="upload"
+                  :to="{ name: 'SourceReplaceCSV', params: { sourceId: source.clientPath } }"
                 />
                 <hydra-operation-button
                   :operation="source.actions.delete"

--- a/ui/src/components/CsvSourceMapping.vue
+++ b/ui/src/components/CsvSourceMapping.vue
@@ -14,6 +14,10 @@
                   :to="{ name: 'SourceEdit', params: { sourceId: source.clientPath } }"
                 />
                 <hydra-operation-button
+                  :operation="source.actions.replace"
+                  :to="{ name: 'CSVReplace', params: { sourceId: source.clientPath } }"
+                />
+                <hydra-operation-button
                   :operation="source.actions.delete"
                   @click="deleteSource(source)"
                 />

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -12,6 +12,7 @@ import CubeProjectCreate from '@/views/CubeProjectCreate.vue'
 import CubeProjectEdit from '@/views/CubeProjectEdit.vue'
 import CSVMapping from '@/views/CSVMapping.vue'
 import CSVUpload from '@/views/CSVUpload.vue'
+import CSVReplace from '@/views/CSVReplace.vue'
 import SourceEdit from '@/views/SourceEdit.vue'
 import TableCreate from '@/views/TableCreate.vue'
 import TableEdit from '@/views/TableEdit.vue'
@@ -72,6 +73,11 @@ const routes: Array<RouteConfig> = [
                 path: 'sources/:sourceId/edit',
                 name: 'SourceEdit',
                 component: SourceEdit,
+              },
+              {
+                path: 'sources/:sourceId/replace',
+                name: 'CSVReplace',
+                component: CSVReplace,
               },
               {
                 path: 'tables/create',

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -75,8 +75,8 @@ const routes: Array<RouteConfig> = [
                 component: SourceEdit,
               },
               {
-                path: 'sources/:sourceId/replace',
-                name: 'CSVReplace',
+                path: 'sources/:sourceId/replace-csv',
+                name: 'SourceReplaceCSV',
                 component: CSVReplace,
               },
               {

--- a/ui/src/store/modules/project.ts
+++ b/ui/src/store/modules/project.ts
@@ -229,6 +229,18 @@ const actions: ActionTree<ProjectState, RootState> = {
     return Promise.all(uploads)
   },
 
+  async replaceCSV (context, files) {
+    const operation = context.state.sources?.id.actions?.replace ?? null
+    const uploads = files.map((file: File) => {
+      const headers = {
+        'content-type': 'text/csv',
+      }
+      return api.invokeSaveOperation(operation, file, headers)
+    })
+
+    return Promise.all(uploads)
+  },
+
   async fetchCubeMetadata (context) {
     const project = context.state.project
 

--- a/ui/src/store/modules/project.ts
+++ b/ui/src/store/modules/project.ts
@@ -229,16 +229,12 @@ const actions: ActionTree<ProjectState, RootState> = {
     return Promise.all(uploads)
   },
 
-  async replaceCSV (context, files) {
-    const operation = context.state.sources?.id.actions?.replace ?? null
-    const uploads = files.map((file: File) => {
-      const headers = {
-        'content-type': 'text/csv',
-      }
-      return api.invokeSaveOperation(operation, file, headers)
-    })
-
-    return Promise.all(uploads)
+  async replaceCSV (context, { source, file }) {
+    const operation = source.actions.replace
+    const headers = {
+      'content-type': 'text/csv',
+    }
+    return api.invokeSaveOperation(operation, file, headers)
   },
 
   async fetchCubeMetadata (context) {

--- a/ui/src/store/serializers.ts
+++ b/ui/src/store/serializers.ts
@@ -66,12 +66,16 @@ export function serializeSourcesCollection (collection: SourcesCollection): Sour
 export function serializeSource (source: CsvSource): CsvSource {
   return Object.freeze({
     ...serializeResource(source),
+    actions: {
+      ...serializeActions(source.actions),
+      replace: source.actions.replace,
+    },
     name: source.name,
     error: source.error,
     columns: source.columns.map(serializeColumn),
     dialect: source.dialect,
     csvMapping: source.csvMapping,
-  }) as CsvSource
+  }) as unknown as CsvSource
 }
 
 export function serializeColumn (column: CsvColumn): CsvColumn {

--- a/ui/src/views/CSVReplace.vue
+++ b/ui/src/views/CSVReplace.vue
@@ -76,7 +76,7 @@ export default class CSVUploadView extends Vue {
       this.$router.push({ name: 'CSVMapping' })
     } catch (e) {
       if (e instanceof APIErrorValidation) {
-        this.error = e.details.detail ?? { detail: e.toString() }
+        this.error = e.details?.detail ?? e.toString()
         console.log(e)
       } else if (e instanceof APIPayloadTooLarge) {
         this.error = 'CSV file is too large'

--- a/ui/src/views/CSVReplace.vue
+++ b/ui/src/views/CSVReplace.vue
@@ -75,10 +75,9 @@ export default class CSVUploadView extends Vue {
 
       this.$router.push({ name: 'CSVMapping' })
     } catch (e) {
-      if (e instanceof APIErrorConflict) {
-        this.error = 'Cannot upload a file with the same name twice'
-      } else if (e instanceof APIErrorValidation) {
-        this.error = e.details?.title ?? null
+      if (e instanceof APIErrorValidation) {
+        this.error = e.details.detail ?? { detail: e.toString() }
+        console.log(e)
       } else if (e instanceof APIPayloadTooLarge) {
         this.error = 'CSV file is too large'
       } else {

--- a/ui/src/views/CSVReplace.vue
+++ b/ui/src/views/CSVReplace.vue
@@ -1,0 +1,80 @@
+<template>
+  <side-pane :is-open="true" title="Replace CSV file" @close="onCancel">
+    <form @submit.prevent="onSubmit">
+      <b-message v-if="error" type="is-danger">
+        {{ error }}
+      </b-message>
+
+      <b-field>
+        <b-upload v-model="files" drag-drop accept=".csv">
+          <section class="section">
+            <div class="content has-text-centered">
+              <p>
+                <b-icon icon="upload" size="is-large" />
+              </p>
+              <p>Drop your file here or click to select files from your disk</p>
+            </div>
+          </section>
+        </b-upload>
+      </b-field>
+
+      <div class="tags">
+        <span v-for="(file, index) in files" :key="index" class="tag is-primary">
+          {{ file.name }}
+          <button class="delete is-small" type="button" @click="removeFile(index)" />
+        </span>
+      </div>
+
+      <form-submit-cancel submit-label="Upload" @cancel="onCancel" :disabled="files.length === 0" />
+    </form>
+  </side-pane>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import SidePane from '@/components/SidePane.vue'
+import FormSubmitCancel from '@/components/FormSubmitCancel.vue'
+import { APIErrorConflict, APIErrorValidation, APIPayloadTooLarge } from '@/api/errors'
+
+@Component({
+  components: { SidePane, FormSubmitCancel },
+})
+export default class CSVUploadView extends Vue {
+  files: File[] = []
+  error: string | null = null
+
+  async onSubmit (): Promise<void> {
+    this.error = null
+    const loader = this.$buefy.loading.open({})
+
+    try {
+      await this.$store.dispatch('project/replaceCSV', this.files)
+
+      await this.$store.dispatch('project/refreshSourcesCollection')
+
+      this.$router.push({ name: 'CSVMapping' })
+    } catch (e) {
+      if (e instanceof APIErrorConflict) {
+        this.error = 'Cannot upload a file with the same name twice'
+      } else if (e instanceof APIErrorValidation) {
+        this.error = e.details?.title ?? null
+      } else if (e instanceof APIPayloadTooLarge) {
+        this.error = 'CSV file is too large'
+      } else {
+        console.error(e)
+        this.error = e.toString()
+      }
+    } finally {
+      loader.close()
+    }
+  }
+
+  onCancel (): void {
+    this.$router.push({ name: 'CSVMapping' })
+  }
+
+  removeFile (index: number): void {
+    this.files.splice(index, 1)
+  }
+}
+</script>


### PR DESCRIPTION
Replaces the current csv with the new one, if all old columns are present in the new csv.

When the file is compatible, the file on S3 gets replaced and and the sample date gets reloaded (same as when editing the dialect)

fixes #275