### PR TITLE
fix: superfluous quads in cube metadata graphs

### DIFF
--- a/.changeset/cool-flowers-clap.md
+++ b/.changeset/cool-flowers-clap.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Ensure that superfluous quads are remove when cube meta is saved

--- a/.changeset/mighty-ligers-bake.md
+++ b/.changeset/mighty-ligers-bake.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Only load necessary data in the cube metadata form

--- a/apis/core/lib/domain/dataset/update.ts
+++ b/apis/core/lib/domain/dataset/update.ts
@@ -33,8 +33,8 @@ export async function update({
     .addOut(rdf.type, _void.Dataset)
     .addOut(rdf.type, dcat.Dataset)
 
-  hasPart.forEach(child => datasetResource.addOut(schema.hasPart, child))
-  dimensionMetadata.forEach(child => datasetResource.addOut(cc.dimensionMetadata, child))
+  datasetResource.deleteOut(schema.hasPart).addOut(schema.hasPart, hasPart.terms)
+  datasetResource.deleteOut(cc.dimensionMetadata).addOut(cc.dimensionMetadata, dimensionMetadata.terms)
 
   return datasetResource
 }

--- a/apis/core/lib/domain/dataset/update.ts
+++ b/apis/core/lib/domain/dataset/update.ts
@@ -1,31 +1,13 @@
 import { cc } from '@cube-creator/core/namespace'
 import { dcat, hydra, rdf, schema, _void } from '@tpluscode/rdf-ns-builders'
 import { GraphPointer } from 'clownface'
-import { DatasetCore, NamedNode, Term } from 'rdf-js'
-import TermSet from '@rdfjs/term-set'
+import { NamedNode } from 'rdf-js'
 import { ResourceStore } from '../../ResourceStore'
 
 interface AddMetaDataCommand {
   dataset: GraphPointer<NamedNode>
   resource: GraphPointer
   store: ResourceStore
-}
-
-/**
- * Copies quads of given subject and its blank node children
- */
-function copySubgraph({ from, to, subject, alreadyAdded = new TermSet() }: { from: DatasetCore; to: DatasetCore; subject: Term; alreadyAdded?: TermSet }) {
-  if (alreadyAdded.has(subject)) {
-    return
-  }
-  alreadyAdded.add(subject)
-
-  for (const quad of from.match(subject)) {
-    to.add(quad)
-    if (quad.object.termType === 'BlankNode') {
-      copySubgraph({ from, to, alreadyAdded, subject: quad.object })
-    }
-  }
 }
 
 export async function update({
@@ -38,18 +20,12 @@ export async function update({
   const hasPart = datasetResource.out(schema.hasPart)
   const dimensionMetadata = datasetResource.out(cc.dimensionMetadata)
 
-  datasetResource.out().forEach(child => {
-    if (child.term.termType === 'BlankNode') {
-      child.deleteOut()
-    }
-  })
-  datasetResource.deleteOut()
-
-  copySubgraph({
-    from: resource.dataset,
-    to: datasetResource.dataset,
-    subject: datasetResource.term,
-  })
+  for (const quad of datasetResource.dataset) {
+    datasetResource.dataset.delete(quad)
+  }
+  for (const quad of resource.dataset) {
+    datasetResource.dataset.add(quad)
+  }
 
   // Make sure the type is correct
   datasetResource.addOut(rdf.type, hydra.Resource)

--- a/apis/core/test/domain/dataset/update.test.ts
+++ b/apis/core/test/domain/dataset/update.test.ts
@@ -6,6 +6,7 @@ import { NamedNode } from 'rdf-js'
 import DatasetExt from 'rdf-ext/lib/Dataset'
 import { dcat, dcterms, hydra, rdf, schema, sh, _void, xsd } from '@tpluscode/rdf-ns-builders'
 import { cc, cube } from '@cube-creator/core/namespace'
+import { ex } from '@cube-creator/testing/lib/namespace'
 import { TestResourceStore } from '../../support/TestResourceStore'
 import { update } from '../../../lib/domain/dataset/update'
 
@@ -141,5 +142,20 @@ describe('domain/dataset/update', () => {
         cc.dimensionMetadata,
       ],
     })
+  })
+
+  it('ignores schema:hasPart and cc:dimensionMetadata from the request', async () => {
+    // given
+    const updatedResource = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('dataset') })
+      .addOut(dcterms.title, 'title')
+      .addOut(schema.hasPart, ex.Foo)
+      .addOut(cc.dimensionMetadata, ex.Bar)
+
+    // when
+    const result = await update({ dataset, resource: updatedResource, store })
+
+    // then
+    expect(result.out(schema.hasPart).terms).to.not.deep.contain.members([ex.Foo])
+    expect(result.out(cc.dimensionMetadata).terms).to.not.deep.contain.members([ex.Bar])
   })
 })

