### PR TITLE
refactor: reverse relation shape describing resources

### DIFF
--- a/apis/shared-dimensions/lib/store.ts
+++ b/apis/shared-dimensions/lib/store.ts
@@ -17,7 +17,11 @@ export interface SharedDimensionsStore {
 
 function resourceQueryPatterns(id: NamedNode) {
   return sparql`
-    ${id} ${sh.node} ?rootShape .
+    ?rootShape ${sh.targetNode} ${id} .
+    MINUS {
+      # Exclude shapes which are children of property shapes
+      ?propertyShape ${sh.node} ?rootShape .
+    }
 
     ?rootShape ${sh.property}/${sh.path} ?rootProp .
     ${id} ?rootProp ?rootObject .
@@ -67,7 +71,7 @@ export default class Store implements SharedDimensionsStore {
 
   save(resource: GraphPointer<NamedNode>): Promise<void> {
     const shape = this.extractShape(resource)
-    shape.addIn(sh.node, resource)
+    shape.addOut(sh.targetNode, resource)
 
     const insert = INSERT.DATA`GRAPH ${this.graph} {
       ${resource.dataset}

--- a/apis/shared-dimensions/test/lib/loader.test.ts
+++ b/apis/shared-dimensions/test/lib/loader.test.ts
@@ -15,12 +15,13 @@ graph ${graph} {
     a ${hydra.Resource} ;
     ${schema.name} "Yes" ;
     ${ex.hidden} "foo" ;
-    ${sh.node} [
-      ${sh.property} [
+  .
+  [
+    ${sh.targetNode} ${ex.foo} ;
+    ${sh.property} [
         ${sh.path} ${schema.name} ;
       ] ;
-    ] ;
-  .
+  ]
 }
 
 graph ${ex('different-graph')} {
@@ -88,9 +89,6 @@ describe('shared-dimensions/lib/loader @SPARQL', () => {
         expect(await resource.dataset()).to.matchShape({
           targetNode: [ex.foo],
           property: [{
-            path: sh.node,
-            maxCount: 0,
-          }, {
             path: ex.hidden,
             maxCount: 0,
           }],

--- a/fuseki/shared-dimensions.trig
+++ b/fuseki/shared-dimensions.trig
@@ -74,13 +74,15 @@ graph <https://lindas.admin.ch/cube/dimension> {
     a schema:DefinedTermSet, meta:SharedDimension, hydra:Resource, md:SharedDimension ;
     schema:name "Technologies"@en ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
-    sh:node [
-              sh:property
-                [ sh:path schema:name ],
-                [ sh:path rdf:type ],
-                [ sh:path schema:validFrom ]
-            ] ;
   .
+
+  [
+    sh:targetNode <term-set/technologies> ;
+    sh:property
+      [ sh:path schema:name ],
+      [ sh:path rdf:type ],
+      [ sh:path schema:validFrom ] ;
+  ] .
 
   <term-set/technologies/rdf>
     a schema:DefinedTerm, hydra:Resource, md:SharedDimensionTerm ;
@@ -88,15 +90,17 @@ graph <https://lindas.admin.ch/cube/dimension> {
     schema:identifier "rdf" ;
     schema:name "RDF"@en ;
     schema:inDefinedTermSet <term-set/technologies> ;
-    sh:node [
-              sh:property
-                [ sh:path schema:name ],
-                [ sh:path rdf:type ],
-                [ sh:path schema:validFrom ],
-                [ sh:path schema:identifier ],
-                [ sh:path schema:inDefinedTermSet ]
-            ] ;
   .
+
+  [
+    sh:targetNode <term-set/technologies/rdf> ;
+    sh:property
+      [ sh:path schema:name ],
+      [ sh:path rdf:type ],
+      [ sh:path schema:validFrom ],
+      [ sh:path schema:identifier ],
+      [ sh:path schema:inDefinedTermSet ] ;
+  ] .
 
   <term-set/technologies/shacl>
     a schema:DefinedTerm, hydra:Resource, md:SharedDimensionTerm ;
@@ -104,15 +108,17 @@ graph <https://lindas.admin.ch/cube/dimension> {
     schema:identifier "shacl", "sh" ;
     schema:name "SHACL"@en ;
     schema:inDefinedTermSet <term-set/technologies> ;
-    sh:node [
-              sh:property
-                [ sh:path schema:name ],
-                [ sh:path rdf:type ],
-                [ sh:path schema:validFrom ],
-                [ sh:path schema:identifier ],
-                [ sh:path schema:inDefinedTermSet ]
-            ] ;
   .
+
+  [
+    sh:targetNode <term-set/technologies/shacl> ;
+    sh:property
+      [ sh:path schema:name ],
+      [ sh:path rdf:type ],
+      [ sh:path schema:validFrom ],
+      [ sh:path schema:identifier ],
+      [ sh:path schema:inDefinedTermSet ] ;
+  ] .
 
   <term-set/technologies/sparql>
     a schema:DefinedTerm, hydra:Resource, md:SharedDimensionTerm ;
@@ -120,13 +126,15 @@ graph <https://lindas.admin.ch/cube/dimension> {
     schema:identifier "sparql" ;
     schema:name "SPARQL"@en ;
     schema:inDefinedTermSet <term-set/technologies> ;
-    sh:node [
-              sh:property
-                [ sh:path schema:name ],
-                [ sh:path rdf:type ],
-                [ sh:path schema:validFrom ],
-                [ sh:path schema:identifier ],
-                [ sh:path schema:inDefinedTermSet ]
-            ] ;
   .
+
+  [
+    sh:targetNode <term-set/technologies/sparql> ;
+    sh:property
+      [ sh:path schema:name ],
+      [ sh:path rdf:type ],
+      [ sh:path schema:validFrom ],
+      [ sh:path schema:identifier ],
+      [ sh:path schema:inDefinedTermSet ] ;
+  ] .
 }


### PR DESCRIPTION
Detaches the shapes describing resource and uses `sh:targetNode` to relate it to said resource.

Run this to update live DB

```sparql
PREFIX sh: <http://www.w3.org/ns/shacl#>

with <https://lindas.admin.ch/cube/dimension> 
delete {
  ?resource sh:node ?shape
} 
insert {
  ?shape sh:targetNode ?resource
}
where { 
  ?resource sh:node ?shape
}
```