### PR TITLE
refactor: rewrite API urls to have correct namespace in db

### DIFF
--- a/.changeset/grumpy-forks-jump.md
+++ b/.changeset/grumpy-forks-jump.md
@@ -1,0 +1,8 @@
+---
+ "@cube-creator/shared-dimensions-api": major
+---
+
+Extends configuration to store shared dimensions using a different base URL
+
+- The API is served and consumer by the app on URL configured by `MANAGED_DIMENSIONS_API_BASE`
+- All resources are saved using a different base URL `MANAGED_DIMENSIONS_BASE`

--- a/.local.env
+++ b/.local.env
@@ -35,7 +35,7 @@ PIPELINE_URI=http://pipeline.cube-creator.lndo.site
 # Shared Dimensions
 MANAGED_DIMENSIONS_GRAPH=https://lindas.admin.ch/cube/dimension
 MANAGED_DIMENSIONS_API_BASE=https://cube-creator.lndo.site/
-MANAGED_DIMENSIONS_BASE=https://ld.admin.ch/
+MANAGED_DIMENSIONS_BASE=https://ld.admin.ch/cube/
 MANAGED_DIMENSIONS_STORE_QUERY_ENDPOINT=http://store:3030/shared-dimensions/query
 MANAGED_DIMENSIONS_STORE_UPDATE_ENDPOINT=http://store:3030/shared-dimensions/update
 MANAGED_DIMENSIONS_STORE_GRAPH_ENDPOINT=http://store:3030/shared-dimensions/data

--- a/.local.env
+++ b/.local.env
@@ -34,8 +34,8 @@ PIPELINE_URI=http://pipeline.cube-creator.lndo.site
 
 # Shared Dimensions
 MANAGED_DIMENSIONS_GRAPH=https://lindas.admin.ch/cube/dimension
-MANAGED_DIMENSIONS_API_BASE=https://cube-creator.lndo.site/shared-dimensions/
-MANAGED_DIMENSIONS_TERM_BASE=https://example.com/dimension/
+MANAGED_DIMENSIONS_API_BASE=https://cube-creator.lndo.site/
+MANAGED_DIMENSIONS_BASE=https://ld.admin.ch/
 MANAGED_DIMENSIONS_STORE_QUERY_ENDPOINT=http://store:3030/shared-dimensions/query
 MANAGED_DIMENSIONS_STORE_UPDATE_ENDPOINT=http://store:3030/shared-dimensions/update
 MANAGED_DIMENSIONS_STORE_GRAPH_ENDPOINT=http://store:3030/shared-dimensions/data

--- a/apis/core/bootstrap/entrypoint.ts
+++ b/apis/core/bootstrap/entrypoint.ts
@@ -1,14 +1,13 @@
 import { turtle } from '@tpluscode/rdf-string'
 import { hydra } from '@tpluscode/rdf-ns-builders'
 import { cc } from '@cube-creator/core/namespace'
