### PR TITLE
chore(ui): remove "slow resource preview" warning

### DIFF
--- a/ui/src/views/ResourcePreview.vue
+++ b/ui/src/views/ResourcePreview.vue
@@ -20,13 +20,7 @@
         </td>
       </tr>
     </table>
-    <div v-else class="is-flex is-flex-direction-column has-text-grey is-align-items-center">
-      <loading-block />
-      <p>
-        We are aware that it is <em>really</em> slow at the moment.
-        It will get faster in a future version :)
-      </p>
-    </div>
+    <loading-block v-else />
   </side-pane>
 </template>
 


### PR DESCRIPTION
Remove warning about the resource preview being slow. It's not anymore :) (cf #399)