### PR TITLE
feat(ui): show dimension property when missing name

### DIFF
--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -27,7 +27,7 @@
         </tr>
         <tr class="has-background-light">
           <th v-for="dimension in dimensions" :key="dimension.id.value">
-            <cube-preview-dimension :dimension="dimension" :selected-language="selectedLanguage" />
+            <cube-preview-dimension :dimension="dimension" :selected-language="selectedLanguage" :cube-uri="cube.id.value" />
           </th>
           <th v-if="dimensions.length === 0" class="has-text-grey has-text-centered">
             No dimensions defined

--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -8,7 +8,7 @@
               <div class="level-left">
                 <div class="level-item">
                   <term-with-language :values="cubeMetadata.title" :selected-language="selectedLanguage">
-                    Missing cube title
+                    <span class="has-text-danger">Missing cube title</span>
                   </term-with-language>
                 </div>
                 <div class="level-item">

--- a/ui/src/components/CubePreviewDimension.vue
+++ b/ui/src/components/CubePreviewDimension.vue
@@ -2,7 +2,7 @@
   <div class="dimension">
     <div class="dimension-header">
       <term-with-language :values="dimension.name" :selected-language="selectedLanguage">
-        Missing dimension name
+        Missing name for <em><term-display :term="dimension.about" :base="cubeUri" /></em>
       </term-with-language>
       <hydra-operation-button
         :operation="dimension.actions.edit"
@@ -23,14 +23,16 @@ import { Vue, Component, Prop } from 'vue-property-decorator'
 import { DimensionMetadata } from '@cube-creator/model'
 import HydraOperationButton from './HydraOperationButton.vue'
 import ScaleOfMeasureIcon from './ScaleOfMeasureIcon.vue'
+import TermDisplay from './TermDisplay.vue'
 import TermWithLanguage from './TermWithLanguage.vue'
 
 @Component({
-  components: { HydraOperationButton, ScaleOfMeasureIcon, TermWithLanguage },
+  components: { HydraOperationButton, ScaleOfMeasureIcon, TermDisplay, TermWithLanguage },
 })
 export default class CubePreviewDimension extends Vue {
   @Prop({ required: true }) dimension!: DimensionMetadata
   @Prop({ required: true }) selectedLanguage!: string
+  @Prop({ required: true }) cubeUri!: string
 
   get description (): string {
     const description = this.dimension.description.find(({ language }) => language === this.selectedLanguage)

--- a/ui/src/components/CubePreviewDimension.vue
+++ b/ui/src/components/CubePreviewDimension.vue
@@ -2,7 +2,9 @@
   <div class="dimension">
     <div class="dimension-header">
       <term-with-language :values="dimension.name" :selected-language="selectedLanguage">
-        Missing name for <em><term-display :term="dimension.about" :base="cubeUri" /></em>
+        <span class="has-text-danger">
+          Missing name for <em><term-display :term="dimension.about" :base="cubeUri" /></em>
+        </span>
       </term-with-language>
       <hydra-operation-button
         :operation="dimension.actions.edit"

--- a/ui/src/components/TermWithLanguage.vue
+++ b/ui/src/components/TermWithLanguage.vue
@@ -1,6 +1,6 @@
 <template>
   <span v-if="value">{{ value }}</span>
-  <span v-else class="has-text-grey"><slot>Missing value</slot></span>
+  <span v-else><slot>Missing value</slot></span>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Instead of just saying "Missing dimension name", say "Missing name for year".