-import env from '@cube-creator/shared-dimensions-api/lib/env'
 
 export const entrypoint = turtle`
 <> {
   <> a ${hydra.Resource}, ${cc.EntryPoint} ;
     ${hydra.title} "Cube Creator" ;
     ${cc.projects} <cube-projects> ;
-    ${cc.sharedDimensions} <${env.MANAGED_DIMENSIONS_API_BASE}> ;
+    ${cc.sharedDimensions} <dimension/> ;
 }
 
 <observations> {

--- a/apis/core/index.ts
+++ b/apis/core/index.ts
@@ -55,7 +55,7 @@ async function main() {
   app.use(await authentication())
   app.use(resource)
 
-  app.use(['/shared-dimensions', '/dimension'], await sharedDimensions())
+  app.use('/dimension', await sharedDimensions())
 
   app.use(resourceStore)
   app.use(await hydraBox({

--- a/apis/shared-dimensions/README.md
+++ b/apis/shared-dimensions/README.md
@@ -2,7 +2,10 @@
 
 This Hydra-driven API provides functionality for creating and finding dimensions (dictionaries) share between all Cube Creator's cubes.
 
-It is not standalone and deployed together with the [Core API](../core) under a sub path `/shared-dimensions`.
+It is not standalone and deployed together with the [Core API](../core) under a sub path `/dimension`.
+
+All resources have their base URL rewritten in the database. This way canonical identifiers are used, but the front end access the API on dereferencable API endpoints.
+Check the configuration section below.
 
 Please refer to the latter for authentication and debugging information.
 
@@ -41,9 +44,9 @@ These environment variables are required for the API to function correctly:
 
 | Variable | Description |
 | -- | -- |
-| `MANAGED_DIMENSIONS_TERM_BASE` | Base URI for term sets and terms |
+| `MANAGED_DIMENSIONS_BASE` | Base URI for term sets and terms |
 | `MANAGED_DIMENSIONS_GRAPH` | Named Graph in the database which contains user-created **Shared Dimensions** |
-| `MANAGED_DIMENSIONS_API_BASE` | Base URI for API resources. Must be `API_CORE_BASE` + `/shared-dimensions` |
+| `MANAGED_DIMENSIONS_API_BASE` | Base URI for API resources. Must be equal `API_CORE_BASE` |
 
 And of course, these variables need to be provided to configure database connection:
 

--- a/apis/shared-dimensions/bootstrap/entrypoint.ts
+++ b/apis/shared-dimensions/bootstrap/entrypoint.ts
@@ -5,4 +5,4 @@ import type { BootstrappedResourceFactory } from './index'
 
 export const entrypoint = (ptr: BootstrappedResourceFactory, ns: NamespaceBuilder) =>
   ptr('').addOut(rdf.type, hydra.Resource)
-    .addOut(md.sharedDimensions, ns('term-sets'))
+    .addOut(md.sharedDimensions, ns('_term-sets'))

--- a/apis/shared-dimensions/bootstrap/index.ts
+++ b/apis/shared-dimensions/bootstrap/index.ts
@@ -13,7 +13,7 @@ export interface BootstrappedResourceFactory {
   (term: string): GraphPointer<NamedNode>
 }
 
-const ns = namespace(env.MANAGED_DIMENSIONS_API_BASE)
+const ns = namespace(`${env.MANAGED_DIMENSIONS_BASE}dimension/`)
 const pointerFactory = (term: string) => clownface({ dataset: $rdf.dataset(), term: ns(term) })
 
 const resources = [

--- a/apis/shared-dimensions/bootstrap/termSetCollections.ts
+++ b/apis/shared-dimensions/bootstrap/termSetCollections.ts
@@ -3,7 +3,7 @@ import { rdf } from '@tpluscode/rdf-ns-builders'
 import type { BootstrappedResourceFactory } from './index'
 
 export const termSets = (ptr: BootstrappedResourceFactory) =>
-  ptr('term-sets').addOut(rdf.type, md.SharedDimensions)
+  ptr('_term-sets').addOut(rdf.type, md.SharedDimensions)
 
 export const terms = (ptr: BootstrappedResourceFactory) =>
-  ptr('terms').addOut(rdf.type, md.SharedDimensionTerms)
+  ptr('_terms').addOut(rdf.type, md.SharedDimensionTerms)

--- a/apis/shared-dimensions/hydra/index.ttl
+++ b/apis/shared-dimensions/hydra/index.ttl
@@ -11,7 +11,7 @@ BASE <urn:hydra-box:api>
 
 <api>
   a hydra:ApiDocumentation ;
-  hydra:entrypoint <> ;
+  hydra:entrypoint <dimension/> ;
 .
 
 hydra:Resource
@@ -41,7 +41,7 @@ md:SharedDimensions
          a hydra:Operation, schema:CreateAction ;
          hydra:method "POST" ;
          hydra:title "Create shared dimension" ;
-         hydra:expects <shape/shared-dimension-create> ;
+         hydra:expects <dimension/_shape/shared-dimension-create> ;
          code:implementedBy
            [
              a code:EcmaScript ;
@@ -50,8 +50,8 @@ md:SharedDimensions
        ]
 .
 
-<shape/shared-dimension-create> a sh:NodeShape, sh:Shape .
-<shape/shared-dimension-update> a sh:NodeShape, sh:Shape .
+<dimension/_shape/shared-dimension-create> a sh:NodeShape, sh:Shape .
+<dimension/_shape/shared-dimension-update> a sh:NodeShape, sh:Shape .
 
 sh:NodeShape
   a hydra:Class ;
@@ -82,7 +82,7 @@ md:SharedDimensionTerms
       hydra-box:variables
         [
           a hydra:IriTemplate ;
-          hydra:template "/terms{?dimension}" ;
+          hydra:template "/_terms{?dimension}" ;
           hydra:variableRepresentation hydra:ExplicitRepresentation ;
           hydra:mapping
             [
@@ -112,7 +112,7 @@ md:SharedDimension
       a hydra:SupportedOperation, schema:CreateAction ;
       hydra:method "POST" ;
       hydra:title "Add term" ;
-      hydra:expects <shape/shared-dimension-term-create> ;
+      hydra:expects <dimension/_shape/shared-dimension-term-create> ;
       code:implementedBy
         [
           a code:EcmaScript ;
@@ -123,7 +123,7 @@ md:SharedDimension
       a hydra:SupportedOperation, schema:ReplaceAction ;
       hydra:method "PUT" ;
       hydra:title "Edit dimension" ;
-      hydra:expects <shape/shared-dimension-update> ;
+      hydra:expects <dimension/_shape/shared-dimension-update> ;
       code:implementedBy
         [
           a code:EcmaScript ;
@@ -139,7 +139,7 @@ md:SharedDimensionTerm
       a hydra:SupportedOperation, schema:ReplaceAction ;
       hydra:method "PUT" ;
       hydra:title "Edit term" ;
-      hydra:expects <shape/shared-dimension-term-update> ;
+      hydra:expects <dimension/_shape/shared-dimension-term-update> ;
       code:implementedBy
         [
           a code:EcmaScript ;
@@ -148,5 +148,5 @@ md:SharedDimensionTerm
     ] ;
 .
 
-<shape/shared-dimension-term-create> a sh:Shape .
-<shape/shared-dimension-term-update> a sh:Shape .
+<dimension/_shape/shared-dimension-term-create> a sh:Shape .
+<dimension/_shape/shared-dimension-term-update> a sh:Shape .

--- a/apis/shared-dimensions/index.ts
+++ b/apis/shared-dimensions/index.ts
@@ -1,7 +1,8 @@
 import { hydraBox } from '@hydrofoil/labyrinth'
-import type { Router } from 'express'
+import { Router } from 'express'
 import path from 'path'
 import $rdf from 'rdf-ext'
+import camouflage from 'camouflage-rewrite'
 import env from './lib/env'
 import bootstrap from './bootstrap'
 import Loader from './lib/loader'
@@ -9,20 +10,26 @@ import { sparql, parsingClient, streamClient } from './lib/sparql'
 
 const apiPath = path.resolve(__dirname, 'hydra')
 const codePath = path.resolve(__dirname, 'lib')
-const baseUri = env.MANAGED_DIMENSIONS_API_BASE
+const baseUri = env.MANAGED_DIMENSIONS_BASE
 
 export async function sharedDimensions(): Promise<Router> {
   await bootstrap()
 
-  return hydraBox({
-    apiPath,
-    codePath,
-    baseUri,
-    loader: new Loader({
-      graph: $rdf.namedNode(env.MANAGED_DIMENSIONS_GRAPH),
-      sparql: parsingClient,
-      stream: streamClient,
-    }),
-    sparql,
-  })
+  return Router()
+    .use(camouflage({
+      url: baseUri,
+      rewriteContent: true,
+      rewriteHeaders: true,
+    }))
+    .use(await hydraBox({
+      apiPath,
+      codePath,
+      baseUri,
+      loader: new Loader({
+        graph: $rdf.namedNode(env.MANAGED_DIMENSIONS_GRAPH),
+        sparql: parsingClient,
+        stream: streamClient,
+      }),
+      sparql,
+    }))
 }

--- a/apis/shared-dimensions/lib/domain/shared-dimension-term.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension-term.ts
@@ -12,8 +12,8 @@ interface UpdateTerm {
 export async function updateTerm({ term, store } : UpdateTerm): Promise<GraphPointer<NamedNode>> {
   const current = await store.load(term.term)
 
-  const termSetId = term.out(schema.inDefinedTermSet).term
-  if (current.has(schema.inDefinedTermSet, termSetId).terms.length === 0) {
+  const termSetId = current.out(schema.inDefinedTermSet).term
+  if (term.has(schema.inDefinedTermSet, termSetId).terms.length === 0) {
     throw new DomainError('Cannot change the term set')
   }
 

--- a/apis/shared-dimensions/lib/domain/shared-dimension-term.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension-term.ts
@@ -12,8 +12,8 @@ interface UpdateTerm {
 export async function updateTerm({ term, store } : UpdateTerm): Promise<GraphPointer<NamedNode>> {
   const current = await store.load(term.term)
 
-  const termSetId = current.out(schema.inDefinedTermSet).term
-  if (term.has(schema.inDefinedTermSet, termSetId).terms.length === 0) {
+  const termSetId = term.out(schema.inDefinedTermSet).term
+  if (current.has(schema.inDefinedTermSet, termSetId).terms.length === 0) {
     throw new DomainError('Cannot change the term set')
   }
 

--- a/apis/shared-dimensions/lib/domain/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension.ts
@@ -34,7 +34,7 @@ export async function create({ resource, store }: CreateSharedDimension): Promis
     throw new DomainError('Missing dimension identifier')
   }
 
-  const termSetId = newId(env.MANAGED_DIMENSIONS_TERM_BASE, identifier)
+  const termSetId = newId(env.MANAGED_DIMENSIONS_BASE, `dimension/${identifier}`)
   if (await store.exists(termSetId, schema.DefinedTermSet)) {
     throw new httpError.Conflict(`Shared Dimension ${identifier} already exists`)
   }

--- a/apis/shared-dimensions/lib/domain/shared-dimensions.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimensions.ts
@@ -13,7 +13,7 @@ export function getSharedDimensions() {
       ?termSet a ${schema.DefinedTermSet}, ${meta.SharedDimension} .
       ?termSet ?p ?o .
 
-      BIND ( IRI(CONCAT("${env.MANAGED_DIMENSIONS_API_BASE}", "terms?dimension=", ENCODE_FOR_URI(STR(?termSet)))) as ?terms )
+      BIND ( IRI(CONCAT("${env.MANAGED_DIMENSIONS_BASE}", "dimension/_terms?dimension=", ENCODE_FOR_URI(STR(?termSet)))) as ?terms )
     `
 }
 

