### PR TITLE
feat: separate dimension namespace

### DIFF
--- a/.changeset/plenty-keys-develop.md
+++ b/.changeset/plenty-keys-develop.md
@@ -1,0 +1,6 @@
+---
+"@cube-creator/core-api": patch
+"@cube-creator/cli": patch
+---
+
+Output canonical dimension URIs from cube transformation

--- a/apis/core/lib/handlers/dimension-mapping.ts
+++ b/apis/core/lib/handlers/dimension-mapping.ts
@@ -2,16 +2,46 @@ import asyncMiddleware from 'middleware-async'
 import { protectedResource } from '@hydrofoil/labyrinth/resource'
 import { Enrichment } from '@hydrofoil/labyrinth/lib/middleware/preprocessResource'
 import { fromPointer } from '@rdfine/prov/lib/Dictionary'
+import env from '@cube-creator/shared-dimensions-api/lib/env'
+import { Term } from 'rdf-js'
+import $rdf from 'rdf-ext'
+import clownface from 'clownface'
 import { shaclValidate } from '../middleware/shacl'
 import { update } from '../domain/dimension-mapping/update'
 import { getUnmappedValues } from '../domain/queries/dimension-mappings'
 
+function rewrite<T extends Term>(term: T, from: string, to: string): T {
+  if (term.termType === 'NamedNode') {
+    return $rdf.namedNode(term.value.replace(new RegExp(`^${from}dimension/`), `${to}dimension/`)) as any
+  }
+
+  return term
+}
+
+function toCanonical<T extends Term>(term: T): T {
+  return rewrite(term, env.MANAGED_DIMENSIONS_API_BASE, env.MANAGED_DIMENSIONS_BASE)
+}
+
+function fromCanonical<T extends Term>(term: T): T {
+  return rewrite(term, env.MANAGED_DIMENSIONS_BASE, env.MANAGED_DIMENSIONS_API_BASE)
+}
+
 export const put = protectedResource(
   shaclValidate,
   asyncMiddleware(async (req, res) => {
+    const mappings = await req.resource()
+    const dataset = $rdf.dataset([...mappings.dataset]).map(quad => {
+      return $rdf.quad(
+        toCanonical(quad.subject),
+        quad.predicate,
+        toCanonical(quad.object),
+        quad.graph,
+      )
+    })
+
     const dimensionMapping = await update({
       resource: req.hydra.resource.term,
-      mappings: await req.resource(),
+      mappings: clownface({ dataset }).node(mappings.term),
       store: req.resourceStore(),
     })
     await req.resourceStore().save()
@@ -20,6 +50,21 @@ export const put = protectedResource(
   }))
 
 export const prepareEntries: Enrichment = async (req, pointer) => {
+  if (req.headers.prefer !== 'return=canonical') {
+    for (const quad of [...pointer.dataset]) {
+      const remapped = $rdf.quad(
+        fromCanonical(quad.subject),
+        quad.predicate,
+        fromCanonical(quad.object),
+        quad.graph,
+      )
+
+      if (!remapped.equals(quad)) {
+        pointer.dataset.delete(quad).add(remapped)
+      }
+    }
+  }
+
   const dictionary = fromPointer(pointer)
   const unmappedValues = await getUnmappedValues(dictionary.id, dictionary.about)
 

--- a/apis/core/test/handlers/dimension-mapping.test.ts
+++ b/apis/core/test/handlers/dimension-mapping.test.ts
@@ -14,8 +14,10 @@ import '../../lib/domain'
 import { Literal } from 'rdf-js'
 
 describe('lib/handlers/dimension-mapping', () => {
-  describe('addMissingEntries', () => {
-    const req = {} as Request
+  describe('prepareEntries', () => {
+    const req = {
+      headers: {},
+    } as Request
     let unmappedTerms: Set<Literal>
 
     beforeEach(() => {
@@ -48,6 +50,103 @@ describe('lib/handlers/dimension-mapping', () => {
           path: prov.hadDictionaryMember,
           minCount: 3,
           maxCount: 3,
+        },
+      })
+    })
+
+    it('maps base IRI of dictionary values to API namespace', async () => {
+      // given
+      const sharedDimension = ex.dimension
+      const mappings = namedNode('mappings')
+      fromPointer(mappings, {
+        sharedDimension,
+        hadDictionaryMember: [{
+          pairKey: 'so2',
+          pairEntity: $rdf.namedNode('https://ld.admin.ch/cube/dimension/foo/bar'),
+        }],
+      })
+
+      // when
+      await prepareEntries(req, mappings)
+
+      // then
+      expect(mappings).to.matchShape({
+        property: {
+          path: prov.hadDictionaryMember,
+          node: {
+            property: [{
+              path: prov.pairKey,
+              hasValue: 'so2',
+            }, {
+              path: prov.pairEntity,
+              hasValue: $rdf.namedNode('https://cube-creator.lndo.site/dimension/foo/bar'),
+            }],
+          },
+        },
+      })
+    })
+
+    it('does not map canonical IRIs when prefer header is set', async () => {
+      // given
+      req.headers.prefer = 'return=canonical'
+      const sharedDimension = ex.dimension
+      const mappings = namedNode('mappings')
+      fromPointer(mappings, {
+        sharedDimension,
+        hadDictionaryMember: [{
+          pairKey: 'so2',
+          pairEntity: $rdf.namedNode('https://ld.admin.ch/cube/dimension/foo/bar'),
+        }],
+      })
+
+      // when
+      await prepareEntries(req, mappings)
+
+      // then
+      expect(mappings).to.matchShape({
+        property: {
+          path: prov.hadDictionaryMember,
+          node: {
+            property: [{
+              path: prov.pairKey,
+              hasValue: 'so2',
+            }, {
+              path: prov.pairEntity,
+              hasValue: $rdf.namedNode('https://ld.admin.ch/cube/dimension/foo/bar'),
+            }],
+          },
+        },
+      })
+    })
+
+    it('does not map IRIs which are not in the canonical namesace', async () => {
+      // given
+      const sharedDimension = ex.dimension
+      const mappings = namedNode('mappings')
+      fromPointer(mappings, {
+        sharedDimension,
+        hadDictionaryMember: [{
+          pairKey: 'so2',
+          pairEntity: $rdf.namedNode('https://test.ld.admin.ch/cube/dimension/foo/bar'),
+        }],
+      })
+
+      // when
+      await prepareEntries(req, mappings)
+
+      // then
+      expect(mappings).to.matchShape({
+        property: {
+          path: prov.hadDictionaryMember,
+          node: {
+            property: [{
+              path: prov.pairKey,
+              hasValue: 'so2',
+            }, {
+              path: prov.pairEntity,
+              hasValue: $rdf.namedNode('https://test.ld.admin.ch/cube/dimension/foo/bar'),
+            }],
+          },
         },
       })
     })

--- a/cli/lib/output-mapper.ts
+++ b/cli/lib/output-mapper.ts
@@ -19,10 +19,10 @@ Hydra.resources.factory.addMixin(...Object.values(Models))
 const undef = $rdf.literal('', cube.Undefined)
 
 const pendingRequests = new Map<string, Promise<any>>()
-function load<T extends RdfResourceCore>(uri: string): Promise<HydraResponse<DatasetCore, T>> {
+function load<T extends RdfResourceCore>(uri: string, headers?: HeadersInit): Promise<HydraResponse<DatasetCore, T>> {
   let promise = pendingRequests.get(uri)
   if (!promise) {
-    promise = Hydra.loadResource<T>(uri)
+    promise = Hydra.loadResource<T>(uri, headers)
       .then(response => {
         pendingRequests.delete(uri)
         return response
@@ -53,7 +53,9 @@ async function loadMetadata(jobUri: string) {
 }
 
 export async function loadDimensionMapping(mappingUri: string) {
-  const mappingResource = await load<Dictionary>(mappingUri)
+  const mappingResource = await load<Dictionary>(mappingUri, {
+    Prefer: 'return=canonical',
+  })
   if (!mappingResource.representation) {
     throw new Error(`Mapping ${mappingUri} not loaded`)
   }


### PR DESCRIPTION
#690 introduced a change that the shared dimensions are store using a different base URI that the hosted API.

Consequently it is also necessary to apply same namespace replacement in the Cube Creator core so that dimension mapping dictionaries are saved using the correct, canonical namespace, and later output like that from the transformation pipeline