### PR TITLE
chore(ui): log errors in console

### DIFF
--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -32,6 +32,7 @@ Sentry.init({
   environment: window.APP_CONFIG.sentry?.environment,
   release: process.env.VUE_APP_SENTRY_RELEASE,
   attachProps: true,
+  logErrors: true,
   tracesSampleRate: 1,
   integrations: [
     new Integrations.BrowserTracing({


### PR DESCRIPTION
When an error is intercepted by Sentry, it is not logged in the console by default. It makes debugging a bit harder. This option will log errors in the console.