### PR TITLE
fix(cli): write output to temporary file

### DIFF
--- a/.changeset/quiet-crabs-fix.md
+++ b/.changeset/quiet-crabs-fix.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": minor
+---
+
+Use temporary file before uploading to store

--- a/cli/lib/commands/transform.ts
+++ b/cli/lib/commands/transform.ts
@@ -3,6 +3,9 @@ import { NamedNode } from 'rdf-js'
 import $rdf from 'rdf-ext'
 import { fileToDataset } from 'barnard59'
 import { Debugger } from 'debug'
+import assert from 'assert'
+import temp from 'tempy'
+import polly from 'polly-js'
 import { setupAuthentication } from '../auth'
 import Runner from 'barnard59/lib/runner'
 import bufferDebug from 'barnard59/lib/bufferDebug'
@@ -10,6 +13,7 @@ import { schema, xsd } from '@tpluscode/rdf-ns-builders'
 import type { Variables } from 'barnard59-core/lib/Pipeline'
 import { updateJobStatus } from '../job'
 import '../hydra-cache'
+import upload from '../upload'
 
 interface RunOptions {
   debug: boolean
@@ -30,7 +34,7 @@ export default function (pipelineId: NamedNode, log: Debugger) {
   const basePath = path.resolve(__dirname, '../../')
 
   return async function ({ variable = new Map(), ...command }: RunOptions) {
-    const { to, job, debug = false, enableBufferMonitor = false, graphStore, executionUrl } = command
+    const { job, debug = false, enableBufferMonitor = false, graphStore, executionUrl } = command
 
     log.enabled = debug
 
@@ -43,14 +47,18 @@ export default function (pipelineId: NamedNode, log: Debugger) {
     const dataset = $rdf.dataset()
       .merge(await fileToDataset('text/turtle', pipelinePath('main')))
       .merge(await fileToDataset('text/turtle', pipelinePath('from-api')))
-      .merge(await fileToDataset('text/turtle', pipelinePath(`to-${to}`)))
+      .merge(await fileToDataset('text/turtle', pipelinePath('to-filesystem')))
 
     log('Running job %s', job)
     variable.set('jobUri', job)
     variable.set('executionUrl', executionUrl)
-    variable.set('graph-store-endpoint', graphStore?.endpoint || process.env.GRAPH_STORE_ENDPOINT)
-    variable.set('graph-store-user', graphStore?.user || process.env.GRAPH_STORE_USER)
-    variable.set('graph-store-password', graphStore?.password || process.env.GRAPH_STORE_PASSWORD)
+    const endpoint = graphStore?.endpoint || process.env.GRAPH_STORE_ENDPOINT!
+    const username = graphStore?.user || process.env.GRAPH_STORE_USER
+    const password = graphStore?.password || process.env.GRAPH_STORE_PASSWORD
+
+    const targetFile = temp.file({ extension: '.nq' })
+    log('Will write output to temp file %s', targetFile)
+    variable.set('targetFile', targetFile)
 
     const timestamp = new Date()
     variable.set('timestamp', $rdf.literal(timestamp.toISOString(), xsd.dateTime))
@@ -70,6 +78,28 @@ export default function (pipelineId: NamedNode, log: Debugger) {
     }
 
     return run.promise
+      .then(() => {
+        log.enabled = debug
+      })
+      .then(async () => {
+        const graph = run.pipeline.context.variables.get('graph')
+        assert(graph)
+
+        log(`Uploading result to graph ${graph}`)
+
+        await polly()
+          .logger(log)
+          .waitAndRetry(3)
+          .executeForPromise(() => upload({
+            pipeline: run.pipeline,
+            endpoint,
+            password,
+            username,
+            graph,
+          }))
+
+        log('Upload complete')
+      })
       .then(() =>
         updateJobStatus({
           log: run.pipeline.context.log,

--- a/cli/lib/commands/transform.ts
+++ b/cli/lib/commands/transform.ts
@@ -91,6 +91,7 @@ export default function (pipelineId: NamedNode, log: Debugger) {
           .logger(log)
           .waitAndRetry(3)
           .executeForPromise(() => upload({
+            method: 'put',
             pipeline: run.pipeline,
             endpoint,
             password,

--- a/cli/lib/upload.ts
+++ b/cli/lib/upload.ts
@@ -22,7 +22,7 @@ export default async function upload({ method, pipeline, endpoint, username, pas
     method,
     headers: {
       'content-type': 'application/n-triples',
-      Authorization: `Basic ${Buffer.from(username + ':' + password)}`,
+      Authorization: `Basic ${Buffer.from(username + ':' + password).toString('base64')}`,
     },
   })
 

--- a/cli/lib/upload.ts
+++ b/cli/lib/upload.ts
@@ -27,6 +27,6 @@ export default async function upload({ method, pipeline, endpoint, username, pas
   })
 
   if (!response.ok) {
-    return Promise.reject(response)
+    throw new Error(`${response.status} ${response.statusText}\n\n${await response.text()}`)
   }
 }

--- a/cli/lib/upload.ts
+++ b/cli/lib/upload.ts
@@ -8,9 +8,10 @@ interface Upload {
   username: string | undefined
   password: string | undefined
   graph: string
+  method: 'post' | 'put'
 }
 
-export default async function upload({ pipeline, endpoint, username, password, graph }: Upload): Promise<void> {
+export default async function upload({ method, pipeline, endpoint, username, password, graph }: Upload): Promise<void> {
   const body = fs.createReadStream(pipeline.context.variables.get('targetFile'))
 
   const url = new URL(endpoint)
@@ -18,7 +19,7 @@ export default async function upload({ pipeline, endpoint, username, password, g
 
   const response = await fetch(url.toString(), {
     body,
-    method: 'put',
+    method,
     headers: {
       'content-type': 'application/n-triples',
       Authorization: `Basic ${Buffer.from(username + ':' + password)}`,

--- a/cli/lib/upload.ts
+++ b/cli/lib/upload.ts
@@ -1,0 +1,31 @@
+import fetch from 'node-fetch'
+import fs from 'fs'
+import type Pipeline from 'barnard59-core/lib/Pipeline'
+
+interface Upload {
+  pipeline: Pipeline
+  endpoint: string
+  username: string | undefined
+  password: string | undefined
+  graph: string
+}
+
+export default async function upload({ pipeline, endpoint, username, password, graph }: Upload): Promise<void> {
+  const body = fs.createReadStream(pipeline.context.variables.get('targetFile'))
+
+  const url = new URL(endpoint)
+  url.searchParams.append('graph', graph)
+
+  const response = await fetch(url.toString(), {
+    body,
+    method: 'put',
+    headers: {
+      'content-type': 'application/n-triples',
+      Authorization: `Basic ${Buffer.from(username + ':' + password)}`,
+    },
+  })
+
+  if (!response.ok) {
+    return Promise.reject(response)
+  }
+}

--- a/cli/lib/variables.ts
+++ b/cli/lib/variables.ts
@@ -7,9 +7,7 @@ declare module 'barnard59-core/lib/Pipeline' {
     'graph-store-endpoint': string
     'graph-store-user': string
     'graph-store-password': string
-    'publish-graph-store-endpoint': string
-    'publish-graph-store-user': string
-    'publish-graph-store-password': string
+    targetFile: string
     'target-graph': string
     revision: number
     namespace: string

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,7 @@
   "description": "Runs a pipeline to create an RDF data cube",
   "main": "index.js",
   "scripts": {
-    "postinstall": "mkdir -p output; touch .env",
+    "postinstall": "touch .env",
     "transform": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts transform --job \"$TRANSFORM_JOB\" --debug --to filesystem'",
     "publish": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts publish --job \"$PUBLISH_JOB\" --debug'",
     "build": "tsc"
@@ -45,12 +45,14 @@
     "node-fetch": "^2.6.1",
     "null-writable": "^1.0.5",
     "once": "^1.4.0",
+    "polly-js": "^1.8.1",
     "rdf-ext": "^1.3.0",
     "rdf-parser-csvw": "^0.14.2",
     "rdf-stream-to-dataset-stream": "^1.0.0",
     "rdf-validate-datatype": "^0.1.3",
     "readable-stream": "^3.6.0",
     "string-to-stream": "^3.0.1",
+    "tempy": "^1",
     "through2": "^4.0.2",
     "through2-reduce": "1.1.1"
   },

--- a/cli/pipelines/publish.ttl
+++ b/cli/pipelines/publish.ttl
@@ -4,7 +4,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 <#Main> a :Pipeline ;
-  :steps [ :stepList ( <#loadGraphStep> <#injectCubeRevision> <#injectMetadata> <#filter> <#uniqueBnodes> <#streamOutputStep> ) ] .
+  :steps [ :stepList ( <#loadGraphStep> <#injectCubeRevision> <#injectMetadata> <#filter> <#uniqueBnodes> <#ToDefaultGraph> <#streamOutputStep> ) ] .
 
 <#loadGraphStep>
   a                  :Step ;
@@ -64,23 +64,8 @@ _:get
                        a         code:EcmaScript ] ;
   code:arguments     ( <#StreamOutput> ) .
 
-<#StreamOutput>
-  a      :Pipeline ;
-  :steps [ :stepList ( _:setGraph _:upload ) ] ;.
-
-_:setGraph
+<#ToDefaultGraph>
   a                  :Step ;
   code:implementedBy [ a         code:EcmaScript ;
-                       code:link <node:barnard59-base#setGraph> ] ;
-  code:arguments     ( "target-graph"^^:VariableName ) .
-
-_:upload
-  a                  :Step ;
-  code:implementedBy [ a         code:EcmaScript ;
-                       code:link <node:barnard59-graph-store#post> ] ;
-  code:arguments     [ code:name  "endpoint" ;
-                       code:value "publish-graph-store-endpoint"^^:VariableName ] ;
-  code:arguments     [ code:name  "user" ;
-                       code:value "publish-graph-store-user"^^:VariableName ] ;
-  code:arguments     [ code:name  "password" ;
-                       code:value "publish-graph-store-password"^^:VariableName ] .
+                       code:link <node:barnard59-base#map> ] ;
+  code:arguments     ( "({ subject, predicate, object }) => require('rdf-ext').quad(subject, predicate, object)"^^code:EcmaScript ) .

--- a/yarn.lock
+++ b/yarn.lock
@@ -5008,6 +5008,11 @@ crypto-js@^4.0.0:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
   integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
 
+crypto-random-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -5428,6 +5433,20 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+del@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
+  integrity sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==
+  dependencies:
+    globby "^11.0.1"
+    graceful-fs "^4.2.4"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.2"
+    p-map "^4.0.0"
+    rimraf "^3.0.2"
+    slash "^3.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -7159,7 +7178,7 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -8039,7 +8058,7 @@ is-obj@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
 
-is-path-cwd@^2.0.0:
+is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
@@ -8064,6 +8083,11 @@ is-path-inside@^2.1.0:
   integrity sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==
   dependencies:
     path-is-inside "^1.0.2"
+
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -10104,6 +10128,13 @@ p-map@^3.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
 p-retry@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-3.0.1.tgz#316b4c8893e2c8dc1cfa891f406c4b422bebf328"
@@ -10440,6 +10471,11 @@ pnp-webpack-plugin@^1.6.4:
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
     ts-pnp "^1.1.6"
+
+polly-js@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/polly-js/-/polly-js-1.8.1.tgz#fff673fec259a8a742d03ca6026655a7fe0b790e"
+  integrity sha512-J0hquBuR797sYwkuYFTewPNU2lFVeMa3cibqjATlE2ZHE2xt9N7fv3K0zDD9q6fIdLlf7aFD9dEYaEMGHLYD1w==
 
 portfinder@^1.0.26:
   version "1.0.28"
@@ -12608,6 +12644,22 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+temp-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
+  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+
+tempy@^1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-1.0.1.tgz#30fe901fd869cfb36ee2bd999805aa72fbb035de"
+  integrity sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==
+  dependencies:
+    del "^6.0.0"
+    is-stream "^2.0.0"
+    temp-dir "^2.0.0"
+    type-fest "^0.16.0"
+    unique-string "^2.0.0"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -12997,6 +13049,11 @@ type-fest@^0.13.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
   integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
+type-fest@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.16.0.tgz#3240b891a78b0deae910dbeb86553e552a148860"
+  integrity sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==
+
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
@@ -13114,6 +13171,13 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unique-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
+  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+  dependencies:
+    crypto-random-string "^2.0.0"
 
 universal-url@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Instead of streaming directly to the endpoint, a temporary file is created first and uploaded separately once transformation if done. If the upload fail, there will be two more attempts made

fixes #628 
likely will also improve #563
possibly could also help with #586, if the problem was indeed the time it would take to transmit the triples 