### PR TITLE
feat(ui): improve cube preview loader height

### DIFF
--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -36,8 +36,8 @@
       </thead>
       <tbody class="is-family-monospace">
         <tr v-if="observations.isLoading">
-          <td :colspan="tableWidth">
-            <loading-block />
+          <td :colspan="tableWidth" class="p-0">
+            <loading-block class="has-background-light is-size-2" :style="`height: calc(38px * ${this.pageSize});`" />
           </td>
         </tr>
         <tr v-else-if="observations.error">


### PR DESCRIPTION
Make the Cube Preview loader take the same height as the loaded
observations to keep all the UI controls in place while loading the next
page.