### PR TITLE
fix(cli): fetch CSV Source every time to get new s3 links

### DIFF
--- a/.changeset/fuzzy-geese-promise.md
+++ b/.changeset/fuzzy-geese-promise.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Prevent CSV links from timing-out in transformation pipeline

--- a/cli/lib/hydra-cache.ts
+++ b/cli/lib/hydra-cache.ts
@@ -1,3 +1,11 @@
 import { Hydra } from 'alcaeus/node'
+import { HydraResponse } from 'alcaeus'
+import { cc } from '@cube-creator/core/namespace'
 
-Hydra.cacheStrategy.shouldLoad = () => false
+Hydra.cacheStrategy.shouldLoad = (previous: HydraResponse) => {
+  if (previous.representation?.root?.types.has(cc.CSVSource)) {
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
Right now we do not fetch any resource twice to prevent unnecessary API requests

This PR makes an exception for the `CSVSource` class, which provides the s3 link. Now every time a CSV is downloaded, a fresh link will be used