### PR TITLE
feat: getting dimension mappings ensure all values

### DIFF
--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -105,7 +105,8 @@ ${shape('dimension/managed-mapping')} {
         ${hydra.template} "managed-dimensions/terms{?termSet}" ;
         ${hydra.mapping} [
           ${hydra.variable} "termSet" ;
-          ${hydra.property} ${schema.inDefinedTermSet} ;
+          ${hydra.property} ${cc.managedDimension} ;
+          ${hydra.required} true ;
         ] ;
       ]
     ];

--- a/apis/core/hydra/dimension-mapping.ttl
+++ b/apis/core/hydra/dimension-mapping.ttl
@@ -4,9 +4,15 @@ prefix hydra: <http://www.w3.org/ns/hydra/core#>
 prefix prov: <http://www.w3.org/ns/prov#>
 prefix code: <https://code.described.at/>
 prefix cc: <https://cube-creator.zazuko.com/vocab#>
+prefix query: <http://hypermedia.app/query#>
 
 prov:Dictionary
   a hydra:Class ;
+  query:preprocess
+    [
+      a code:EcmaScript ;
+      code:link <file:handlers/dimension-mapping#prepareEntries> ;
+    ] ;
   hydra:supportedOperation
     [
       a hydra:Operation, schema:ReplaceAction ;

--- a/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
+++ b/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
@@ -1,4 +1,4 @@
-import { NamedNode, Term } from 'rdf-js'
+import { Literal, NamedNode, Term } from 'rdf-js'
 import { Constructor, property } from '@tpluscode/rdfine'
 import { prov, schema } from '@tpluscode/rdf-ns-builders'
 import { Dictionary, KeyEntityPair } from '@rdfine/prov'
@@ -11,6 +11,7 @@ declare module '@rdfine/prov' {
     managedDimension: NamedNode
     replaceEntries(entries: KeyEntityPair[]): Map<Term, Term>
     changeManageDimension(managedDimension: NamedNode): void
+    addMissingEntries(unmappedValues: Set<Literal>): void
   }
 }
 
@@ -64,6 +65,24 @@ export function ProvDictionaryMixinEx<Base extends Constructor<Dictionary>>(Reso
       }
 
       return newEntries
+    }
+
+    addMissingEntries(unmappedValues: Set<Literal>) {
+      const currentEntries = this.hadDictionaryMember
+      const newEntries: any[] = []
+
+      for (const key of unmappedValues) {
+        if (!currentEntries.some(({ pairKey }) => pairKey?.equals(key))) {
+          newEntries.push({
+            pairKey: key,
+          })
+        }
+      }
+
+      this.hadDictionaryMember = [
+        ...currentEntries,
+        ...newEntries,
+      ]
     }
   }
 

--- a/apis/core/lib/handlers/dimension-mapping.ts
+++ b/apis/core/lib/handlers/dimension-mapping.ts
@@ -1,7 +1,12 @@
 import asyncMiddleware from 'middleware-async'
 import { protectedResource } from '@hydrofoil/labyrinth/resource'
+import { Enrichment } from '@hydrofoil/labyrinth/lib/middleware/preprocessResource'
+import { fromPointer } from '@rdfine/prov/lib/Dictionary'
 import { shaclValidate } from '../middleware/shacl'
 import { update } from '../domain/dimension-mapping/update'
+import { getUnmappedValues } from '../domain/queries/dimension-mappings'
+import { prov } from '@tpluscode/rdf-ns-builders'
+import { cc } from '@cube-creator/core/namespace'
 
 export const put = protectedResource(
   shaclValidate,
@@ -15,3 +20,13 @@ export const put = protectedResource(
 
     return res.dataset(dimensionMapping.dataset)
   }))
+
+export const prepareEntries: Enrichment = async (req, pointer) => {
+  const dictionary = fromPointer(pointer)
+  const unmappedValues = await getUnmappedValues(dictionary.id, dictionary.about)
+
+  dictionary.addMissingEntries(unmappedValues)
+
+  pointer.out(prov.hadDictionaryMember)
+    .addOut(cc.managedDimension, dictionary.managedDimension)
+}

