### PR TITLE
feat: when deleting table delete all mappings referencing this table

### DIFF
--- a/apis/core/test/domain/column-mapping/delete.test.ts
+++ b/apis/core/test/domain/column-mapping/delete.test.ts
@@ -134,8 +134,10 @@ describe('domain/column-mapping/delete', () => {
     }
 
     dimensionIsUsedByOtherMapping = sinon.stub().resolves(false)
+    const getReferencingMappingsForTable = sinon.stub().returns([])
     columnMappingQueries = {
       dimensionIsUsedByOtherMapping,
+      getReferencingMappingsForTable,
     }
 
     sinon.stub(orgQueries, 'findOrganization').resolves({

--- a/apis/core/test/domain/table/delete.test.ts
+++ b/apis/core/test/domain/table/delete.test.ts
@@ -129,10 +129,6 @@ describe('domain/table/delete', () => {
       getTableForColumnMapping,
     }
 
-    async function * mappingGenerator() {
-      yield 'blabla'
-    }
-
     dimensionIsUsedByOtherMapping = sinon.stub().resolves(false)
     getReferencingMappingsForTable = sinon.stub().returns([])
     columnMappingQueries = {

--- a/apis/core/test/domain/table/update.test.ts
+++ b/apis/core/test/domain/table/update.test.ts
@@ -106,8 +106,10 @@ describe('domain/table/update', () => {
     dimensionMetadataQueries = { getDimensionMetaDataCollection }
 
     dimensionIsUsedByOtherMapping = sinon.stub().resolves(false)
+    const getReferencingMappingsForTable = sinon.stub().returns([])
     columnMappingQueries = {
       dimensionIsUsedByOtherMapping,
+      getReferencingMappingsForTable,
     }
 
     sinon.stub(orgQueries, 'findOrganization').resolves({


### PR DESCRIPTION
When a table to delete has any referencing column mappings, this mapping should also be deleted to avoid orphaned column mappings.

fixes #425 