### PR TITLE
fix: apply csvw.default when available

### DIFF
--- a/.changeset/heavy-geese-kneel.md
+++ b/.changeset/heavy-geese-kneel.md
@@ -3,4 +3,4 @@
 "@cube-creator/cli":" patch
 ---
 
-Output the dafault value for empty CSV cells
+Output the default value for empty CSV cells

--- a/.changeset/heavy-geese-kneel.md
+++ b/.changeset/heavy-geese-kneel.md
@@ -1,6 +1,6 @@
 ---
 "@cube-creator/core-api": patch
-"@cube-creator/cli":" patch
+"@cube-creator/cli": patch
 ---
 
 Output the default value for empty CSV cells

--- a/.changeset/heavy-geese-kneel.md
+++ b/.changeset/heavy-geese-kneel.md
@@ -1,5 +1,6 @@
 ---
 "@cube-creator/core-api": patch
+"@cube-creator/cli":" patch
 ---
 
 Output the dafault value for empty CSV cells

--- a/.changeset/heavy-geese-kneel.md
+++ b/.changeset/heavy-geese-kneel.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Output the dafault value for empty CSV cells

--- a/apis/core/lib/csvw-builder/index.ts
+++ b/apis/core/lib/csvw-builder/index.ts
@@ -56,6 +56,10 @@ function mappedLiteralColumn({ cubeIdentifier, organization, columnMapping, colu
     csvwColumn.lang = columnMapping.language
   }
 
+  if (columnMapping.defaultValue) {
+    csvwColumn.default = columnMapping.defaultValue.value
+  }
+
   return csvwColumn
 }
 

--- a/apis/core/test/csvw-builder/index.test.ts
+++ b/apis/core/test/csvw-builder/index.test.ts
@@ -236,6 +236,27 @@ describe('lib/csvw-builder', () => {
     expect(csvwColumn?.lang).to.eq('de-DE')
   })
 
+  it('maps column with default value', async () => {
+    // given
+    csvSource.columns = [
+      CsvColumn.fromPointer(csvSource.pointer.namedNode('jahr-column'), { name: 'JAHR' }),
+    ]
+    const columnMapping = ColumnMapping.literalFromPointer(clownface({ dataset: $rdf.dataset() }).namedNode('year-mapping'), {
+      sourceColumn: $rdf.namedNode('jahr-column') as any,
+      targetProperty: schema.yearBuilt,
+      defaultValue: '2020',
+    })
+    resources.push(columnMapping.pointer as any)
+    table.columnMappings = [columnMapping] as any
+
+    // when
+    const csvw = await buildCsvw({ table, resources })
+
+    // then
+    const csvwColumn = findColumn(csvw, 'JAHR')
+    expect(csvwColumn?.default).to.eq('2020')
+  })
+
   it('maps column from reference column mapping', async () => {
     // given
     const stationSource = CsvSource.create(graph.namedNode('station-source'), {

--- a/cli/package.json
+++ b/cli/package.json
@@ -46,6 +46,7 @@
     "null-writable": "^1.0.5",
     "once": "^1.4.0",
     "rdf-ext": "^1.3.0",
+    "rdf-parser-csvw": "^0.14.2",
     "rdf-stream-to-dataset-stream": "^1.0.0",
     "readable-stream": "^3.6.0",
     "string-to-stream": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,7 +1385,7 @@
     rdf-loaders-registry "^0.2.0"
     sparql-http-client "^2.2.2"
 
-"@hydrofoil/shaperone-core@^0.6.6", "@hydrofoil/shaperone-core@0.6.8", "@hydrofoil/shaperone-core@^0.6.8":
+"@hydrofoil/shaperone-core@0.6.8", "@hydrofoil/shaperone-core@^0.6.6", "@hydrofoil/shaperone-core@^0.6.8":
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/@hydrofoil/shaperone-core/-/shaperone-core-0.6.8.tgz#b697be545af94a1cae83addfc25820d15d5f3a92"
   integrity sha512-XF2eJh/h2OQhL9R1VYe5jYCYOd7OIE5RBUuI7YTbqsdxTrFYhfVC8uEoF6bM7U5b7i1gOAQE6fcIYhmrFDymWA==
@@ -11359,10 +11359,10 @@ rdf-normalize@^1.0.0:
   resolved "https://registry.yarnpkg.com/rdf-normalize/-/rdf-normalize-1.0.0.tgz#53496baf362cce9d9fca1f2216c6c30007f99cca"
   integrity sha1-U0lrrzYszp2fyh8iFsbDAAf5nMo=
 
-rdf-parser-csvw@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/rdf-parser-csvw/-/rdf-parser-csvw-0.14.0.tgz#c7c7f7675cce51626aae2d6d9213ee677364b9a2"
-  integrity sha512-K7Ra68SGxQBOgJGcss6Zi+dZMTBWWvRwtja4+EDk7K6cvNoXeZUGpAlElDBjnzo7mzAKnGf9EqnCubHQ7mPQog==
+rdf-parser-csvw@^0.14.0, rdf-parser-csvw@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/rdf-parser-csvw/-/rdf-parser-csvw-0.14.2.tgz#27eeb601f37080621ec2345202e4169084525a49"
+  integrity sha512-lQM8mGr7QXR/CUTGyLDWG8/teh/rDf6KQoET0pohNpJPfQZSAfeui+ML9xuugs1gPgLIE04sYRzqzc+0cmTHiA==
   dependencies:
     "@rdfjs/data-model" "^1.1.2"
     commander "^3.0.1"


### PR DESCRIPTION
Turns out `cc:defaultValue` was completely ignored when building the CSVW. This PR fixes that.

Now I looked at https://github.com/rdf-ext/rdf-parser-csvw and I'm pretty sure it's not handling `csvw:default` either...

Related to #345 

[UPDATE] I submitting [a PR to add support for `csvw:default` to `rdf-parser-csvw`](https://github.com/rdf-ext/rdf-parser-csvw/pull/31)