--- a/apis/core/test/domain/dimension-mapping/DimensionMappings.test.ts
+++ b/apis/core/test/domain/dimension-mapping/DimensionMappings.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, beforeEach } from 'mocha'
+import { fromPointer } from '@rdfine/prov/lib/Dictionary'
+import { GraphPointer } from 'clownface'
+import { expect } from 'chai'
+import { NamedNode } from 'rdf-js'
+import $rdf from 'rdf-ext'
+import namespace from '@rdfjs/namespace'
+import TermSet from '@rdfjs/term-set'
+import { prov } from '@tpluscode/rdf-ns-builders'
+import { namedNode } from '../../support/clownface'
+import '../../../lib/domain'
+
+const wtd = namespace('http://www.wikidata.org/entity/')
+
+const wikidata = {
+  arsenic: wtd.Q871,
+  lead: wtd.Q708,
+  carbonMonoxide: wtd.Q2025,
+  sulphurDioxide: wtd.Q5282,
+}
+
+describe('lib/domain/DimensionMappings', () => {
+  let pointer: GraphPointer<NamedNode>
+
+  beforeEach(() => {
+    pointer = namedNode('mapping')
+  })
+
+  describe('addMissingEntries', function () {
+    it('creates prov:KeyEntityPairs for missing keys', () => {
+      // given
+      const dictionary = fromPointer(pointer, {
+        hadDictionaryMember: [{
+          pairKey: 'so2',
+          pairEntity: wikidata.sulphurDioxide,
+        }],
+      })
+      const unmappedKeys = new TermSet([
+        $rdf.literal('As'),
+        $rdf.literal('Pb'),
+      ])
+
+      // when
+      dictionary.addMissingEntries(unmappedKeys)
+
+      // then
+      expect(dictionary).to.matchShape({
+        property: {
+          path: prov.hadDictionaryMember,
+          minCount: 3,
+          maxCount: 3,
+          node: {
+            xone: [{
+              property: [{
+                path: prov.pairKey,
+                hasValue: 'As',
+              }, {
+                path: prov.pairEntity,
+                maxCount: 0,
+              }],
+            }, {
+              property: [{
+                path: prov.pairKey,
+                hasValue: 'Pb',
+              }, {
+                path: prov.pairEntity,
+                maxCount: 0,
+              }],
+            }, {
+              property: [{
+                path: prov.pairKey,
+                hasValue: 'so2',
+              }, {
+                path: prov.pairEntity,
+                hasValue: wikidata.sulphurDioxide,
+                minCount: 1,
+                maxCount: 1,
+              }],
+            }],
+          },
+        },
+      })
+    })
+
+    it('skips keys which already have entries', () => {
+      // given
+      const dictionary = fromPointer(pointer, {
+        hadDictionaryMember: [{
+          pairKey: 'so2',
+          pairEntity: wikidata.sulphurDioxide,
+        }, {
+          pairKey: 'As',
+        }],
+      })
+      const unmappedKeys = new TermSet([
+        $rdf.literal('so2'),
+        $rdf.literal('As'),
+      ])
+
+      // when
+      dictionary.addMissingEntries(unmappedKeys)
+
+      // then
+      expect(dictionary).to.matchShape({
+        property: {
+          path: prov.hadDictionaryMember,
+          minCount: 2,
+          maxCount: 2,
+          node: {
+            xone: [{
+              property: [{
+                path: prov.pairKey,
+                hasValue: 'As',
+              }, {
+                path: prov.pairEntity,
+                maxCount: 0,
+              }],
+            }, {
+              property: [{
+                path: prov.pairKey,
+                hasValue: 'so2',
+              }, {
+                path: prov.pairEntity,
+                hasValue: wikidata.sulphurDioxide,
+                minCount: 1,
+                maxCount: 1,
+              }],
+            }],
+          },
+        },
+      })
+    })
+  })
+})

