### PR TITLE
fix(ui): dimension metadata saved in wrong graph

### DIFF
--- a/.changeset/heavy-jokes-greet.md
+++ b/.changeset/heavy-jokes-greet.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Fix dimension metadata saved in wrong graph

--- a/.changeset/heavy-jokes-greet.md
+++ b/.changeset/heavy-jokes-greet.md
@@ -2,4 +2,4 @@
 "@cube-creator/ui": patch
 ---
 
-Fix dimension metadata saved in wrong graph
+Fix dimension metadata not reflected in Cube Designer when saved (#646)

--- a/ui/src/views/DimensionEdit.vue
+++ b/ui/src/views/DimensionEdit.vue
@@ -23,7 +23,7 @@ import { RuntimeOperation } from 'alcaeus'
 import { Shape } from '@rdfine/shacl'
 import clownface, { GraphPointer } from 'clownface'
 import { namespace } from 'vuex-class'
-import { Dataset, DimensionMetadata } from '@cube-creator/model'
+import { Dataset, DimensionMetadata, DimensionMetadataCollection } from '@cube-creator/model'
 import SidePane from '@/components/SidePane.vue'
 import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
 import TermDisplay from '@/components/TermDisplay.vue'
@@ -37,6 +37,7 @@ const projectNS = namespace('project')
 })
 export default class extends Vue {
   @projectNS.State('cubeMetadata') cubeMetadata!: Dataset | null
+  @projectNS.State('dimensionMetadataCollection') dimensionMetadataCollection!: DimensionMetadataCollection | null
   @projectNS.Getter('findDimension') findDimension!: (id: string) => DimensionMetadata
 
   resource: GraphPointer | null = null;
@@ -49,7 +50,7 @@ export default class extends Vue {
       this.shape = await api.fetchOperationShape(this.operation)
     }
 
-    const graph = this.cubeMetadata?.id
+    const graph = this.dimensionMetadataCollection?.id
     const dataset = this.dimension.pointer.dataset.match(this.dimension.id, null, null, graph)
     this.resource = clownface({ dataset, graph }).node(this.dimension.id)
   }


### PR DESCRIPTION
Dimension metadata was apparently saved in the cube graph instead of the dimension metadata collection graph. I don't understand why it looked like it was working, but this PR may fix a bunch of stuff.

Fixes #646 