### PR TITLE
fix: ensure external dimensions do not have PUT/DELETE operations

### DIFF
--- a/apis/managed-dimensions/hydra/index.ttl
+++ b/apis/managed-dimensions/hydra/index.ttl
@@ -116,7 +116,7 @@ md:ManagedDimensionTerms
         ] ;
     ] .
 
-meta:SharedDimension
+md:ManagedDimension
   a hydra:Class ;
   query:preprocess
     [
@@ -139,7 +139,7 @@ meta:SharedDimension
     ]
 .
 
-schema:DefinedTerm
+md:ManagedDimensionTerm
   a hydra:Class ;
   hydra:supportedOperation
     [

--- a/apis/managed-dimensions/lib/domain/managed-dimension.ts
+++ b/apis/managed-dimensions/lib/domain/managed-dimension.ts
@@ -3,7 +3,7 @@ import { NamedNode, Quad } from 'rdf-js'
 import $rdf from 'rdf-ext'
 import UrlSlugify from 'url-slugify'
 import { hydra, rdf, schema } from '@tpluscode/rdf-ns-builders'
-import { meta } from '@cube-creator/core/namespace'
+import { md, meta } from '@cube-creator/core/namespace'
 import { DomainError } from '@cube-creator/api-errors'
 import env from '../env'
 import { ManagedDimensionsStore } from '../store'
@@ -35,7 +35,7 @@ export async function create({ resource, store }: CreateSharedDimension): Promis
   const dataset = $rdf.dataset([...resource.dataset].map(replace(resource.term, termSetId)))
   const termSet = clownface({ dataset })
     .namedNode(termSetId)
-    .addOut(rdf.type, [hydra.Resource, schema.DefinedTermSet, meta.SharedDimension])
+    .addOut(rdf.type, [hydra.Resource, schema.DefinedTermSet, meta.SharedDimension, md.ManagedDimension])
 
   await store.save(termSet)
   return termSet
@@ -58,7 +58,7 @@ export async function createTerm({ termSet, resource, store }: CreateTerm): Prom
   const term = clownface({ dataset })
     .namedNode(termId)
     .addOut(schema.inDefinedTermSet, termSet)
-    .addOut(rdf.type, [schema.DefinedTerm, hydra.Resource])
+    .addOut(rdf.type, [schema.DefinedTerm, hydra.Resource, md.ManagedDimensionTerm])
 
   if (!term.has(schema.validFrom).term) {
     term.addOut(schema.validFrom, termSet.out(schema.validFrom))

--- a/apis/managed-dimensions/lib/handlers/managed-dimension-term.ts
+++ b/apis/managed-dimensions/lib/handlers/managed-dimension-term.ts
@@ -1,12 +1,14 @@
 import asyncMiddleware from 'middleware-async'
+import { protectedResource } from '@hydrofoil/labyrinth/resource'
 import { updateTerm } from '../domain/managed-dimension-term'
 import { store } from '../store'
+import { shaclValidate } from '../middleware/shacl'
 
-export const put = asyncMiddleware(async (req, res) => {
+export const put = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const pointer = await updateTerm({
     store: store(),
     term: await req.resource(),
   })
 
   return res.dataset(pointer.dataset)
-})
+}))

--- a/apis/managed-dimensions/lib/handlers/managed-dimension.ts
+++ b/apis/managed-dimensions/lib/handlers/managed-dimension.ts
@@ -1,9 +1,11 @@
 import asyncMiddleware from 'middleware-async'
+import { protectedResource } from '@hydrofoil/labyrinth/resource'
 import clownface from 'clownface'
 import { createTerm } from '../domain/managed-dimension'
 import { store } from '../store'
+import { shaclValidate } from '../middleware/shacl'
 
