### PR TITLE
build: pin versions to have them bumped on upstream changes

### DIFF
--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -7,9 +7,9 @@
   },
   "dependencies": {
     "@cube-creator/api-errors": "0.0.1",
-    "@cube-creator/core": "^0.3.0",
-    "@cube-creator/model": "^0.1.17",
-    "@cube-creator/shared-dimensions-api": "^0.3.0",
+    "@cube-creator/core": "0.3.0",
+    "@cube-creator/model": "0.1.17",
+    "@cube-creator/shared-dimensions-api": "0.3.0",
     "@hydrofoil/labyrinth": "^0.4.1",
     "@rdfine/csvw": "^0.6.3",
     "@rdfine/hydra": "^0.6.4",

--- a/apis/shared-dimensions/package.json
+++ b/apis/shared-dimensions/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@cube-creator/api-errors": "0.0.1",
-    "@cube-creator/core": "^0.3.0",
+    "@cube-creator/core": "0.3.0",
     "@hydrofoil/labyrinth": "^0.4.1",
     "@rdfine/rdfs": "^0.6.4",
     "@rdfine/schema": "^0.6.3",

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,8 +10,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@cube-creator/core": "^0.3.0",
-    "@cube-creator/model": "^0.1.17",
+    "@cube-creator/core": "0.3.0",
+    "@cube-creator/model": "0.1.17",
     "@rdfine/csvw": "^0.6.3",
     "@rdfine/prov": "^0.1.1",
     "@rdfine/schema": "^0.6.3",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.17",
   "private": true,
   "dependencies": {
-    "@cube-creator/core": "^0.3.0",
+    "@cube-creator/core": "0.3.0",
     "@rdf-esm/data-model": "^0.5.3",
     "@rdfine/csvw": "^0.6.3",
     "@rdfine/hydra": "^0.6.4",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.16",
   "private": true,
   "dependencies": {
-    "@cube-creator/core": "^0.3.0",
+    "@cube-creator/core": "0.3.0",
     "@rdfine/shacl": "^0.7.4",
     "@rdfjs/express-handler": "^1.2.1",
     "@rdfjs/formats-common": "^2.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,8 +11,8 @@
     "serve-local": "nodenv --env ../.local.env --exec 'vue-cli-service serve'"
   },
   "dependencies": {
-    "@cube-creator/core": "^0.3.0",
-    "@cube-creator/model": "^0.1.17",
+    "@cube-creator/core": "0.3.0",
+    "@cube-creator/model": "0.1.17",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-regular-svg-icons": "^5.15.1",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",


### PR DESCRIPTION
Re: https://github.com/atlassian/changesets/issues/544

This ensures that version of dependent packages are bumped when pinned dependencies are updated