### PR TITLE
fix: shared dimension idnetifier

### DIFF
--- a/.changeset/cool-jeans-wonder.md
+++ b/.changeset/cool-jeans-wonder.md
@@ -2,4 +2,4 @@
 "@cube-creator/shared-dimensions-api": patch
 ---
 
-Create share dimension URIs from user-provided identifier
+Create shared dimension URIs from user-provided identifier

--- a/.changeset/cool-jeans-wonder.md
+++ b/.changeset/cool-jeans-wonder.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Create share dimension URIs from user-provided identifier

--- a/.changeset/fifty-doors-deliver.md
+++ b/.changeset/fifty-doors-deliver.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": minor
+---
+
+Change the resoure naming scheme

--- a/apis/core/index.ts
+++ b/apis/core/index.ts
@@ -55,7 +55,7 @@ async function main() {
   app.use(await authentication())
   app.use(resource)
 
-  app.use('/shared-dimensions', await sharedDimensions())
+  app.use(['/shared-dimensions', '/dimension'], await sharedDimensions())
 
   app.use(resourceStore)
   app.use(await hydraBox({

--- a/apis/shared-dimensions/lib/domain/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension.ts
@@ -1,12 +1,12 @@
 import clownface, { GraphPointer } from 'clownface'
 import { NamedNode, Quad } from 'rdf-js'
 import $rdf from 'rdf-ext'
-import UrlSlugify from 'url-slugify'
-import { hydra, rdf, schema } from '@tpluscode/rdf-ns-builders'
+import { dcterms, hydra, rdf, schema } from '@tpluscode/rdf-ns-builders'
 import { md, meta } from '@cube-creator/core/namespace'
 import { DomainError } from '@cube-creator/api-errors'
 import env from '../env'
 import { SharedDimensionsStore } from '../store'
+import httpError from 'http-errors'
 
 interface CreateSharedDimension {
   resource: GraphPointer<NamedNode>
@@ -14,7 +14,7 @@ interface CreateSharedDimension {
 }
 
 function newId(base: string, name: string) {
-  return $rdf.namedNode(`${base}/${new UrlSlugify().slugify(name)}`)
+  return $rdf.namedNode(`${base}/${name}`)
 }
 
 function replace(from: NamedNode, to: NamedNode) {
@@ -26,12 +26,16 @@ function replace(from: NamedNode, to: NamedNode) {
 }
 
 export async function create({ resource, store }: CreateSharedDimension): Promise<GraphPointer> {
-  const name = resource.out(schema.name, { language: ['en', '*'] }).value
-  if (!name) {
-    throw new DomainError('Missing dimension name')
+  const identifier = resource.out(dcterms.identifier).value
+  if (!identifier) {
+    throw new DomainError('Missing dimension identifier')
   }
 
-  const termSetId = newId(`${env.MANAGED_DIMENSIONS_BASE}term-set`, name)
+  const termSetId = newId(`${env.MANAGED_DIMENSIONS_BASE}term-set`, identifier)
+  if (await store.exists(termSetId, schema.DefinedTermSet)) {
+    throw new httpError.Conflict(`Shared Dimension ${identifier} already exists`)
+  }
+
   const dataset = $rdf.dataset([...resource.dataset].map(replace(resource.term, termSetId)))
   const termSet = clownface({ dataset })
     .namedNode(termSetId)
@@ -48,15 +52,20 @@ interface CreateTerm {
 }
 
 export async function createTerm({ termSet, resource, store }: CreateTerm): Promise<GraphPointer> {
-  const name = resource.out(schema.name, { language: ['en', '*'] }).value
-  if (!name) {
-    throw new DomainError('Missing term name')
+  const identifier = resource.out(dcterms.identifier).value
+  if (!identifier) {
+    throw new DomainError('Missing term id')
   }
 
-  const termId = newId(termSet.value, name)
+  const termId = newId(termSet.value, identifier)
+  if (await store.exists(termId, schema.DefinedTerm)) {
+    throw new httpError.Conflict(`Term ${identifier} already exists`)
+  }
+
   const dataset = $rdf.dataset([...resource.dataset].map(replace(resource.term, termId)))
   const term = clownface({ dataset })
     .namedNode(termId)
+    .deleteOut(dcterms.identifier)
     .addOut(schema.inDefinedTermSet, termSet)
     .addOut(rdf.type, [schema.DefinedTerm, hydra.Resource, md.SharedDimensionTerm])
 

--- a/apis/shared-dimensions/lib/domain/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension.ts
@@ -14,6 +14,9 @@ interface CreateSharedDimension {
 }
 
 function newId(base: string, name: string) {
+  if (base.endsWith('/')) {
+    return $rdf.namedNode(`${base}${name}`)
+  }
   return $rdf.namedNode(`${base}/${name}`)
 }
 
@@ -31,7 +34,7 @@ export async function create({ resource, store }: CreateSharedDimension): Promis
     throw new DomainError('Missing dimension identifier')
   }
 
-  const termSetId = newId(`${env.MANAGED_DIMENSIONS_BASE}`, identifier)
+  const termSetId = newId(new URL('/dimension', env.MANAGED_DIMENSIONS_BASE).toString(), identifier)
   if (await store.exists(termSetId, schema.DefinedTermSet)) {
     throw new httpError.Conflict(`Shared Dimension ${identifier} already exists`)
   }

--- a/apis/shared-dimensions/lib/domain/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension.ts
@@ -31,7 +31,7 @@ export async function create({ resource, store }: CreateSharedDimension): Promis
     throw new DomainError('Missing dimension identifier')
   }
 
-  const termSetId = newId(`${env.MANAGED_DIMENSIONS_BASE}term-set`, identifier)
+  const termSetId = newId(`${env.MANAGED_DIMENSIONS_BASE}`, identifier)
   if (await store.exists(termSetId, schema.DefinedTermSet)) {
     throw new httpError.Conflict(`Shared Dimension ${identifier} already exists`)
   }

--- a/apis/shared-dimensions/lib/shapes/shared-dimension-term.ts
+++ b/apis/shared-dimensions/lib/shapes/shared-dimension-term.ts
@@ -1,6 +1,6 @@
 import { Initializer } from '@tpluscode/rdfine/RdfResource'
 import { NodeShape, PropertyShape } from '@rdfine/shacl'
-import { dash, rdf, schema, xsd } from '@tpluscode/rdf-ns-builders'
+import { dash, dcterms, rdf, schema, xsd } from '@tpluscode/rdf-ns-builders'
 import { supportedLanguages } from '@cube-creator/core/languages'
 import { md } from '@cube-creator/core/namespace'
 
@@ -34,7 +34,17 @@ const commonProperties: Initializer<PropertyShape>[] = [{
 
 export const create = (): Initializer<NodeShape> => ({
   closed: true,
-  property: commonProperties,
+  property: [
+    ...commonProperties,
+    {
+      name: 'Identifier',
+      description: 'A lowercase, alphanumeric value which identifies a shared dimension term',
+      path: dcterms.identifier,
+      order: 0,
+      pattern: '^[a-z0-9-]+$',
+      minCount: 1,
+      maxCount: 1,
+    }],
 })
 
 export const update = (): Initializer<NodeShape> => ({

--- a/apis/shared-dimensions/lib/shapes/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/shapes/shared-dimension.ts
@@ -1,4 +1,4 @@
-import { dash, qudt, rdf, rdfs, schema, sh, time, xsd } from '@tpluscode/rdf-ns-builders'
+import { dash, dcterms, qudt, rdf, rdfs, schema, sh, time, xsd } from '@tpluscode/rdf-ns-builders'
 import { supportedLanguages } from '@cube-creator/core/languages'
 import type { Initializer } from '@tpluscode/rdfine/RdfResource'
 import type { NodeShape } from '@rdfine/shacl'
@@ -8,6 +8,14 @@ import { meta, sh1 } from '@cube-creator/core/namespace'
 export default (): Initializer<NodeShape> => ({
   closed: true,
   property: [{
+    name: 'Identifier',
+    description: 'A lowercase, alphanumeric value which identifies a shared dimension',
+    path: dcterms.identifier,
+    order: 0,
+    pattern: '^[a-z0-9-]+$',
+    minCount: 1,
+    maxCount: 1,
+  }, {
     name: 'Name',
     path: schema.name,
     uniqueLang: true,

--- a/apis/shared-dimensions/package.json
+++ b/apis/shared-dimensions/package.json
@@ -25,7 +25,6 @@
     "middleware-async": "^1.2.7",
     "once": "^1.4.0",
     "rdf-ext": "^1.3.0",
-    "url-slugify": "^1.0.6",
     "sparql-http-client": "^2.2.2"
   },
   "devDependencies": {

--- a/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
+++ b/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
@@ -26,7 +26,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       const termSet = await create({ resource, store })
 
       // then
-      expect(termSet.value).to.match(/\/canton$/)
+      expect(termSet.value).to.eq('https://cube-creator.lndo.site/dimension/canton')
     })
 
     it('saves to the store', async () => {
@@ -77,7 +77,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
   describe('createTerm', () => {
     it("copies term set's validFrom data", async () => {
       // given
-      const termSet = namedNode('term-set')
+      const termSet = namedNode('http://example.com/term-set')
         .addOut(schema.validFrom, $rdf.literal('2000-10-02', xsd.date))
       const resource = namedNode('')
         .addOut(dcterms.identifier, 'Term')
@@ -95,7 +95,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
 
     it('creates URI from the term set and identifier', async () => {
       // given
-      const termSet = namedNode('term-set')
+      const termSet = namedNode('http://example.com/term-set')
         .addOut(schema.validFrom, $rdf.literal('2000-10-02', xsd.date))
       const resource = namedNode('')
         .addOut(dcterms.identifier, 'term')
@@ -108,7 +108,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       })
 
       // then
-      expect(term.value).to.match(/term-set\/term$/)
+      expect(term.value).to.eq('http://example.com/term-set/term')
     })
 
     it('throws if identifier is already used', async () => {
@@ -133,7 +133,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
 
     it('ensures rdf type', async () => {
       // given
-      const termSet = namedNode('term-set')
+      const termSet = namedNode('http://example.com/term-set')
         .addOut(schema.validFrom, $rdf.literal('2000-10-02', xsd.date))
       const resource = namedNode('')
         .addOut(dcterms.identifier, 'Term')

--- a/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
+++ b/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, beforeEach } from 'mocha'
 import { expect } from 'chai'
 import { namedNode } from '@cube-creator/testing/clownface'
-import { hydra, rdf, schema, xsd } from '@tpluscode/rdf-ns-builders'
+import { dcterms, hydra, rdf, schema, xsd } from '@tpluscode/rdf-ns-builders'
 import { md, meta } from '@cube-creator/core/namespace'
 import { create, createTerm } from '../../../lib/domain/shared-dimension'
 import { SharedDimensionsStore } from '../../../lib/store'
 import { testStore } from '../../support/store'
 import $rdf from 'rdf-ext'
+import httpError from 'http-errors'
 
 describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () => {
   describe('create', () => {
@@ -16,22 +17,22 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       store = testStore()
     })
 
-    it('generates a unique id derived from dimension name', async () => {
+    it('creates id using provided identifier', async () => {
       // given
       const resource = namedNode('')
-        .addOut(schema.name, 'canton')
+        .addOut(dcterms.identifier, 'canton')
 
       // when
       const termSet = await create({ resource, store })
 
       // then
-      expect(termSet.value).to.match(/\/canton-.+$/)
+      expect(termSet.value).to.match(/\/canton$/)
     })
 
     it('saves to the store', async () => {
       // given
       const resource = namedNode('')
-        .addOut(schema.name, 'canton')
+        .addOut(dcterms.identifier, 'canton')
 
       // when
       await create({ resource, store })
@@ -43,7 +44,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
     it('adds required RDF types', async () => {
       // given
       const resource = namedNode('')
-        .addOut(schema.name, 'canton')
+        .addOut(dcterms.identifier, 'canton')
 
       // when
       const termSet = await create({ resource, store })
@@ -58,6 +59,19 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
         }],
       })
     })
+
+    it('throws if identifier is already used', async () => {
+      // given
+      await store.save(namedNode('https://cube-creator.lndo.site/shared-dimensions/term-set/canton'))
+      const resource = namedNode('')
+        .addOut(dcterms.identifier, 'canton')
+
+      // when
+      const promise = create({ resource, store })
+
+      // then
+      expect(promise).eventually.rejectedWith(httpError.Conflict)
+    })
   })
 
   describe('createTerm', () => {
@@ -66,7 +80,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       const termSet = namedNode('term-set')
         .addOut(schema.validFrom, $rdf.literal('2000-10-02', xsd.date))
       const resource = namedNode('')
-        .addOut(schema.name, 'Term')
+        .addOut(dcterms.identifier, 'Term')
 
       // when
       const term = await createTerm({
@@ -79,12 +93,12 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       expect(term.out(schema.validFrom).term).to.deep.eq(termSet.out(schema.validFrom).term)
     })
 
-    it('derives URI from the term set and slugifies the name', async () => {
+    it('creates URI from the term set and identifier', async () => {
       // given
       const termSet = namedNode('term-set')
         .addOut(schema.validFrom, $rdf.literal('2000-10-02', xsd.date))
       const resource = namedNode('')
-        .addOut(schema.name, 'Term')
+        .addOut(dcterms.identifier, 'term')
 
       // when
       const term = await createTerm({
@@ -94,15 +108,35 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       })
 
       // then
-      expect(term.value).to.match(/term-set\/term-.+$/)
+      expect(term.value).to.match(/term-set\/term$/)
     })
 
-    it('derives URI from the term set and slugifies the name', async () => {
+    it('throws if identifier is already used', async () => {
+      // given
+      const store = testStore()
+      await store.save(namedNode('https://cube-creator.lndo.site/shared-dimensions/term-set/canton/bern'))
+      const termSet = namedNode('term-set')
+        .addOut(schema.validFrom, $rdf.literal('2000-10-02', xsd.date))
+      const resource = namedNode('')
+        .addOut(dcterms.identifier, 'bern')
+
+      // when
+      const promise = createTerm({
+        store,
+        termSet,
+        resource,
+      })
+
+      // then
+      expect(promise).eventually.rejectedWith(httpError.Conflict)
+    })
+
+    it('ensures rdf type', async () => {
       // given
       const termSet = namedNode('term-set')
         .addOut(schema.validFrom, $rdf.literal('2000-10-02', xsd.date))
       const resource = namedNode('')
-        .addOut(schema.name, 'Term')
+        .addOut(dcterms.identifier, 'Term')
 
       // when
       const term = await createTerm({

--- a/apis/shared-dimensions/test/lib/shapes/index.test.ts
+++ b/apis/shared-dimensions/test/lib/shapes/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, beforeEach } from 'mocha'
 import { blankNode, namedNode } from '@cube-creator/testing/clownface'
-import { qudt, rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
+import { dcterms, qudt, rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
 import { md } from '@cube-creator/core/namespace'
 import $rdf from 'rdf-ext'
 import { expect } from 'chai'
@@ -20,6 +20,7 @@ describe('@cube-creator/shared-dimensions-api/lib/shapes', () => {
     it('is valid when resource has all required props', () => {
       // given
       const resource = blankNode()
+        .addOut(dcterms.identifier, $rdf.literal('test'))
         .addOut(schema.name, $rdf.literal('Test', 'en'))
         .addOut(sh.property, prop => {
           prop
@@ -41,6 +42,7 @@ describe('@cube-creator/shared-dimensions-api/lib/shapes', () => {
     it('is valid when a term has only names', () => {
       // given
       const resource = blankNode()
+        .addOut(dcterms.identifier, $rdf.literal('test'))
         .addOut(schema.name, [$rdf.literal('Foo', 'en'), $rdf.literal('bar', 'de')])
 
       // then
@@ -50,6 +52,7 @@ describe('@cube-creator/shared-dimensions-api/lib/shapes', () => {
     it('is valid when a term has many identifiers', () => {
       // given
       const resource = blankNode()
+        .addOut(dcterms.identifier, $rdf.literal('test'))
         .addOut(schema.name, $rdf.literal('Foo', 'en'))
         .addOut(schema.identifier, ['a', 'b', 'c'])
 

--- a/apis/shared-dimensions/test/support/store.ts
+++ b/apis/shared-dimensions/test/support/store.ts
@@ -1,4 +1,5 @@
 import TermMap from '@rdfjs/term-map'
+import { rdf } from '@tpluscode/rdf-ns-builders'
 import sinon from 'sinon'
 import { SharedDimensionsStore } from '../../lib/store'
 
@@ -14,6 +15,11 @@ export function testStore(): SharedDimensionsStore {
     },
     async delete(term) {
       resources.delete(term)
+    },
+    async exists(term, type) {
+      const resource = await this.load(term)
+
+      return resource?.has(rdf.type, type).terms.length > 0
     },
   }
 

--- a/e2e-tests/shared-dimensions/term-set.hydra
+++ b/e2e-tests/shared-dimensions/term-set.hydra
@@ -23,8 +23,10 @@ With Class meta:SharedDimension {
             prefix qudt: <http://qudt.org/schema/qudt/>
             prefix meta: <https://cube.link/meta/>
             prefix sh: <http://www.w3.org/ns/shacl#>
+            prefix dcterms: <http://purl.org/dc/terms/>
 
             <> schema:name "node.js"@en ;
+               dcterms:identifier "node-js" ;
                schema:validThrough "2022-01-01T00:00:00Z"^^xsd:dateTime .
             ```
         } => {

--- a/e2e-tests/shared-dimensions/term-set.hydra
+++ b/e2e-tests/shared-dimensions/term-set.hydra
@@ -5,7 +5,7 @@ PREFIX qudt: <http://qudt.org/schema/qudt/>
 PREFIX meta: <https://cube.link/meta/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-ENTRYPOINT "shared-dimensions/technologies"
+ENTRYPOINT "dimension/technologies"
 
 HEADERS {
   x-user "john-doe"

--- a/e2e-tests/shared-dimensions/term-set.hydra
+++ b/e2e-tests/shared-dimensions/term-set.hydra
@@ -5,7 +5,7 @@ PREFIX qudt: <http://qudt.org/schema/qudt/>
 PREFIX meta: <https://cube.link/meta/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-ENTRYPOINT "shared-dimensions/term-set/technologies"
+ENTRYPOINT "shared-dimensions/technologies"
 
 HEADERS {
   x-user "john-doe"

--- a/e2e-tests/shared-dimensions/term-sets.hydra
+++ b/e2e-tests/shared-dimensions/term-sets.hydra
@@ -29,8 +29,10 @@ With Class hydra:Resource {
                 prefix qudt: <http://qudt.org/schema/qudt/>
                 prefix meta: <https://cube.link/meta/>
                 prefix sh: <http://www.w3.org/ns/shacl#>
+                prefix dcterms: <http://purl.org/dc/terms/>
 
                 <> schema:name "Categories"@en ;
+                   dcterms:identifier "categories" ;
                    schema:validFrom "2020-02-20T00:00:00"^^xsd:dateTime ;
                    sh:property [
                      schema:name "Categories"@en ;

--- a/e2e-tests/shared-dimensions/term.hydra
+++ b/e2e-tests/shared-dimensions/term.hydra
@@ -5,7 +5,7 @@ PREFIX qudt: <http://qudt.org/schema/qudt/>
 PREFIX meta: <https://cube.link/meta/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-ENTRYPOINT "shared-dimensions/technologies/rdf"
+ENTRYPOINT "dimension/technologies/rdf"
 
 HEADERS {
   x-user "john-doe"
@@ -29,7 +29,7 @@ With Class schema:DefinedTerm {
               a schema:DefinedTerm, md:SharedDimensionTerm ;
               schema:identifier "rdf" ;
               schema:name "Resource Description Framework"@en, "Resource Description Framework"@de ;
-              schema:inDefinedTermSet <https://cube-creator.lndo.site/shared-dimensions/technologies> ;
+              schema:inDefinedTermSet <https://cube-creator.lndo.site/dimension/technologies> ;
             .
             ```
         } => {

--- a/e2e-tests/shared-dimensions/term.hydra
+++ b/e2e-tests/shared-dimensions/term.hydra
@@ -5,7 +5,7 @@ PREFIX qudt: <http://qudt.org/schema/qudt/>
 PREFIX meta: <https://cube.link/meta/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-ENTRYPOINT "shared-dimensions/term-set/technologies/rdf"
+ENTRYPOINT "shared-dimensions/technologies/rdf"
 
 HEADERS {
   x-user "john-doe"
@@ -29,7 +29,7 @@ With Class schema:DefinedTerm {
               a schema:DefinedTerm, md:SharedDimensionTerm ;
               schema:identifier "rdf" ;
               schema:name "Resource Description Framework"@en, "Resource Description Framework"@de ;
-              schema:inDefinedTermSet <https://cube-creator.lndo.site/shared-dimensions/term-set/technologies> ;
+              schema:inDefinedTermSet <https://cube-creator.lndo.site/shared-dimensions/technologies> ;
             .
             ```
         } => {

--- a/fuseki/shared-dimensions.trig
+++ b/fuseki/shared-dimensions.trig
@@ -6,7 +6,7 @@ prefix md: <https://cube-creator.zazuko.com/shared-dimensions/vocab#>
 prefix void: <http://rdfs.org/ns/void#>
 prefix schema: <http://schema.org/>
 prefix meta: <https://cube.link/meta/>
-base <https://cube-creator.lndo.site/shared-dimensions/>
+base <https://cube-creator.lndo.site/dimension/>
 
 <shared-dimensions> a void:Dataset .
 

--- a/fuseki/shared-dimensions.trig
+++ b/fuseki/shared-dimensions.trig
@@ -70,30 +70,30 @@ graph <http://example.com/dimension/colors> {
 }
 
 graph <https://lindas.admin.ch/cube/dimension> {
-  <term-set/technologies>
+  <technologies>
     a schema:DefinedTermSet, meta:SharedDimension, hydra:Resource, md:SharedDimension ;
     schema:name "Technologies"@en ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
   .
 
   [
-    sh:targetNode <term-set/technologies> ;
+    sh:targetNode <technologies> ;
     sh:property
       [ sh:path schema:name ],
       [ sh:path rdf:type ],
       [ sh:path schema:validFrom ] ;
   ] .
 
-  <term-set/technologies/rdf>
+  <technologies/rdf>
     a schema:DefinedTerm, hydra:Resource, md:SharedDimensionTerm ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     schema:identifier "rdf" ;
     schema:name "RDF"@en ;
-    schema:inDefinedTermSet <term-set/technologies> ;
+    schema:inDefinedTermSet <technologies> ;
   .
 
   [
-    sh:targetNode <term-set/technologies/rdf> ;
+    sh:targetNode <technologies/rdf> ;
     sh:property
       [ sh:path schema:name ],
       [ sh:path rdf:type ],
@@ -102,16 +102,16 @@ graph <https://lindas.admin.ch/cube/dimension> {
       [ sh:path schema:inDefinedTermSet ] ;
   ] .
 
-  <term-set/technologies/shacl>
+  <technologies/shacl>
     a schema:DefinedTerm, hydra:Resource, md:SharedDimensionTerm ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     schema:identifier "shacl", "sh" ;
     schema:name "SHACL"@en ;
-    schema:inDefinedTermSet <term-set/technologies> ;
+    schema:inDefinedTermSet <technologies> ;
   .
 
   [
-    sh:targetNode <term-set/technologies/shacl> ;
+    sh:targetNode <technologies/shacl> ;
     sh:property
       [ sh:path schema:name ],
       [ sh:path rdf:type ],
@@ -120,16 +120,16 @@ graph <https://lindas.admin.ch/cube/dimension> {
       [ sh:path schema:inDefinedTermSet ] ;
   ] .
 
-  <term-set/technologies/sparql>
+  <technologies/sparql>
     a schema:DefinedTerm, hydra:Resource, md:SharedDimensionTerm ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     schema:identifier "sparql" ;
     schema:name "SPARQL"@en ;
-    schema:inDefinedTermSet <term-set/technologies> ;
+    schema:inDefinedTermSet <technologies> ;
   .
 
   [
-    sh:targetNode <term-set/technologies/sparql> ;
+    sh:targetNode <technologies/sparql> ;
     sh:property
       [ sh:path schema:name ],
       [ sh:path rdf:type ],


### PR DESCRIPTION
Add `dcterms:identifier` to be used to generate term (set) URIs. (only lowercase, number and hyphen)

Will respond 409 if another term (Set) with the generated URI already exists.

Is it a little weird to have both `dcterms:identfier` and `schema:identifier`? 🤷 