### PR TITLE
fix(ui): stop polling jobs on API error

### DIFF
--- a/.changeset/tasty-snails-roll.md
+++ b/.changeset/tasty-snails-roll.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Stop polling project jobs if an error occurs

--- a/ui/src/views/CubeProject.vue
+++ b/ui/src/views/CubeProject.vue
@@ -69,9 +69,7 @@ export default class CubeProjectView extends Vue {
     await this.$store.dispatch('project/fetchProject', id)
 
     // Poll jobs
-    this.poller = window.setInterval(() => {
-      // this.$store.dispatch('project/fetchJobCollection')
-    }, 3000)
+    this.poller = window.setInterval(this.pollJobs, 3000)
 
     if (this.$router.currentRoute.name === 'CubeProject') {
       if (this.hasCSVMapping) {
@@ -83,6 +81,19 @@ export default class CubeProjectView extends Vue {
   }
 
   beforeDestroy (): void {
+    this.stopPolling()
+  }
+
+  async pollJobs (): Promise<any> {
+    try {
+      await this.$store.dispatch('project/fetchJobCollection')
+    } catch (e) {
+      this.stopPolling()
+      throw e
+    }
+  }
+
+  stopPolling (): void {
     if (this.poller) {
       clearInterval(this.poller)
     }


### PR DESCRIPTION
I don't really understand why the error never reaches `App.errorCaptured`, but it probably has to do with the fact that the code is async.

Anyway, this change will just stop polling jobs if any error occurs. This should solve our Sentry overflow issue.