### PR TITLE
fix(ui): no identifier autocomplete on observation table

### DIFF
--- a/ui/src/forms/editors/IdentifierTemplateEditor.vue
+++ b/ui/src/forms/editors/IdentifierTemplateEditor.vue
@@ -32,6 +32,7 @@ export default class extends Vue {
   @Prop() value!: string | undefined
   @Prop() update!: (newValue: string) => void
   @Prop() tableName!: string
+  @Prop() isObservationTable!: boolean
   @Prop() sourceId?: Term
   @Prop({ default: true }) autoPrefill!: boolean // TODO: Should only be true on table creation
 
@@ -99,13 +100,17 @@ export default class extends Vue {
   }
 
   @Watch('tableName')
+  @Watch('isObservationTable')
   prefill (): void {
     if (this.wasModified) return
 
     if (!this.tableName) return
 
-    const prefix = this.tableName.replace(' ', '')
-    const prefillValue = `${prefix}/{REPLACE}`
+    const prefix = this.tableName.split(' ').join('')
+    const prefillValue = !this.isObservationTable
+      ? `${prefix}/{REPLACE}`
+      : ''
+
     this.update(prefillValue)
     this.$emit('input', prefillValue)
   }

--- a/ui/src/forms/editors/index.ts
+++ b/ui/src/forms/editors/index.ts
@@ -147,11 +147,16 @@ export const identifierTemplateEditor: Lazy<SingleEditorComponent> = {
     await import('./IdentifierTemplateEditor.vue').then(createCustomElement('identifier-template-editor'))
 
     return ({ value, updateComponentState, focusNode }, { update }) => {
-      let { tableName, sourceId } = value.componentState
+      let { tableName, isObservationTable, sourceId } = value.componentState
 
       if (tableName !== focusNode.out(schema.name).value) {
         tableName = focusNode.out(schema.name).value
         updateComponentState({ tableName })
+      }
+
+      if (isObservationTable !== focusNode.out(ns.cc.isObservationTable).value) {
+        isObservationTable = focusNode.out(ns.cc.isObservationTable).value === 'true'
+        updateComponentState({ isObservationTable })
       }
 
       if (sourceId !== focusNode.out(ns.cc.csvSource).term) {
@@ -163,6 +168,7 @@ export const identifierTemplateEditor: Lazy<SingleEditorComponent> = {
         .value="${value.object?.value || ''}"
         .update="${update}"
         .tableName="${tableName}"
+        .isObservationTable="${isObservationTable}"
         .sourceId="${sourceId}"
       ></identifier-template-editor>`
     }


### PR DESCRIPTION
Do not auto-complete identifier template if "is observation table" is selected. We want to encourage users to let us generate identifiers for observations.