-export const post = asyncMiddleware(async (req, res) => {
+export const post = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const term = await createTerm({
     resource: await req.resource(),
     termSet: clownface({ dataset: await req.hydra.resource.dataset() }).node(req.hydra.term),
@@ -13,4 +15,4 @@ export const post = asyncMiddleware(async (req, res) => {
   res.setHeader('Location', term.value)
   res.status(201)
   return res.dataset(term.dataset)
-})
+}))

--- a/apis/managed-dimensions/lib/handlers/resource.ts
+++ b/apis/managed-dimensions/lib/handlers/resource.ts
@@ -1,10 +1,11 @@
 import asyncMiddleware from 'middleware-async'
 import { NO_CONTENT } from 'http-status'
 import clownface from 'clownface'
+import { protectedResource } from '@hydrofoil/labyrinth/resource'
 import { store } from '../store'
 import { cascadeDelete } from '../domain/resource'
 
-export const DELETE = asyncMiddleware(async (req, res) => {
+export const DELETE = protectedResource(asyncMiddleware(async (req, res) => {
   await cascadeDelete({
     store: store(),
     term: req.hydra.resource.term,
@@ -12,4 +13,4 @@ export const DELETE = asyncMiddleware(async (req, res) => {
   })
 
   res.sendStatus(NO_CONTENT)
-})
+}))

--- a/apis/managed-dimensions/lib/shapes/managed-dimension-term.ts
+++ b/apis/managed-dimensions/lib/shapes/managed-dimension-term.ts
@@ -2,6 +2,7 @@ import { Initializer } from '@tpluscode/rdfine/RdfResource'
 import { NodeShape, PropertyShape } from '@rdfine/shacl'
 import { rdf, schema, xsd } from '@tpluscode/rdf-ns-builders'
 import { supportedLanguages } from '@cube-creator/core/languages'
+import { md } from '@cube-creator/core/namespace'
 
 const commonProperties: Initializer<PropertyShape>[] = [{
   name: 'Name',
@@ -35,7 +36,7 @@ export const update = (): Initializer<NodeShape> => ({
     ...commonProperties,
     {
       path: rdf.type,
-      hasValue: [schema.DefinedTerm],
+      hasValue: [schema.DefinedTerm, md.ManagedDimensionTerm],
       hidden: true,
     },
     {

--- a/apis/managed-dimensions/test/lib/domain/managed-dimension.test.ts
+++ b/apis/managed-dimensions/test/lib/domain/managed-dimension.test.ts
@@ -2,7 +2,7 @@ import { describe, it, beforeEach } from 'mocha'
 import { expect } from 'chai'
 import { namedNode } from '@cube-creator/testing/clownface'
 import { hydra, rdf, schema, xsd } from '@tpluscode/rdf-ns-builders'
-import { meta } from '@cube-creator/core/namespace'
+import { md, meta } from '@cube-creator/core/namespace'
 import { create, createTerm } from '../../../lib/domain/managed-dimension'
 import { ManagedDimensionsStore } from '../../../lib/store'
 import { testStore } from '../../support/store'
@@ -52,9 +52,9 @@ describe('@cube-creator/managed-dimensions-api/lib/domain/managed-dimension', ()
       expect(termSet).to.matchShape({
         property: [{
           path: rdf.type,
-          hasValue: [hydra.Resource, schema.DefinedTermSet, meta.SharedDimension],
-          minCount: 3,
-          maxCount: 3,
+          hasValue: [hydra.Resource, schema.DefinedTermSet, meta.SharedDimension, md.ManagedDimension],
+          minCount: 4,
+          maxCount: 4,
         }],
       })
     })
@@ -95,6 +95,24 @@ describe('@cube-creator/managed-dimensions-api/lib/domain/managed-dimension', ()
 
       // then
       expect(term.value).to.match(/term-set\/term-.+$/)
+    })
+
+    it('derives URI from the term set and slugifies the name', async () => {
+      // given
+      const termSet = namedNode('term-set')
+        .addOut(schema.validFrom, $rdf.literal('2000-10-02', xsd.date))
+      const resource = namedNode('')
+        .addOut(schema.name, 'Term')
+
+      // when
+      const term = await createTerm({
+        store: testStore(),
+        termSet,
+        resource,
+      })
+
+      // then
+      expect(term.out(rdf.type).terms).to.deep.contain(md.ManagedDimensionTerm)
     })
   })
 })

--- a/apis/managed-dimensions/test/lib/shapes/index.test.ts
+++ b/apis/managed-dimensions/test/lib/shapes/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, before, beforeEach } from 'mocha'
 import { blankNode, namedNode } from '@cube-creator/testing/clownface'
 import { qudt, rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
+import { md } from '@cube-creator/core/namespace'
 import $rdf from 'rdf-ext'
 import { expect } from 'chai'
 import { NamedNode } from 'rdf-js'
@@ -57,7 +58,7 @@ describe('@cube-creator/managed-dimensions-api/lib/shapes', () => {
     })
   })
 