--- a/apis/shared-dimensions/lib/env.ts
+++ b/apis/shared-dimensions/lib/env.ts
@@ -10,7 +10,7 @@ type ENV_VARS = 'GRAPH'
 | 'STORE_GRAPH_ENDPOINT'
 | 'STORE_USERNAME'
 | 'STORE_PASSWORD'
-| 'TERM_BASE'
+| 'BASE'
 
 type PREFIXED_ENV_VARS<U> = U extends ENV_VARS ? `${typeof prefix}${U}` : never
 

--- a/apis/shared-dimensions/lib/handlers/shared-dimension-term.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimension-term.ts
@@ -3,11 +3,12 @@ import { protectedResource } from '@hydrofoil/labyrinth/resource'
 import { updateTerm } from '../domain/shared-dimension-term'
 import { store } from '../store'
 import { shaclValidate } from '../middleware/shacl'
+import { rewrite } from '../rewrite'
 
 export const put = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const pointer = await updateTerm({
     store: store(),
-    term: await req.resource(),
+    term: rewrite(await req.resource()),
   })
 
   return res.dataset(pointer.dataset)

--- a/apis/shared-dimensions/lib/handlers/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimension.ts
@@ -5,10 +5,11 @@ import { hydra } from '@tpluscode/rdf-ns-builders'
 import { createTerm, update } from '../domain/shared-dimension'
 import { store } from '../store'
 import { shaclValidate } from '../middleware/shacl'
