### PR TITLE
fix: kill blank node observation

### DIFF
--- a/cli/lib/output-filter.ts
+++ b/cli/lib/output-filter.ts
@@ -27,8 +27,12 @@ function removeDefaultProperties(quad: Quad): boolean {
   return !quad.predicate.value.startsWith('#')
 }
 
-export function fromTransformed(quad: Quad): boolean {
+export function keepCsvwDescribes(quad: Quad): boolean {
   return removeCsvwTriples(quad, true) && removeDefaultProperties(quad)
+}
+
+export function excludeAllCsvw(quad: Quad): boolean {
+  return removeCsvwTriples(quad, false) && removeDefaultProperties(quad)
 }
 
 export function fromPublished(quad: Quad): boolean {

--- a/cli/package.json
+++ b/cli/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "mkdir -p output; touch .env",
-    "transform": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts transform --job \"$TRANSFORM_JOB\" --debug'",
+    "transform": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts transform --job \"$TRANSFORM_JOB\" --debug --to filesystem'",
     "publish": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts publish --job \"$PUBLISH_JOB\" --debug'",
     "build": "tsc"
   },

--- a/cli/pipelines/main.ttl
+++ b/cli/pipelines/main.ttl
@@ -67,7 +67,7 @@
   :steps [ :stepList (
                        <#loadCsvStep>
                        <#parse>
-                       <#filter>
+                       <#filterObservationTable>
                        <#toDataset>
                        <#toObservation>
                        <#toCubeShape>
@@ -80,7 +80,7 @@
   :steps [ :stepList (
                        <#loadCsvStep>
                        <#parse>
-                       <#filter>
+                       <#filterNonObservationTable>
                      ) ] .
 
 <#LoadCsv>
@@ -108,11 +108,18 @@
                        a         code:EcmaScript ] ;
   code:arguments     ( "csvw"^^:VariableName ) .
 
-<#filter>
+<#filterNonObservationTable>
   a                  :Step ;
   code:implementedBy [ a         code:EcmaScript ;
                        code:link <node:barnard59-base#filter> ] ;
-  code:arguments     ( [ code:link <file:../lib/output-filter#fromTransformed> ;
+  code:arguments     ( [ code:link <file:../lib/output-filter#keepCsvwDescribes> ;
+                         a         code:EcmaScript ] ) .
+
+<#filterObservationTable>
+  a                  :Step ;
+  code:implementedBy [ a         code:EcmaScript ;
+                       code:link <node:barnard59-base#filter> ] ;
+  code:arguments     ( [ code:link <file:../lib/output-filter#excludeAllCsvw> ;
                          a         code:EcmaScript ] ) .
 
 <#toDataset> a :Step;

--- a/cli/test/lib/commands/transform.test.ts
+++ b/cli/test/lib/commands/transform.test.ts
@@ -100,6 +100,18 @@ describe('lib/commands/transform', function () {
       expect(hasDescribesProperty).to.eq(false)
     })
 
+    it('all observations are named nodes', async () => {
+      const hasDescribesProperty = await ASK`
+        ?observation a ${cube.Observation} .
+
+        FILTER ( BNODE (?observation) )
+      `
+        .FROM($rdf.namedNode(`${env.API_CORE_BASE}cube-project/ubd/cube-data`))
+        .execute(client.query)
+
+      expect(hasDescribesProperty).to.eq(false)
+    })
+
     it('removes all CSVW triples but csvw:describes', async () => {
       const distinctCsvwProps = await SELECT.DISTINCT`?prop`
         .FROM($rdf.namedNode(`${env.API_CORE_BASE}cube-project/ubd/cube-data`))


### PR DESCRIPTION
Changing the filter pipeline steps to exclude all `csvw:` triples from transformed observation tables. Still keeps `csvw:describes` for non-observation tables.

This fixes a strange behaviour which causes the first row of some CSV files be transformed into a blank node. Since we need the `csvw:describes` only for non-observation tables, this is fine.