--- a/apis/core/test/domain/queries/dimension-mappings.test.ts
+++ b/apis/core/test/domain/queries/dimension-mappings.test.ts
@@ -7,49 +7,72 @@ import { DESCRIBE } from '@tpluscode/sparql-builder'
 import { parsingClient, client, insertTestData } from '@cube-creator/testing/lib'
 import clownface from 'clownface'
 import TermMap from '@rdfjs/term-map'
-import { replaceValueWithDefinedTerms } from '../../../lib/domain/queries/dimension-mappings'
+import { replaceValueWithDefinedTerms, getUnmappedValues } from '../../../lib/domain/queries/dimension-mappings'
 
 describe('lib/domain/queries/dimension-mappings @SPARQL', function () {
   this.timeout(20000)
 
   const dimensionMapping = $rdf.namedNode('https://cube-creator.lndo.site/cube-project/ubd/dimension-mapping/pollutant')
-  let terms: Map<Term, Term>
-  const sparqlSpy = sinon.spy(client.query, 'update')
 
   beforeEach(async () => {
-    terms = new TermMap()
     await insertTestData('fuseki/sample-ubd.trig')
-
-    sparqlSpy.resetHistory()
   })
 
-  it('does nothing when called without any terms', async () => {
+  describe('replaceValueWithDefinedTerms', () => {
+    let terms: Map<Term, Term>
+    const sparqlSpy = sinon.spy(client.query, 'update')
+
+    beforeEach(async () => {
+      terms = new TermMap()
+
+      sparqlSpy.resetHistory()
+    })
+
+    it('does nothing when called without any terms', async () => {
     // when
-    await replaceValueWithDefinedTerms({ dimensionMapping, terms }, client)
+      await replaceValueWithDefinedTerms({ dimensionMapping, terms }, client)
 
-    // then
-    expect(sparqlSpy).not.to.have.been.called
-  })
+      // then
+      expect(sparqlSpy).not.to.have.been.called
+    })
 
-  it('updates observations', async () => {
+    it('updates observations', async () => {
     // given
-    const observationId = $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-2003-annualmean')
-    const definedTerm = $rdf.namedNode('http://www.wikidata.org/entity/Q5282')
-    terms.set($rdf.literal('so2'), definedTerm)
+      const observationId = $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-2003-annualmean')
+      const definedTerm = $rdf.namedNode('http://www.wikidata.org/entity/Q5282')
+      terms.set($rdf.literal('so2'), definedTerm)
 
-    // when
-    await replaceValueWithDefinedTerms({ dimensionMapping, terms }, client)
+      // when
+      await replaceValueWithDefinedTerms({ dimensionMapping, terms }, client)
 
-    // then
-    const quads = await DESCRIBE`${observationId}`.execute(parsingClient.query)
-    const observation = clownface({ dataset: $rdf.dataset(quads) }).namedNode(observationId)
-    expect(observation).to.matchShape({
-      property: {
-        path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/pollutant'),
-        hasValue: definedTerm,
-        minCount: 1,
-        maxCount: 1,
-      },
+      // then
+      const quads = await DESCRIBE`${observationId}`.execute(parsingClient.query)
+      const observation = clownface({ dataset: $rdf.dataset(quads) }).namedNode(observationId)
+      expect(observation).to.matchShape({
+        property: {
+          path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/pollutant'),
+          hasValue: definedTerm,
+          minCount: 1,
+          maxCount: 1,
+        },
+      })
+    })
+  })
+
+  describe('getUnmappedValues', () => {
+    const dimension = $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/pollutant')
+
+    it('returns combined unmapped values from shapes and observations', async () => {
+      // when
+      const unmappedValues = await getUnmappedValues(dimensionMapping, dimension, parsingClient)
+
+      // then
+      expect(unmappedValues).to.have.property('size', 3)
+      expect([...unmappedValues]).to.have.deep.members([
+        $rdf.literal('so2'),
+        $rdf.literal('As'),
+        $rdf.literal('Pb'),
+      ])
     })
   })
 })

--- a/apis/core/test/handlers/dimension-mapping.test.ts
+++ b/apis/core/test/handlers/dimension-mapping.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, beforeEach } from 'mocha'
+import { Request } from 'express'
+import sinon from 'sinon'
+import TermSet from '@rdfjs/term-set'
+import { expect } from 'chai'
+import $rdf from 'rdf-ext'
+import { prov } from '@tpluscode/rdf-ns-builders'
+import { cc } from '@cube-creator/core/namespace'
+import { fromPointer } from '@rdfine/prov/lib/Dictionary'
+import { prepareEntries } from '../../lib/handlers/dimension-mapping'
+import { namedNode } from '../support/clownface'
+import { ex } from '../support/namespace'
+import * as queries from '../../lib/domain/queries/dimension-mappings'
+import '../../lib/domain'
+import { Literal } from 'rdf-js'
+
+describe('lib/handlers/dimension-mapping', () => {
+  describe('addMissingEntries', () => {
+    const req = {} as Request
+    let unmappedTerms: Set<Literal>
+
+    beforeEach(() => {
+      unmappedTerms = new TermSet()
+
+      sinon.restore()
+      sinon.stub(queries, 'getUnmappedValues').callsFake(async () => unmappedTerms)
+    })
+
+    it('add link to dimension to every entry', async () => {
+      // given
+      unmappedTerms.add($rdf.literal('Pb'))
+      const managedDimension = ex.dimension
+      const mappings = namedNode('mappings')
+      fromPointer(mappings, {
+        managedDimension: managedDimension,
+        hadDictionaryMember: [{
+          pairKey: 'so2',
+        }, {
+          pairKey: 'As',
+        }],
+      })
+
+      // when
+      await prepareEntries(req, mappings)
+
+      // then
+      expect(mappings).to.matchShape({
+        property: {
+          path: prov.hadDictionaryMember,
+          minCount: 3,
+          maxCount: 3,
+          node: {
+            property: {
+              path: cc.managedDimension,
+              hasValue: managedDimension,
+              minCount: 1,
+              maxCount: 1,
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -154,7 +154,19 @@ graph <cube-project/ubd/cube-data> {
     <https://environment.ld.admin.ch/foen/ubd/28/unit-id>         "µg/m3" ;
   .
 
-<https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-1999-annualmean>
+  <https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-2004-annualmean>
+    a                cube:Observation ;
+    cube:observedBy  <urn:will:replace> ;
+    <https://environment.ld.admin.ch/foen/ubd/28/aggregation>     <https://environment.ld.admin.ch/foen/ubd/28/aggregation/annualmean> ;
+    <https://environment.ld.admin.ch/foen/ubd/28/dimension/value> "6.1"^^xsd:float ;
+    <https://environment.ld.admin.ch/foen/ubd/28/dimension/year>  "2002"^^xsd:gYear ;
+    # does not appear in constraint shape but adding to check query for missing values
+    <https://environment.ld.admin.ch/foen/ubd/28/pollutant>       "Pb" ;
+    <https://environment.ld.admin.ch/foen/ubd/28/station>         <https://environment.ld.admin.ch/foen/ubd/28/station/blBAS> ;
+    <https://environment.ld.admin.ch/foen/ubd/28/unit-id>         "µg/m3" ;
+  .
+
+  <https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-1999-annualmean>
     a                cube:Observation ;
     cube:observedBy  <urn:will:replace> ;
     <https://environment.ld.admin.ch/foen/ubd/28/aggregation>     <https://environment.ld.admin.ch/foen/ubd/28/aggregation/annualmean> ;
@@ -194,6 +206,7 @@ graph <cube-project/ubd/cube-data> {
   _:pollutant
     sh:in        (
                    "so2" # <http://www.wikidata.org/entity/Q5282>
+                   "As" # does not appear in observations but adding to check query for missing values
                    <http://www.wikidata.org/entity/Q2025>
                  ) ;
     sh:maxCount  1 ;


### PR DESCRIPTION
This PR ensures that all unmapped values found in `cube:Observation` and `cube:Constraint` are dynamically added to the mappings dictionary when GETing the resource.

The individual entries repeat the link to the dimension so that is can be queried from the editor using `hydra:search` annotation.