--- a/ui/src/graph.ts
+++ b/ui/src/graph.ts
@@ -1,0 +1,37 @@
+/* eslint-disable camelcase */
+import { DatasetCore, NamedNode, Quad, Quad_Graph, Quad_Predicate, Term } from 'rdf-js'
+import TermSet from '@rdfjs/term-set'
+import clownface, { GraphPointer } from 'clownface'
+import $rdf from 'rdf-ext'
+
+function quadsAbout (dataset: DatasetCore, graph: Quad_Graph | undefined, excludeProps: Quad_Predicate[] = []) {
+  const subjects = new TermSet()
+  const excludedProps = new TermSet(excludeProps)
+
+  return function * nextSubject (subject: Term): Generator<Quad> {
+    if (!subjects.has(subject) && subject.termType !== 'Literal') {
+      subjects.add(subject)
+      for (const quad of dataset.match(subject, null, null, graph)) {
+        if (excludedProps.has(quad.predicate)) {
+          continue
+        }
+
+        yield quad
+        for (const objectQuad of nextSubject(quad.object)) {
+          yield objectQuad
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Returns a Concise Bounded Description of a given resource, taking quads from the original graph
+ * and optionally excluding any subgraphs connected with the provided predicate
+ */
+export function conciseBoundedDescription (pointer: GraphPointer, exclude: NamedNode[] = []): GraphPointer {
+  const graph = pointer._context[0].graph
+  const dataset = $rdf.dataset().addAll([...quadsAbout(pointer.dataset, graph, exclude)(pointer.term)])
+
+  return clownface({ dataset, term: pointer.term, graph })
+}

--- a/ui/src/views/CubeMetadataEdit.vue
+++ b/ui/src/views/CubeMetadataEdit.vue
@@ -25,6 +25,8 @@ import SidePane from '@/components/SidePane.vue'
 import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
 import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
+import { cc, cube } from '@cube-creator/core/namespace'
+import { conciseBoundedDescription } from '@/graph'
 
 const projectNS = namespace('project')
 
@@ -44,7 +46,15 @@ export default class CubeMetadataEdit extends Vue {
       this.shape = await api.fetchOperationShape(this.operation)
     }
 
-    this.resource = Object.freeze(this.cubeMetadata.pointer)
+    // Since the /dataset resource is loaded with a bunch on inlined data,
+    // the form will only be populated with the concise description of cube metadata,
+    // excluding dimension metadata, cube Shape and observations link resource
+    const exclude = [
+      cube.observationConstraint,
+      cc.observations,
+      cc.dimensionMetadata
+    ]
+    this.resource = Object.freeze(conciseBoundedDescription(this.cubeMetadata.pointer, exclude))
   }
 
   get operation (): RuntimeOperation | null {


### PR DESCRIPTION
This fixes some problems with unexpected quads being stored in the cube meta graph when saving

1. The UI will only load the correct quads in the form
2. The API will actually replace the graph with only the quads coming from the request