### PR TITLE
Disable OIDC session monitoring

### DIFF
--- a/ui/src/store/modules/auth.ts
+++ b/ui/src/store/modules/auth.ts
@@ -14,14 +14,15 @@ const cookieStorage = new CookieStorage({
   sameSite: 'Strict',
 })
 
-const oidcSettings: VuexOidcClientSettings = {
+const oidcSettings = {
   redirectUri: new URL('oidc-callback', base).toString(),
   postLogoutRedirectUri: new URL('logout', base).toString(),
   responseType: 'code',
   automaticSilentRenew: true,
   stateStore: new WebStorageStateStore({ store: cookieStorage }),
+  monitorSession: false,
   ...oidc,
-}
+} as VuexOidcClientSettings
 
 export function auth (): Module<VuexOidcState, RootState> {
   return vuexOidcCreateStoreModule(oidcSettings, {


### PR DESCRIPTION
The session monitoring sometime triggered a race condition where the auth server notified a session change, which made the OIDC client silently re-check the session, but with the wrong scopes.

The hardcoded scope can be seen here: https://github.com/IdentityModel/oidc-client-js/blob/e7093cf17cfa006036066bcae27f7728fafe8419/src/UserManager.js#L334

This disables the session monitoring. It was there to trigger app logouts when the user logs out from the auth server but not from within the app. I think we can live without that :)

This should fix #480 