### PR TITLE
fix: only check observation tables for used dimensions

### DIFF
--- a/apis/core/lib/domain/queries/column-mapping.ts
+++ b/apis/core/lib/domain/queries/column-mapping.ts
@@ -15,13 +15,14 @@ export async function dimensionIsUsedByOtherMapping(columnMapping: Term, client 
             }
           
             graph ?table {
-              ?table a ${cc.Table} ;
+              ?table a ${cc.ObservationTable} ;
                 ${cc.columnMapping} ?deletedMapping ;
                 ${cc.csvMapping} ?csvMapping ;
             }
           
             graph ?otherTable {
-              ?otherTable ${cc.csvMapping} ?csvMapping ;
+              ?otherTable a ${cc.ObservationTable} ;
+                          ${cc.csvMapping} ?csvMapping ;
                           ${cc.columnMapping} ?otherMapping ;
             }
           


### PR DESCRIPTION
We check if a property is used by an other table before deleting the dimension metadata.

This is wrong since we only handle metadata for observation tables.
This PR checks that we only keep a dimension if it is used by an other observation table.

fixes #438 