-  describe('managed-dimension-term-create', () => {
+  describe('managed-dimension-term-update', () => {
     before(() => {
       shape = shapes.get(ns.shape['shape/managed-dimension-term-update'])!()
     })
@@ -67,7 +68,7 @@ describe('@cube-creator/managed-dimensions-api/lib/shapes', () => {
     beforeEach(() => {
       term = blankNode()
         .addOut(schema.name, $rdf.literal('Foo', 'en'))
-        .addOut(rdf.type, schema.DefinedTerm)
+        .addOut(rdf.type, [schema.DefinedTerm, md.ManagedDimensionTerm])
         .addOut(schema.inDefinedTermSet, namedNode('term-set'))
     })
 
@@ -86,6 +87,14 @@ describe('@cube-creator/managed-dimensions-api/lib/shapes', () => {
     it('is not valid when a term does not have a term set', () => {
       // given
       term.deleteOut(schema.inDefinedTermSet)
+
+      // then
+      expect(term).not.to.matchShape(shape)
+    })
+
+    it('is not valid when a term does not have types', () => {
+      // given
+      term.deleteOut(rdf.type)
 
       // then
       expect(term).not.to.matchShape(shape)

--- a/e2e-tests/managed-dimensions/term-set.hydra
+++ b/e2e-tests/managed-dimensions/term-set.hydra
@@ -24,12 +24,7 @@ With Class meta:SharedDimension {
             prefix meta: <https://cube.link/meta/>
             prefix sh: <http://www.w3.org/ns/shacl#>
 
-            <> schema:name "node.js"@en ;
-              sh:property [
-                schema:name "node.js"@en ;
-                qudt:scaleType qudt:NominalScale ;
-              ] ;
-            .
+            <> schema:name "node.js"@en .
             ```
         } => {
             Expect Status 201

--- a/e2e-tests/managed-dimensions/term.hydra
+++ b/e2e-tests/managed-dimensions/term.hydra
@@ -23,9 +23,10 @@ With Class schema:DefinedTerm {
             prefix qudt: <http://qudt.org/schema/qudt/>
             prefix meta: <https://cube.link/meta/>
             prefix sh: <http://www.w3.org/ns/shacl#>
+            PREFIX md: <https://cube-creator.zazuko.com/managed-dimensions/vocab#>
 
             <>
-              a schema:DefinedTerm ;
+              a schema:DefinedTerm, md:ManagedDimensionTerm ;
               schema:identifier "rdf" ;
               schema:name "Resource Description Framework"@en, "Resource Description Framework"@de ;
               schema:inDefinedTermSet <https://cube-creator.lndo.site/managed-dimensions/term-set/technologies> ;

--- a/fuseki/managed-dimensions.trig
+++ b/fuseki/managed-dimensions.trig
@@ -71,7 +71,7 @@ graph <http://example.com/dimension/colors> {
 
 graph <https://lindas.admin.ch/cube/dimension> {
   <term-set/technologies>
-    a schema:DefinedTermSet, meta:SharedDimension, hydra:Resource ;
+    a schema:DefinedTermSet, meta:SharedDimension, hydra:Resource, md:ManagedDimension ;
     schema:name "Technologies"@en ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     sh:node [
@@ -83,7 +83,7 @@ graph <https://lindas.admin.ch/cube/dimension> {
   .
 
   <term-set/technologies/rdf>
-    a schema:DefinedTerm, hydra:Resource ;
+    a schema:DefinedTerm, hydra:Resource, md:ManagedDimensionTerm ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     schema:identifier "rdf" ;
     schema:name "RDF"@en ;
@@ -99,7 +99,7 @@ graph <https://lindas.admin.ch/cube/dimension> {
   .
 
   <term-set/technologies/shacl>
-    a schema:DefinedTerm, hydra:Resource ;
+    a schema:DefinedTerm, hydra:Resource, md:ManagedDimensionTerm ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     schema:identifier "shacl", "sh" ;
     schema:name "SHACL"@en ;
@@ -115,7 +115,7 @@ graph <https://lindas.admin.ch/cube/dimension> {
   .
 
   <term-set/technologies/sparql>
-    a schema:DefinedTerm, hydra:Resource ;
+    a schema:DefinedTerm, hydra:Resource, md:ManagedDimensionTerm ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     schema:identifier "sparql" ;
     schema:name "SPARQL"@en ;

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -76,7 +76,9 @@ type MetaDataProperty =
 type CubeCreatorTerms = CubeCreatorClass | CubeCreatorProperty | OtherTerms | MetaDataProperty
 
 type ManagedDimensionsTerms =
+  'ManagedDimension' |
   'ManagedDimensions' |
+  'ManagedDimensionTerm' |
   'ManagedDimensionTerms' |
   'managedDimensions' |
   'terms'


### PR DESCRIPTION
Reintroduce `md:ManagedDimension(Term)` types to separate API operations from external `meta:SharedDimension`