### PR TITLE
feat(ui): improve form validation messages

### DIFF
--- a/.changeset/cold-knives-love.md
+++ b/.changeset/cold-knives-love.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Improve form validation errors (#175)

--- a/ui/src/components/HydraOperationError.vue
+++ b/ui/src/components/HydraOperationError.vue
@@ -1,21 +1,19 @@
 <template>
   <b-message v-if="error" type="is-danger" :title="error.title" class="error-message">
-    <div class="">
-      <p v-if="error.detail && !error.report">
-        {{ error.detail }}
-      </p>
-      <ul v-if="error.report" class="">
-        <li v-for="(reportError, reportIndex) in error.report" :key="reportIndex" class="mb-2">
-          <strong>{{ propertyLabel(reportError.path) }}</strong>:&nbsp;
-          <span v-if="reportError.message.length === 1">{{ reportError.message[0] }}</span>
-          <ul v-else>
-            <li v-for="(message, messageIndex) in reportError.message" :key="messageIndex">
-              {{ message }}
-            </li>
-          </ul>
-        </li>
-      </ul>
-    </div>
+    <p v-if="error.detail && !error.report">
+      {{ error.detail }}
+    </p>
+    <ul v-if="error.report">
+      <li v-for="(reportError, reportIndex) in error.report" :key="reportIndex" class="mb-2">
+        <strong>{{ propertyLabel(reportError.path) }}</strong>:&nbsp;
+        <span v-if="reportError.message.length === 1">{{ reportError.message[0] }}</span>
+        <ul v-else>
+          <li v-for="(message, messageIndex) in reportError.message" :key="messageIndex">
+            {{ message }}
+          </li>
+        </ul>
+      </li>
+    </ul>
   </b-message>
 </template>
 

--- a/ui/src/components/HydraOperationError.vue
+++ b/ui/src/components/HydraOperationError.vue
@@ -1,13 +1,14 @@
 <template>
   <b-message v-if="error" type="is-danger" :title="error.title" class="error-message">
-    <div class="content">
-      <p v-if="error.detail">
+    <div class="">
+      <p v-if="error.detail && !error.report">
         {{ error.detail }}
       </p>
-      <ul v-if="error.report">
-        <li v-for="(reportError, reportIndex) in error.report" :key="reportIndex">
-          {{ shrink(reportError.path) }}
-          <ul>
+      <ul v-if="error.report" class="">
+        <li v-for="(reportError, reportIndex) in error.report" :key="reportIndex" class="mb-2">
+          <strong>{{ propertyLabel(reportError.path) }}</strong>:&nbsp;
+          <span v-if="reportError.message.length === 1">{{ reportError.message[0] }}</span>
+          <ul v-else>
             <li v-for="(message, messageIndex) in reportError.message" :key="messageIndex">
               {{ message }}
             </li>
@@ -20,14 +21,29 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator'
+import type { Shape } from '@rdfine/shacl'
+import $rdf from '@rdf-esm/data-model'
 import { ErrorDetails } from '@/api/errors'
+import { sh } from '@tpluscode/rdf-ns-builders'
 
 @Component
 export default class extends Vue {
   @Prop({ default: null }) error!: ErrorDetails | null
+  @Prop({ default: null }) shape!: Shape | null
 
-  shrink (uri: string | undefined): string {
-    return uri ? uri.split('#').slice(-1)[0] : ''
+  propertyLabel (uri: string | undefined): string {
+    if (!uri) return ''
+
+    const shrunkProperty = uri.split('#').slice(-1)[0]
+
+    if (!this.shape) return shrunkProperty
+
+    const label = this.shape.pointer.any()
+      .has(sh.path, $rdf.namedNode(uri))
+      .out(sh.name, { language: ['en', ''] })
+      .value
+
+    return label || shrunkProperty
   }
 }
 </script>

--- a/ui/src/components/HydraOperationForm.vue
+++ b/ui/src/components/HydraOperationForm.vue
@@ -4,7 +4,7 @@
 
     <loading-block v-if="!shape" />
 
-    <hydra-operation-error :error="error" class="mt-4" />
+    <hydra-operation-error :error="error" :shape="shape" class="mt-4" />
 
     <form-submit-cancel
       :submit-label="_submitLabel"


### PR DESCRIPTION
Part of #175

This PR doesn't fully solve the issue, but it makes the following improvements:
- Display field labels instead of property paths for invalid fields
- Don't display "the request doesn't conform to SHACL blabla"
- Take less space to display information and make it easier to read.

Screenshot:
<img width="392" alt="Screenshot 2021-02-22 at 15 08 21" src="https://user-images.githubusercontent.com/1334124/108719412-d309c180-751f-11eb-9a9c-e5787e75550f.png">