### PR TITLE
refactor: use meta: namespace for shared dimension

### DIFF
--- a/apis/managed-dimensions/lib/domain/managed-dimensions.ts
+++ b/apis/managed-dimensions/lib/domain/managed-dimensions.ts
@@ -1,6 +1,6 @@
 import { CONSTRUCT } from '@tpluscode/sparql-builder'
 import { hydra, schema } from '@tpluscode/rdf-ns-builders'
-import { md } from '@cube-creator/core/namespace'
+import { md, meta } from '@cube-creator/core/namespace'
 import { NamedNode, Term } from 'rdf-js'
 
 export function getManagedDimensions(term: NamedNode) {
@@ -10,7 +10,7 @@ export function getManagedDimensions(term: NamedNode) {
   `
     .WHERE`
       GRAPH ?g {
-        ?termSet a ${schema.DefinedTermSet}, ${md.ManagedDimension} .
+        ?termSet a ${schema.DefinedTermSet}, ${meta.SharedDimension} .
         ?termSet ?p ?o .
       }
     `
@@ -23,7 +23,7 @@ export function getManagedTerms(managedDimension: Term, collection: NamedNode) {
     `
     .WHERE`
       GRAPH ?g {
-        ${managedDimension} a ${md.ManagedDimension} .
+        ${managedDimension} a ${meta.SharedDimension} .
         ?term ${schema.inDefinedTermSet} ${managedDimension} ; ?p ?o .
       }
     `

--- a/fuseki/managed-dimensions.trig
+++ b/fuseki/managed-dimensions.trig
@@ -2,6 +2,7 @@ prefix xsd: <http://www.w3.org/2001/XMLSchema#>
 prefix md: <https://cube-creator.zazuko.com/managed-dimensions/vocab#>
 prefix void: <http://rdfs.org/ns/void#>
 prefix schema: <http://schema.org/>
+prefix meta: <https://cube.link/meta/>
 base <https://cube-creator.lndo.site/managed-dimensions/>
 
 <managed-dimensions> a void:Dataset .
@@ -9,7 +10,7 @@ base <https://cube-creator.lndo.site/managed-dimensions/>
 <http://example.com/dimension/countries> void:inDataset <managed-dimensions> .
 graph <http://example.com/dimension/countries> {
   <http://example.com/dimension/countries>
-    a schema:DefinedTermSet, md:ManagedDimension ;
+    a schema:DefinedTermSet, meta:SharedDimension ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     schema:name "Countries"@en, "Länder"@de, "Des pays"@fr, "Paesi"@it ;
   .
@@ -26,7 +27,7 @@ graph <http://example.com/dimension/countries> {
 <http://example.com/dimension/colors> void:inDataset <managed-dimensions> .
 graph <http://example.com/dimension/colors> {
   <http://example.com/dimension/colors>
-    a schema:DefinedTermSet, md:ManagedDimension ;
+    a schema:DefinedTermSet, meta:SharedDimension ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     schema:name "Colors"@en, "Farben"@de, "I colori"@it, "Les couleurs"@fr ;
   .

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -75,10 +75,13 @@ type MetaDataProperty =
 type CubeCreatorTerms = CubeCreatorClass | CubeCreatorProperty | OtherTerms | MetaDataProperty
 
 type ManagedDimensionsTerms =
-  'ManagedDimension' |
   'ManagedDimensions' |
   'ManagedDimensionTerms' |
   'managedDimensions'
+
+type MetaTerms =
+  'SharedDimension' |
+  'dataKind'
 
 prefixes.freq = 'http://purl.org/cld/freq/'
 prefixes.cube = 'http://ns.bergnet.org/cube/'
@@ -87,7 +90,7 @@ prefixes.meta = 'https://cube.link/meta/'
 
 export const query = namespace('http://hypermedia.app/query#')
 export const cube = namespace(prefixes.cube)
-export const meta = namespace(prefixes.meta)
+export const meta = namespace<MetaTerms>(prefixes.meta)
 export const view = namespace(prefixes.view)
 export const hydraBox = namespace('http://hydra-box.org/schema/')
 export const cc = namespace<CubeCreatorTerms>('https://cube-creator.zazuko.com/vocab#')


### PR DESCRIPTION
As discussed, this replaces the earlier proposed `md:ManagedDimension` with `meta:SharedDimension`