+import { rewrite } from '../rewrite'
 
 export const post = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const term = await createTerm({
-    resource: await req.resource(),
+    resource: rewrite(await req.resource()),
     termSet: clownface({ dataset: await req.hydra.resource.dataset() }).node(req.hydra.term),
     store: store(),
   })
@@ -20,7 +21,7 @@ export const post = protectedResource(shaclValidate, asyncMiddleware(async (req,
 
 export const put = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const dimension = await update({
-    resource: await req.resource(),
+    resource: rewrite(await req.resource()),
     store: store(),
     shape: req.hydra.operation.out(hydra.expects),
   })

--- a/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
@@ -13,6 +13,7 @@ import { create } from '../domain/shared-dimension'
 import { store } from '../store'
 import { parsingClient } from '../sparql'
 import env from '../env'
+import { rewrite } from '../rewrite'
 
 interface CollectionHandler {
   memberType: NamedNode
@@ -45,7 +46,7 @@ export const get = asyncMiddleware(async (req, res) => {
 })
 
 function termsCollectionId(dimension: Term) {
-  return $rdf.namedNode(`${env.MANAGED_DIMENSIONS_API_BASE}terms?dimension=${encodeURIComponent(dimension.value)}`)
+  return $rdf.namedNode(`${env.MANAGED_DIMENSIONS_BASE}dimension/_terms?dimension=${encodeURIComponent(dimension.value)}`)
 }
 
 export const getTerms = asyncMiddleware(async (req, res, next) => {
@@ -65,12 +66,13 @@ export const getTerms = asyncMiddleware(async (req, res, next) => {
     collection: termsCollectionId(term),
   })
 
+  res.setLink(req.absoluteUrl(), 'canonical')
   return res.dataset(collection.dataset)
 })
 
 export const post = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const pointer = await create({
-    resource: await req.resource(),
+    resource: rewrite(await req.resource()),
     store: store(),
   })
 

--- a/apis/shared-dimensions/lib/middleware/shacl.ts
+++ b/apis/shared-dimensions/lib/middleware/shacl.ts
@@ -1,5 +1,7 @@
 import { shaclMiddleware } from 'hydra-box-middleware-shacl'
+import $rdf from 'rdf-ext'
 import shapes from '../shapes'
+import env from '../env'
 
 export const shaclValidate = shaclMiddleware({
   async loadResource(id) {
@@ -7,5 +9,15 @@ export const shaclValidate = shaclMiddleware({
   },
   async loadResourcesTypes() {
     return []
+  },
+  getTargetNode(req) {
+    if (req.method === 'PUT') {
+      // needs to override the target node to validate because
+      // the SHACL middleware runs before camouflage-rewrite
+      return $rdf.namedNode(env.MANAGED_DIMENSIONS_API_BASE + req.baseUrl.substr(1) + req.path)
+    }
+
+    // however, I don't understand why only when updating existing resources
+    return undefined
   },
 })

--- a/apis/shared-dimensions/lib/middleware/shacl.ts
+++ b/apis/shared-dimensions/lib/middleware/shacl.ts
@@ -14,7 +14,7 @@ export const shaclValidate = shaclMiddleware({
     if (req.method === 'PUT') {
       // needs to override the target node to validate because
       // the SHACL middleware runs before camouflage-rewrite
-      return $rdf.namedNode(env.MANAGED_DIMENSIONS_API_BASE + req.baseUrl.substr(1) + req.path)
+      return $rdf.namedNode(req.absoluteUrl().replace(env.MANAGED_DIMENSIONS_BASE, env.MANAGED_DIMENSIONS_API_BASE))
     }
 
     // however, I don't understand why only when updating existing resources

--- a/apis/shared-dimensions/lib/namespace.ts
+++ b/apis/shared-dimensions/lib/namespace.ts
@@ -6,4 +6,4 @@ type Shapes = 'shape/shared-dimension-create'
 | 'shape/shared-dimension-term-create'
 | 'shape/shared-dimension-term-update'
 
-export const shape = namespace<Shapes>(`${env.MANAGED_DIMENSIONS_API_BASE}`)
+export const shape = namespace<Shapes>(`${env.MANAGED_DIMENSIONS_BASE}dimension/_`)

--- a/apis/shared-dimensions/lib/rewrite.ts
+++ b/apis/shared-dimensions/lib/rewrite.ts
@@ -1,0 +1,30 @@
+import { Quad, Term } from 'rdf-js'
+import $rdf from 'rdf-ext'
+import clownface, { GraphPointer } from 'clownface'
+import env from './env'
+
+function rewriteTerm<T extends Term>(term: T): T {
+  if (term.termType === 'NamedNode') {
+    return $rdf.namedNode(term.value.replace(env.MANAGED_DIMENSIONS_API_BASE, env.MANAGED_DIMENSIONS_BASE)) as any
+  }
+
+  return term
+}
+
+function rewriteQuad({ subject, predicate, object, graph }: Quad): Quad {
+  return $rdf.quad(
+    rewriteTerm(subject),
+    rewriteTerm(predicate),
+    rewriteTerm(object),
+    rewriteTerm(graph),
+  )
+}
+
+/**
+ * Rewrite pointer's dataset by replacing the API_BASE with BASE as configured in the environment
+ */
+export function rewrite<T extends Term>(pointer: GraphPointer<T>): GraphPointer<T> {
+  return clownface({
+    dataset: $rdf.dataset([...pointer.dataset].map(rewriteQuad)),
+  }).node(rewriteTerm<T>(pointer.term as any))
+}

--- a/apis/shared-dimensions/lib/rewrite.ts
+++ b/apis/shared-dimensions/lib/rewrite.ts
@@ -3,7 +3,7 @@ import $rdf from 'rdf-ext'
 import clownface, { GraphPointer } from 'clownface'
 import env from './env'
 
-function rewriteTerm<T extends Term>(term: T): T {
+export function rewriteTerm<T extends Term>(term: T): T {
   if (term.termType === 'NamedNode') {
     return $rdf.namedNode(term.value.replace(env.MANAGED_DIMENSIONS_API_BASE, env.MANAGED_DIMENSIONS_BASE)) as any
   }

--- a/apis/shared-dimensions/package.json
+++ b/apis/shared-dimensions/package.json
@@ -17,8 +17,10 @@
     "@tpluscode/rdf-string": "^0.2.21",
     "@tpluscode/rdfine": "^0.5.25",
     "@tpluscode/sparql-builder": "^0.3.11",
+    "camouflage-rewrite": "^1.2.0",
     "clownface": "^1.2.0",
     "debug": "^4.3.1",
+    "express": "^4.17.1",
     "http-errors": "^1.8.0",
     "http-status": "^1.5.0",
     "hydra-box-middleware-shacl": "1.0.0",
@@ -30,6 +32,7 @@
   "devDependencies": {
     "@cube-creator/testing": "^0.1.17",
     "@types/sinon": "^9.0.11",
+    "@types/camouflage-rewrite": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "mocha": "^8.1.3",

--- a/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
+++ b/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
@@ -26,7 +26,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       const termSet = await create({ resource, store })
 
       // then
-      expect(termSet.value).to.eq('https://ld.admin.ch/dimension/canton')
+      expect(termSet.value).to.eq('https://ld.admin.ch/cube/dimension/canton')
     })
 
     it('saves to the store', async () => {

--- a/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
+++ b/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
@@ -26,7 +26,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       const termSet = await create({ resource, store })
 
       // then
-      expect(termSet.value).to.eq('https://example.com/dimension/canton')
+      expect(termSet.value).to.eq('https://ld.admin.ch/dimension/canton')
     })
 
     it('saves to the store', async () => {

--- a/e2e-tests/shared-dimensions/term-set.hydra
+++ b/e2e-tests/shared-dimensions/term-set.hydra
@@ -55,7 +55,7 @@ With Class meta:SharedDimension {
             prefix hydra: <http://www.w3.org/ns/hydra/core#>
             prefix md: <https://cube-creator.zazuko.com/shared-dimensions/vocab#>
 
-            <>
+            <https://cube-creator.lndo.site/dimension/technologies>
                 a schema:DefinedTermSet, meta:SharedDimension, hydra:Resource, md:SharedDimension ;
                 schema:name "Technologies"@en, "Les technologies"@fr ;
                 schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;

--- a/e2e-tests/shared-dimensions/term-sets.hydra
+++ b/e2e-tests/shared-dimensions/term-sets.hydra
@@ -5,7 +5,7 @@ PREFIX qudt: <http://qudt.org/schema/qudt/>
 PREFIX meta: <https://cube.link/meta/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-ENTRYPOINT "shared-dimensions/"
+ENTRYPOINT "dimension/"
 
 HEADERS {
   x-user "john-doe"

--- a/e2e-tests/shared-dimensions/term.hydra
+++ b/e2e-tests/shared-dimensions/term.hydra
@@ -25,7 +25,7 @@ With Class schema:DefinedTerm {
             prefix sh: <http://www.w3.org/ns/shacl#>
             PREFIX md: <https://cube-creator.zazuko.com/shared-dimensions/vocab#>
 
-            <>
+            <https://cube-creator.lndo.site/dimension/technologies/rdf>
               a schema:DefinedTerm, md:SharedDimensionTerm ;
               schema:identifier "rdf" ;
               schema:name "Resource Description Framework"@en, "Resource Description Framework"@de ;

--- a/e2e-tests/shared-dimensions/terms.hydra
+++ b/e2e-tests/shared-dimensions/terms.hydra
@@ -5,7 +5,7 @@ PREFIX qudt: <http://qudt.org/schema/qudt/>
 PREFIX meta: <https://cube.link/meta/>
 PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-ENTRYPOINT "shared-dimensions/terms?dimension=http%3A%2F%2Fexample.com%2Fdimension%2Fcolors"
+ENTRYPOINT "dimension/_terms?dimension=http%3A%2F%2Fexample.com%2Fdimension%2Fcolors"
 
 HEADERS {
   x-user "john-doe"

--- a/fuseki/shared-dimensions.trig
+++ b/fuseki/shared-dimensions.trig
@@ -6,7 +6,7 @@ prefix md: <https://cube-creator.zazuko.com/shared-dimensions/vocab#>
 prefix void: <http://rdfs.org/ns/void#>
 prefix schema: <http://schema.org/>
 prefix meta: <https://cube.link/meta/>
-base <https://ld.admin.ch/dimension/>
+base <https://ld.admin.ch/cube/dimension/>
 
 <shared-dimensions> a void:Dataset .
 

--- a/fuseki/shared-dimensions.trig
+++ b/fuseki/shared-dimensions.trig
@@ -6,7 +6,7 @@ prefix md: <https://cube-creator.zazuko.com/shared-dimensions/vocab#>
 prefix void: <http://rdfs.org/ns/void#>
 prefix schema: <http://schema.org/>
 prefix meta: <https://cube.link/meta/>
-base <https://cube-creator.lndo.site/dimension/>
+base <https://ld.admin.ch/dimension/>
 
 <shared-dimensions> a void:Dataset .
 

--- a/packages/shacl-middleware/index.ts
+++ b/packages/shacl-middleware/index.ts
@@ -10,7 +10,7 @@ import { ProblemDocument } from 'http-problem-details'
 interface ShaclMiddlewareOptions {
   loadResource(id: NamedNode): Promise<GraphPointer<NamedNode> | null>
   loadResourcesTypes(ids: Term[]): Promise<Quad[]>
-  getTargetNode?(req: Request, res: Response): NamedNode
+  getTargetNode?(req: Request, res: Response): NamedNode | undefined
 }
 
 export const shaclMiddleware = ({ getTargetNode, loadResource, loadResourcesTypes }: ShaclMiddlewareOptions) => asyncMiddleware(async (req, res, next) => {
@@ -21,10 +21,7 @@ export const shaclMiddleware = ({ getTargetNode, loadResource, loadResourcesType
     resource = await req.resource()
   }
 
-  let targetNode = resource.term
-  if (getTargetNode) {
-    targetNode = getTargetNode(req, res)
-  }
+  const targetNode = getTargetNode?.(req, res) || resource.term
 
   const shapes = $rdf.dataset()
   await Promise.all(req.hydra.operation.out(hydra.expects).map(async (expects) => {

--- a/packages/shacl-middleware/index.ts
+++ b/packages/shacl-middleware/index.ts
@@ -23,8 +23,6 @@ export const shaclMiddleware = ({ getTargetNode, loadResource, loadResourcesType
 
   const targetNode = getTargetNode?.(req, res) || resource.term
 
-  console.log(targetNode.value)
-
   const shapes = $rdf.dataset()
   await Promise.all(req.hydra.operation.out(hydra.expects).map(async (expects) => {
     if (expects.term.termType !== 'NamedNode') return

--- a/packages/shacl-middleware/index.ts
+++ b/packages/shacl-middleware/index.ts
@@ -23,6 +23,8 @@ export const shaclMiddleware = ({ getTargetNode, loadResource, loadResourcesType
 
   const targetNode = getTargetNode?.(req, res) || resource.term
 
+  console.log(targetNode.value)
+
   const shapes = $rdf.dataset()
   await Promise.all(req.hydra.operation.out(hydra.expects).map(async (expects) => {
     if (expects.term.termType !== 'NamedNode') return

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,6 +1959,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/camouflage-rewrite@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/camouflage-rewrite/-/camouflage-rewrite-1.2.0.tgz#0413506d606865655425f75b1712fbb72302b0f0"
+  integrity sha512-sqcBk0FCFdyQsP3l2YwLLxlKgF4GNphi90EL6w8Fu5g7dyLZj8x/t44ERe05VJvRWm5bMqUAsMF4Vm8rqQNflg==
+  dependencies:
+    "@types/express" "*"
+
 "@types/chai-as-promised@^7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.3.tgz#779166b90fda611963a3adbfd00b339d03b747bd"
@@ -3087,7 +3094,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-absolute-url@^1.2.2:
+absolute-url@^1.2.1, absolute-url@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/absolute-url/-/absolute-url-1.2.2.tgz#b92859eaf75a46fd84fc3dab5ce243516a4e24fc"
   integrity sha1-uShZ6vdaRv2E/D2rXOJDUWpOJPw=
@@ -4180,6 +4187,15 @@ camelcase@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+
+camouflage-rewrite@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/camouflage-rewrite/-/camouflage-rewrite-1.2.0.tgz#011603994978b88cdd51147fd4b7ad068169016c"
+  integrity sha512-3ll6Z03tn/LHisp1cWryw/+uIWaMFHL3xJkTsgVLL4SBXJ0kW2H0+BYhPM72zI/M4RWqphRLoz96EREdjX/uYQ==
+  dependencies:
+    absolute-url "^1.2.1"
+    hijackresponse "^2.0.0"
+    string-replace-stream "0.0.2"
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -7326,6 +7342,11 @@ highlight.js@^9.12.0:
   version "9.18.5"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
   integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
+
+hijackresponse@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/hijackresponse/-/hijackresponse-2.0.1.tgz#45f5e0c9b87d73bad858f66021bec377c736b8b3"
+  integrity sha1-RfXgybh9c7rYWPZgIb7Dd8c2uLM=
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -12345,6 +12366,13 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+string-replace-stream@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/string-replace-stream/-/string-replace-stream-0.0.2.tgz#eb75d4ec565d8dd4ca871797c92cc7643358a5bb"
+  integrity sha1-63XU7FZdjdTKhxeXySzHZDNYpbs=
+  dependencies:
+    through2 "^2.0.0"
 
 string-to-stream@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This attempts to completely hide the API URL and the shared dimension terms. All resources will be stored as `ld.admin.ch/cube/dimension` but the API will rewrite those URLs for the purpose of client-server communication

Uses `camouflage-rewrite` to but requests have to be manually rewritten in our code (see https://github.com/zazuko/camouflage-rewrite/issues/2)