### PR TITLE
build: use proper version ranges between packages

### DIFF
--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -6,10 +6,10 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@cube-creator/core": "*",
+    "@cube-creator/core": "^0.2.0",
     "@cube-creator/api-errors": "0.0.0",
-    "@cube-creator/model": "*",
-    "@cube-creator/managed-dimensions-api": "*",
+    "@cube-creator/model": "^0.1.16",
+    "@cube-creator/managed-dimensions-api": "^0.1.0",
     "@hydrofoil/labyrinth": "^0.4.1",
     "@rdfine/csvw": "^0.6.3",
     "@rdfine/hydra": "^0.6.4",
@@ -68,7 +68,7 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-typescript": "^7.10.4",
     "@babel/register": "^7.11.5",
-    "@cube-creator/testing": "*",
+    "@cube-creator/testing": "^0.1.15",
     "@types/absolute-url": "^1.2.0",
     "@types/chai": "^4.2.13",
     "@types/chai-as-promised": "^7.1.3",

--- a/apis/managed-dimensions/package.json
+++ b/apis/managed-dimensions/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@cube-creator/core": "*",
+    "@cube-creator/core": "^0.2.0",
     "@hydrofoil/labyrinth": "^0.4.1",
     "@rdfine/schema": "^0.6.3",
     "@cube-creator/api-errors": "0.0.0",
@@ -29,7 +29,7 @@
     "sparql-http-client": "^2.2.2"
   },
   "devDependencies": {
-    "@cube-creator/testing": "*",
+    "@cube-creator/testing": "^0.1.15",
     "@types/sinon": "^9.0.10",
     "mocha": "^8.1.3",
     "chai": "^4.2.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,8 +10,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@cube-creator/core": "*",
-    "@cube-creator/model": "*",
+    "@cube-creator/core": "^0.2.0",
+    "@cube-creator/model": "^0.1.16",
     "@rdfine/csvw": "^0.6.3",
     "@rdfine/prov": "^0.1.1",
     "@rdfine/schema": "^0.6.3",
@@ -54,8 +54,7 @@
     "through2-reduce": "1.1.1"
   },
   "devDependencies": {
-    "@cube-creator/core": "*",
-    "@cube-creator/testing": "*",
+    "@cube-creator/testing": "^0.1.15",
     "@tpluscode/rdf-ns-builders": "^0.4",
     "@tpluscode/rdf-string": "^0.2.21",
     "@tpluscode/sparql-builder": "^0.3.10",

--- a/packages/express-rdf-request/package.json
+++ b/packages/express-rdf-request/package.json
@@ -13,7 +13,7 @@
     "hydra-box": "^0.6"
   },
   "devDependencies": {
-    "@cube-creator/testing": "*",
+    "@cube-creator/testing": "^0.1.15",
     "@tpluscode/rdf-string": "^0.2.21",
     "chai": "^4.2.0",
     "chai-snapshot-matcher": "^1.0.6",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.16",
   "private": true,
   "dependencies": {
-    "@cube-creator/core": "*",
+    "@cube-creator/core": "^0.2.0",
     "@rdf-esm/data-model": "^0.5.3",
     "@rdfine/csvw": "^0.6.3",
     "@rdfine/hydra": "^0.6.4",

--- a/packages/shacl-middleware/package.json
+++ b/packages/shacl-middleware/package.json
@@ -17,7 +17,7 @@
     "express-rdf-request": "0.1.0"
   },
   "devDependencies": {
-    "@cube-creator/testing": "*",
+    "@cube-creator/testing": "^0.1.15",
     "@rdfjs/term-map": "^1.0.0",
     "@tpluscode/rdf-string": "^0.2.21",
     "@types/rdf-js": "^4",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.15",
   "private": true,
   "dependencies": {
-    "@cube-creator/core": "*",
+    "@cube-creator/core": "^0.2.0",
     "@rdfjs/formats-common": "^2.1.0",
     "@rdfjs/namespace": "^1.1.0",
     "@rdfjs/express-handler": "^1.2.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,8 +11,8 @@
     "serve-local": "nodenv --env ../.local.env --exec 'vue-cli-service serve'"
   },
   "dependencies": {
-    "@cube-creator/core": "*",
-    "@cube-creator/model": "*",
+    "@cube-creator/core": "^0.2.0",
+    "@cube-creator/model": "^0.1.16",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-regular-svg-icons": "^5.15.1",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",


### PR DESCRIPTION
`"*"` ranges prevent automatic version bumps when a dependency changes in the monorepo