### PR TITLE
feat: more details on job list

### DIFF
--- a/.changeset/cyan-garlics-chew.md
+++ b/.changeset/cyan-garlics-chew.md
@@ -1,0 +1,10 @@
+---
+"@cube-creator/core-api": minor
+"@cube-creator/ui": minor
+---
+
+Show more details about publish jobs:
+- cube version
+- cube status
+- "publish to" application
+- link to query the cube in Lindas

--- a/.local.env
+++ b/.local.env
@@ -9,6 +9,7 @@ STORE_QUERY_ENDPOINT=http://store:3030/cube-creator/query
 STORE_UPDATE_ENDPOINT=http://store:3030/cube-creator/update
 STORE_GRAPH_ENDPOINT=http://store:3030/cube-creator/data
 PUBLIC_QUERY_ENDPOINT=https://test.lindas.admin.ch/query
+TRIFID_UI=https://lindas.admin.ch/sparql
 
 # AuthN config
 AUTH_AUDIENCE=cube-creator

--- a/apis/core/README.md
+++ b/apis/core/README.md
@@ -7,6 +7,12 @@ The API is secured with a JWT middleware. To configure set these environment var
 - `AUTH_ISSUER`
 - `AUTH_AUDIENCE`
 
+## Configuration variables
+
+| ENV variable | |
+| -- | -- |
+| `TRIFID_UI` | `/sparql` endpoint of a [Trifid](https://zazuko.com/products/trifid/) instance which will be linked from published cubes |
+
 ### Dev environment
 
 In the local environment it is possible to authorize requests with HTTP headers serving as a testing backdoor

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -6,6 +6,7 @@ import { CsvMapping, Project, Dataset } from '@cube-creator/model'
 import { ResourceStore } from '../../ResourceStore'
 import * as id from '../identifiers'
 import { DomainError } from '@cube-creator/api-errors'
+import { schema } from '@tpluscode/rdf-ns-builders'
 
 interface StartTransformationCommand {
   resource: NamedNode
@@ -55,12 +56,16 @@ export async function createPublishJob({
     throw new DomainError('Cannot publish cube. Project does not have publish graph')
   }
 
+  const metadata = await store.getResource(project.dataset)
+
   const jobPointer = await store.createMember(jobCollection.term, id.job(jobCollection))
   Job.createPublish(jobPointer, {
     project: projectPointer,
     name: 'Publish job',
     revision: project.nextRevision,
     publishGraph: organization.publishGraph,
+    status: metadata?.pointer.out(schema.creativeWorkStatus).term,
+    publishedTo: metadata?.pointer.out(schema.workExample).term,
   })
 
   return jobPointer

--- a/apis/core/lib/domain/job/update.ts
+++ b/apis/core/lib/domain/job/update.ts
@@ -3,12 +3,32 @@ import { GraphPointer } from 'clownface'
 import { Job, JobMixin, Project, Dataset } from '@cube-creator/model'
 import { isPublishJob } from '@cube-creator/model/Job'
 import RdfResource from '@tpluscode/rdfine'
+import env from '@cube-creator/core/env'
+import { DESCRIBE } from '@tpluscode/sparql-builder'
+import type { Organization } from '@rdfine/schema'
 import { ResourceStore } from '../../ResourceStore'
 import { schema } from '@tpluscode/rdf-ns-builders'
 
 interface JobUpdateParams {
   resource: GraphPointer<NamedNode>
   store: ResourceStore
+}
+
+function lindasWebQueryLink(cube: NamedNode, version: number, cubeGraph: NamedNode) {
+  const describe = DESCRIBE`?cube`
+    .FROM(cubeGraph)
+    .WHERE`
+      ${cube} ${schema.hasPart} ?cube .
+      ?cube ${schema.version} ${version} .
+    `.build()
+
+  const queryLink = new URL('https://lindas.admin.ch/sparql')
+  queryLink.hash = new URLSearchParams([
+    ['query', describe],
+    ['endpoint', env.PUBLIC_QUERY_ENDPOINT],
+  ]).toString()
+
+  return queryLink.toString()
 }
 
 export async function update({ resource, store }: JobUpdateParams): Promise<GraphPointer> {
@@ -28,6 +48,12 @@ export async function update({ resource, store }: JobUpdateParams): Promise<Grap
       if (job.revision === 1) {
         dataset.setPublishedDate(job.modified)
       }
+
+      const organization = await store.getResource<Organization>(project.maintainer)
+      const cubeId = organization.createIdentifier({
+        cubeIdentifier: project.cubeIdentifier,
+      })
+      job.query = lindasWebQueryLink(cubeId, job.revision, job.publishGraph)
     }
   }
 

--- a/apis/core/lib/domain/job/update.ts
+++ b/apis/core/lib/domain/job/update.ts
@@ -22,7 +22,7 @@ function lindasWebQueryLink(cube: NamedNode, version: number, cubeGraph: NamedNo
       ?cube ${schema.version} ${version} .
     `.build()
 
-  const queryLink = new URL('https://lindas.admin.ch/sparql')
+  const queryLink = new URL(env.TRIFID_UI)
   queryLink.hash = new URLSearchParams([
     ['query', describe],
     ['endpoint', env.PUBLIC_QUERY_ENDPOINT],
@@ -53,7 +53,9 @@ export async function update({ resource, store }: JobUpdateParams): Promise<Grap
       const cubeId = organization.createIdentifier({
         cubeIdentifier: project.cubeIdentifier,
       })
-      job.query = lindasWebQueryLink(cubeId, job.revision, job.publishGraph)
+      if (env.has('TRIFID_UI')) {
+        job.query = lindasWebQueryLink(cubeId, job.revision, job.publishGraph)
+      }
     }
   }
 

--- a/apis/core/test/domain/job/create.test.ts
+++ b/apis/core/test/domain/job/create.test.ts
@@ -11,6 +11,7 @@ import * as sinon from 'sinon'
 import * as Organization from '@cube-creator/model/Organization'
 import { namedNode } from '@cube-creator/testing/clownface'
 import * as Project from '@cube-creator/model/Project'
+import { ex } from '@cube-creator/testing/lib/namespace'
 
 describe('domain/job/create', () => {
   let store: TestResourceStore
@@ -36,6 +37,8 @@ describe('domain/job/create', () => {
   const dimensionCollection = namedNode('myDimensionCollection')
   const dataset = namedNode('myDataset')
     .addOut(cc.dimensionMetadata, dimensionCollection)
+    .addOut(schema.creativeWorkStatus, ex.Draft)
+    .addOut(schema.workExample, ex.Visualise)
 
   beforeEach(() => {
     sinon.restore()
@@ -80,6 +83,8 @@ describe('domain/job/create', () => {
       expect(job.out(rdf.type).values).to.contain(cc.Job.value)
       expect(job.out(rdf.type).values).to.contain(cc.PublishJob.value)
       expect(job.out(cc.publishGraph).term).to.deep.eq($rdf.namedNode('publishGraph'))
+      expect(job.out(schema.creativeWorkStatus).term).to.deep.eq(ex.Draft)
+      expect(job.out(schema.workExample).term).to.deep.eq(ex.Visualise)
     })
 
     it('sets next revision to job resource', async () => {

--- a/apis/core/test/domain/job/update.test.ts
+++ b/apis/core/test/domain/job/update.test.ts
@@ -20,6 +20,8 @@ describe('domain/job/update', () => {
 
   beforeEach(() => {
     maintainer = namedNode('org')
+      .addOut(rdf.type, schema.Organization)
+      .addOut(cc.namespace, 'http://example.com/')
     job = clownface({ dataset: $rdf.dataset() })
       .namedNode('job')
       .addOut(rdf.type, cc.Job)
@@ -28,7 +30,7 @@ describe('domain/job/update', () => {
       .addOut(rdf.type, cc.CubeProject)
       .addOut(cc.latestPublishedRevision, 2)
       .addOut(cc.dataset, $rdf.namedNode('dataset'))
-      .addOut(schema.maintainter, maintainer)
+      .addOut(schema.maintainer, maintainer)
     dataset = clownface({ dataset: $rdf.dataset() })
       .namedNode('dataset')
       .addOut(rdf.type, _void.Dataset)
@@ -143,35 +145,38 @@ describe('domain/job/update', () => {
     })
   })
 
-  it('sets lindas web query link', async () => {
-    // given
-    const resource = clownface({ dataset: $rdf.dataset() })
-      .namedNode('job')
-      .addOut(schema.actionStatus, schema.CompletedActionStatus)
-
-    // when
-    await update({
-      resource,
-      store,
+  describe('publish job', () => {
+    beforeEach(() => {
+      job
+        .addOut(rdf.type, cc.PublishJob)
+        .addOut(cc.project, project)
+        .addOut(cc.publishGraph, job.namedNode('http://example.com/publish-graph'))
     })
 
-    // then
-    const link = new URL(job.out(schema.query).value!)
-    const params = new URLSearchParams(link.hash)
-    expect(link.hostname).to.eq('lindas.admin.ch')
-    expect(params.get('endpoint')).to.be.ok
-    expect(params.get('query')).to.be.ok
-  })
+    it('sets lindas web query link', async () => {
+      // given
+      const resource = clownface({ dataset: $rdf.dataset() })
+        .namedNode('job')
+        .addOut(schema.actionStatus, schema.CompletedActionStatus)
 
-  describe('publish job', () => {
+      // when
+      await update({
+        resource,
+        store,
+      })
+
+      // then
+      const link = new URL(job.out(schema.query).value!)
+      const params = new URLSearchParams(link.hash)
+      expect(link.hostname).to.eq('lindas.admin.ch')
+      expect(params.get('endpoint')).to.be.ok
+    })
+
     it("increments project's cc:publishedRevision when succeeded", async () => {
       // given
       const resource = clownface({ dataset: $rdf.dataset() })
         .namedNode('job')
         .addOut(schema.actionStatus, schema.CompletedActionStatus)
-      job
-        .addOut(rdf.type, cc.PublishJob)
-        .addOut(cc.project, project)
 
       // when
       await update({
@@ -197,8 +202,6 @@ describe('domain/job/update', () => {
         .addOut(schema.actionStatus, schema.CompletedActionStatus)
         .addOut(dcterms.modified, $rdf.literal('2020-12-12T11:30:30', xsd.dateTime))
       job
-        .addOut(rdf.type, cc.PublishJob)
-        .addOut(cc.project, project)
         .addOut(cc.revision, 1)
 
       // when
@@ -225,8 +228,6 @@ describe('domain/job/update', () => {
         .addOut(schema.actionStatus, schema.CompletedActionStatus)
         .addOut(dcterms.modified, $rdf.literal('2020-12-12T11:30:30', xsd.dateTime))
       job
-        .addOut(rdf.type, cc.PublishJob)
-        .addOut(cc.project, project)
         .addOut(cc.revision, 20)
       dataset.addOut(schema.datePublished, $rdf.literal('2020-10-12', xsd.date))
 

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -50,6 +50,8 @@ graph <cube-project/ubd/dataset> {
     dcterms:title 'UBD28' ;
     dcat:contactPoint [ vcard:fn 'Test Name' ;
                         vcard:hasEmail 'test@mail.ch' ] ;
+    schema:workExample <https://ld.admin.ch/application/visualize> ;
+    schema:creativeWorkStatus <https://ld.admin.ch/definedTerm/CreativeWorkStatus/Draft> ;
   .
 
   <https://environment.ld.admin.ch/foen/ubd/28/>
@@ -685,5 +687,23 @@ graph <cube-project/ubd/csv-mapping/jobs/test-publish-job> {
     schema:actionStatus schema:PotentialActionStatus ;
     cc:publishGraph <https://lindas.admin.ch/foen/cube> ;
     cc:revision 2 ;
+    schema:creativeWorkStatus <https://ld.admin.ch/definedTerm/CreativeWorkStatus/Draft> ;
+    schema:workExample <https://ld.admin.ch/application/visualize> ;
+  .
+}
+
+<cube-project/ubd/csv-mapping/jobs/finished-publish-job> void:inDataset <ubd-example> .
+graph <cube-project/ubd/csv-mapping/jobs/finished-publish-job> {
+  <cube-project/ubd/csv-mapping/jobs/finished-publish-job>
+    a hydra:Resource, cc:Job, cc:PublishJob ;
+    cc:project <cube-project/ubd> ;
+    dcterms:created "2020-10-30T12:01:70"^^xsd:dateTime ;
+    rdfs:seeAlso <https://github.com/zazuko/cube-creator/actions/runs/345020889> ;
+    schema:actionStatus schema:CompletedActionStatus ;
+    cc:publishGraph <https://lindas.admin.ch/foen/cube> ;
+    cc:revision 3 ;
+    schema:creativeWorkStatus <https://ld.admin.ch/definedTerm/CreativeWorkStatus/Draft> ;
+    schema:workExample <https://ld.admin.ch/application/visualize> ;
+    cc:cube <https://environment.ld.admin.ch/foen/ubd/28/3> ;
   .
 }

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -704,6 +704,5 @@ graph <cube-project/ubd/csv-mapping/jobs/finished-publish-job> {
     cc:revision 3 ;
     schema:creativeWorkStatus <https://ld.admin.ch/definedTerm/CreativeWorkStatus/Draft> ;
     schema:workExample <https://ld.admin.ch/application/visualize> ;
-    cc:cube <https://environment.ld.admin.ch/foen/ubd/28/3> ;
   .
 }

--- a/packages/core/env.ts
+++ b/packages/core/env.ts
@@ -44,6 +44,7 @@ type ENV_VARS =
   | 'PIPELINE_TOKEN'
   | 'PIPELINE_ENV'
   | 'PUBLIC_QUERY_ENDPOINT'
+  | 'TRIFID_UI'
 
 type KnownVariables<T extends string> = {
   /* eslint-disable-next-line no-unused-vars */

--- a/packages/model/Job.ts
+++ b/packages/model/Job.ts
@@ -7,7 +7,7 @@ import { Action, ActionMixin } from '@rdfine/schema'
 import { cc } from '@cube-creator/core/namespace'
 import { TableCollection } from './Table'
 import { Link } from './lib/Link'
-import { NamedNode } from 'rdf-js'
+import { NamedNode, Term } from 'rdf-js'
 import { schema, dcterms, rdfs } from '@tpluscode/rdf-ns-builders'
 import { initializer } from './lib/initializer'
 import { DimensionMetadataCollection } from './DimensionMetadata'
@@ -29,6 +29,9 @@ export interface PublishJob extends Job {
   project: NamedNode
   revision: number
   publishGraph: NamedNode
+  publishedTo?: Term
+  status?: Term
+  query?: string
 }
 
 export function isPublishJob(job: Job): job is PublishJob {
@@ -94,6 +97,15 @@ export function PublishJobMixin<Base extends Constructor<RdfResource>>(base: Bas
 
     @property({ path: cc.publishGraph })
     publishGraph!: NamedNode
+
+    @property({ path: schema.workExample })
+    publishedTo?: NamedNode
+
+    @property({ path: schema.creativeWorkStatus })
+    status?: NamedNode
+
+    @property.literal({ path: schema.query })
+    query?: string
   }
 
   return Impl

--- a/ui/src/components/ExternalResource.vue
+++ b/ui/src/components/ExternalResource.vue
@@ -1,0 +1,35 @@
+<template>
+  <p :title="resourceId.value">
+    {{ name }}
+  </p>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Term } from 'rdf-js'
+import { Hydra } from 'alcaeus/web'
+import { schema } from '@tpluscode/rdf-ns-builders'
+
+@Component
+export default class ExternalResource extends Vue {
+  @Prop({ required: true }) resourceId?: Term | undefined
+
+  name = ''
+  title = ''
+
+  async mounted () {
+    if (this.resourceId?.termType === 'NamedNode') {
+      const { representation } = await Hydra.loadResource(this.resourceId.value)
+      if (representation?.root) {
+        [this.name] = representation.root.pointer.out(schema.name, { language: ['en', '*'] }).values
+      } else {
+        this.name = this.resourceId.value
+      }
+    } else {
+      this.name = this.resourceId?.value || ''
+    }
+
+    this.title = this.resourceId?.value || ''
+  }
+}
+</script>

--- a/ui/src/components/JobItem.vue
+++ b/ui/src/components/JobItem.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="panel-block job">
     <job-icon :job="job" />
-    <div class="ml-3 is-flex-grow-1">
+    <div class="ml-3">
       <span>{{ job.name }}</span><br>
       <span class="has-text-grey">{{ job.created | format-date }}</span>
     </div>
-    <a v-if="job.link" :href="job.link.id.value" target="_blank" class="has-text-grey is-flex">
+    <slot />
+    <a :disabled="!link" :href="link" target="_blank" class="has-text-grey is-flex">
       Logs <b-icon icon="chevron-right" />
     </a>
   </div>
@@ -21,5 +22,23 @@ import JobIcon from './JobIcon.vue'
 })
 export default class extends Vue {
   @Prop() job!: Job
+
+  get link () {
+    return this.job.link?.id.value
+  }
 }
 </script>
+
+<style scoped>
+  .panel-block {
+    display: flex;
+  }
+
+  .panel-block > div {
+    flex: 1;
+  }
+
+  a[disabled] {
+    cursor: not-allowed;
+  }
+</style>

--- a/ui/src/store/serializers.ts
+++ b/ui/src/store/serializers.ts
@@ -210,18 +210,8 @@ export function serializeJobCollection (collection: JobCollection): JobCollectio
       createTransform: collection.actions.createTransform,
       createPublish: collection.actions.createPublish,
     },
-    member: members.map(serializeJob),
+    member: members.map(Object.freeze),
   }) as unknown as JobCollection
-}
-
-export function serializeJob (job: Job): Job {
-  return Object.freeze({
-    ...serializeResource(job),
-    name: job.name,
-    created: job.created,
-    actionStatus: job.actionStatus,
-    link: job.link ? serializeLink(job.link) : null,
-  }) as Job
 }
 
 export function serializeCubeMetadata (cubeMetadata: Dataset): Dataset {

--- a/ui/src/views/Publication.vue
+++ b/ui/src/views/Publication.vue
@@ -15,7 +15,35 @@
         </h3>
       </div>
       <div v-if="jobs.length > 0" class="panel container-narrow">
-        <job-item v-for="job in jobs" :key="job.clientPath" :job="job" />
+        <job-item v-for="job in jobs" :key="job.clientPath" :job="job">
+          <div>
+            <p class="heading">
+              Version
+            </p>
+            <p>
+              {{ job.revision }}
+            </p>
+          </div>
+          <div>
+            <p class="heading">
+              Status
+            </p>
+            <ExternalResource :resource-id="job.status" />
+          </div>
+          <div>
+            <p class="heading">
+              Published To
+            </p>
+            <p>
+              <ExternalResource :resource-id="job.publishedTo" />
+            </p>
+          </div>
+          <div>
+            <a v-if="job.query" :href="job.query" target="_blank" class="has-text-grey">
+              Open in LINDAS
+            </a>
+          </div>
+        </job-item>
       </div>
       <p v-else class="has-text-grey">
         No jobs yet
@@ -31,16 +59,17 @@ import { namespace } from 'vuex-class'
 import LoadingBlock from '@/components/LoadingBlock.vue'
 import JobForm from '@/components/JobForm.vue'
 import JobItem from '@/components/JobItem.vue'
-import { JobCollection, Job } from '@cube-creator/model'
+import ExternalResource from '@/components/ExternalResource.vue'
+import { JobCollection, PublishJob } from '@cube-creator/model'
 
 const projectNS = namespace('project')
 
 @Component({
-  components: { LoadingBlock, JobForm, JobItem },
+  components: { LoadingBlock, JobForm, JobItem, ExternalResource },
 })
 export default class PublicationView extends Vue {
   @projectNS.State('jobCollection') jobCollection!: JobCollection | null;
-  @projectNS.Getter('publishJobs') jobs!: Job[]
+  @projectNS.Getter('publishJobs') jobs!: PublishJob[]
 }
 </script>
 


### PR DESCRIPTION
Extends the details of publish jobs:

- version (will show for existing jobs)
- status
- "publish to"
- link to a Lindas query (only when job succeeds)

"status" and "publish to" actually dereference to show `schema:name`

The Lindas query is indirect, searching by the parent cube and version rather than concrete URI. Like below:

```sparql
PREFIX schema: <http://schema.org/>
describe ?cube
from <https://lindas.admin.ch/foen/cube>
where {
  <https://environment.ld.admin.ch/foen/faostat-prod_test001> schema:hasPart ?cube .
  ?cube schema:version 4 .
}
```

Partially addresses #651