### PR TITLE
fix(cli): setting expiry of previous cubes

### DIFF
--- a/.changeset/green-glasses-matter.md
+++ b/.changeset/green-glasses-matter.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Previous cubes would not be expired if there are gaps in version numbers (re. [visualize-admin/visualization-tool#80](https://github.com/visualize-admin/visualization-tool/issues/80)

--- a/cli/.test.env
+++ b/cli/.test.env
@@ -9,6 +9,7 @@ GRAPH_STORE_USER=admin
 GRAPH_STORE_PASSWORD=password
 
 PUBLISH_GRAPH_STORE_ENDPOINT=http://db.cube-creator.lndo.site/cube-creator/data
+PUBLISH_GRAPH_QUERY_ENDPOINT=http://db.cube-creator.lndo.site/cube-creator
 PUBLISH_GRAPH_STORE_USER=admin
 PUBLISH_GRAPH_STORE_PASSWORD=password
 

--- a/cli/lib/commands/publish.ts
+++ b/cli/lib/commands/publish.ts
@@ -61,6 +61,7 @@ export default function (pipelineId: NamedNode, log: Debugger) {
     variable.set('graph-store-user', graphStore?.user || process.env.GRAPH_STORE_USER)
     variable.set('graph-store-password', graphStore?.password || process.env.GRAPH_STORE_PASSWORD)
     variable.set('publish-graph-store-endpoint', publishStore?.endpoint || process.env.PUBLISH_GRAPH_STORE_ENDPOINT)
+    variable.set('publish-graph-query-endpoint', publishStore?.endpoint || process.env.PUBLISH_GRAPH_QUERY_ENDPOINT)
     variable.set('publish-graph-store-user', publishStore?.user || process.env.PUBLISH_GRAPH_STORE_USER)
     variable.set('publish-graph-store-password', publishStore?.password || process.env.PUBLISH_GRAPH_STORE_PASSWORD)
 

--- a/cli/lib/cube.ts
+++ b/cli/lib/cube.ts
@@ -1,12 +1,13 @@
 import $rdf from 'rdf-ext'
-import { DatasetCore, Quad, Term, Quad_Subject as QuadSubject } from 'rdf-js'
-import { cc, cube } from '@cube-creator/core/namespace'
+import { DatasetCore, Quad, Term } from 'rdf-js'
+import { cc } from '@cube-creator/core/namespace'
 import { GraphPointer } from 'clownface'
 import type { Context } from 'barnard59-core/lib/Pipeline'
 import { obj } from 'through2'
-import TermMap from '@rdfjs/term-map'
-import { rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
+import { CONSTRUCT } from '@tpluscode/sparql-builder'
+import { schema, sh } from '@tpluscode/rdf-ns-builders'
 import { Dataset } from '@cube-creator/model'
+import StreamClient from 'sparql-http-client/StreamClient'
 import { loadDataset } from './metadata'
 
 export const getObservationSetId = ({ dataset }: { dataset: DatasetCore }) => {
@@ -23,11 +24,32 @@ export function getCubeId({ ptr }: { ptr: GraphPointer }) {
   return ptr.out(cc.cube).term || ''
 }
 
+export function expirePreviousVersions(this: Pick<Context, 'variables' | 'log'>) {
+  const timestamp = this.variables.get('timestamp')
+  const baseCube = $rdf.namedNode(this.variables.get('namespace'))
+  const client = new StreamClient({
+    endpointUrl: this.variables.get('publish-graph-query-endpoint'),
+    user: this.variables.get('publish-graph-store-user'),
+    password: this.variables.get('publish-graph-store-password'),
+  })
+
+  return CONSTRUCT`
+    ?cube ${schema.validThrough} ${timestamp}
+  `.WHERE`
+    ${baseCube} ${schema.hasPart} ?cube .
+
+    OPTIONAL { ?cube ${schema.validThrough} ?validThrough }
+
+    filter (
+      !bound(?validThrough)
+    )
+  `.FROM($rdf.namedNode(this.variables.get('target-graph')))
+    .execute(client.query)
+}
+
 export async function injectRevision(this: Pick<Context, 'variables' | 'log'>, jobUri?: string) {
   let cubeNamespace = this.variables.get('namespace')
   const revision = this.variables.get('revision')
-  const previousCubes = new TermMap<Term, QuadSubject>()
-  this.variables.set('previousCubes', previousCubes)
   let dataset: Dataset | undefined
   if (jobUri) {
     ({ dataset } = await loadDataset(jobUri))
@@ -57,10 +79,6 @@ export async function injectRevision(this: Pick<Context, 'variables' | 'log'>, j
 
   return obj(function ({ subject, predicate, object, graph }: Quad, _, callback) {
     const rebasedSub = rebase(subject)
-
-    if (revision > 1 && predicate.equals(rdf.type) && object.equals(cube.Cube)) {
-      previousCubes.set(rebasedSub, rebase(subject, revision - 1))
-    }
 
     // do not inject revision into dimension URI used in Constraint Shape
     if (predicate.equals(sh.path)) {

--- a/cli/lib/metadata.ts
+++ b/cli/lib/metadata.ts
@@ -44,7 +44,6 @@ export async function injectMetadata(this: Context, jobUri: string) {
   const cubeIdentifier = this.variables.get('cubeIdentifier')
   const { dataset, maintainer } = await loadDataset(jobUri)
   const datasetTriples = dataset.pointer.dataset.match(null, null, null, dataset.id)
-  const previousCubes = this.variables.get('previousCubes')
   const timestamp = this.variables.get('timestamp')
 
   return obj(async function (quad: Quad, _, callback) {
@@ -70,11 +69,6 @@ export async function injectMetadata(this: Context, jobUri: string) {
 
       if (revision === 1) {
         this.push($rdf.quad(quad.subject, schema.datePublished, timestamp))
-      }
-
-      const previousCube = previousCubes.get(quad.subject)
-      if (previousCube) {
-        this.push($rdf.quad(previousCube, schema.validThrough, timestamp))
       }
 
       [...datasetTriples.match(dataset.id)]

--- a/cli/lib/variables.ts
+++ b/cli/lib/variables.ts
@@ -1,4 +1,4 @@
-import { Literal, Term, Quad_Subject as QuadSubject } from 'rdf-js'
+import { Literal } from 'rdf-js'
 
 declare module 'barnard59-core/lib/Pipeline' {
   interface VariableNames {
@@ -7,6 +7,7 @@ declare module 'barnard59-core/lib/Pipeline' {
     'graph-store-endpoint': string
     'graph-store-user': string
     'graph-store-password': string
+    'publish-graph-query-endpoint': string
     'publish-graph-store-endpoint': string
     'publish-graph-store-user': string
     'publish-graph-store-password': string
@@ -15,7 +16,6 @@ declare module 'barnard59-core/lib/Pipeline' {
     namespace: string
     cubeIdentifier: string
     timestamp: Literal
-    previousCubes: Map<Term, QuadSubject>
     isObservationTable: boolean
     graph: string
     bnodeUuid: string

--- a/cli/package.json
+++ b/cli/package.json
@@ -23,6 +23,7 @@
     "@sentry/tracing": "^6.2.0",
     "@tpluscode/rdf-ns-builders": "^0.4",
     "@tpluscode/rdfine": "^0.5.19",
+    "@tpluscode/sparql-builder": "^0.3.12",
     "alcaeus": "^1.0.1",
     "aws-sdk": "^2.559.0",
     "barnard59": "^0.1.2",
@@ -52,7 +53,8 @@
     "readable-stream": "^3.6.0",
     "string-to-stream": "^3.0.1",
     "through2": "^4.0.2",
-    "through2-reduce": "1.1.1"
+    "through2-reduce": "1.1.1",
+    "sparql-http-client": "^2.2"
   },
   "devDependencies": {
     "@cube-creator/testing": "^0.1.17",

--- a/cli/pipelines/publish.ttl
+++ b/cli/pipelines/publish.ttl
@@ -4,7 +4,35 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 <#Main> a :Pipeline ;
-  :steps [ :stepList ( <#loadGraphStep> <#injectCubeRevision> <#injectMetadata> <#filter> <#uniqueBnodes> <#streamOutputStep> ) ] .
+        :steps
+          [
+            :stepList
+              ( <#concatStreams> <#streamOutputStep> ) ;
+          ] .
+
+<#concatStreams>
+  a :Step ;
+  code:implementedBy
+    [
+      a code:EcmaScript ;
+      code:link <node:barnard59-base#concat.object>
+    ] ;
+  code:arguments
+    (
+      <#PublishedLatestCube>
+      <#ExpirePreviousVersions>
+    )
+.
+
+<#PublishedLatestCube>
+  a :Pipeline, :ReadableObjectMode ;
+  :steps [ :stepList ( <#loadGraphStep> <#injectCubeRevision> <#injectMetadata> <#filter> <#uniqueBnodes> ) ]
+.
+
+<#ExpirePreviousVersions>
+  a :Pipeline, :ReadableObjectMode ;
+  :steps [ :stepList ( <#expirePreviousVersions> ) ] ;
+.
 
 <#loadGraphStep>
   a                  :Step ;
@@ -33,6 +61,12 @@ _:get
 <#injectCubeRevision>
   a :Step ;
   code:implementedBy [ code:link <file:../lib/cube#injectRevision> ;
+                       a         code:EcmaScript ] ;
+  code:arguments     ( "jobUri"^^:VariableName ) .
+
+<#expirePreviousVersions>
+  a :Step ;
+  code:implementedBy [ code:link <file:../lib/cube#expirePreviousVersions> ;
                        a         code:EcmaScript ] ;
   code:arguments     ( "jobUri"^^:VariableName ) .
 

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -58,7 +58,7 @@ describe('lib/commands/publish', function () {
         `
         .execute(ccClients.parsingClient.query)
 
-      targetCube = namespace(ns.baseCube('2/').value)
+      targetCube = namespace(ns.baseCube('3/').value)
 
       const dataset = await $rdf.dataset().import(await CONSTRUCT`?s ?p ?o`
         .FROM(expectedGraph as NamedNode)
@@ -71,7 +71,7 @@ describe('lib/commands/publish', function () {
     it('does not remove previously published triples', () => {
       const prevCube = cubePointer.namedNode(ns.baseCube('1'))
 
-      expect(prevCube.out().terms).to.have.length(1)
+      expect(prevCube.out().terms).to.have.length.greaterThan(0)
       expect(prevCube).to.matchShape({
         property: {
           path: rdf.type,
@@ -129,7 +129,7 @@ describe('lib/commands/publish', function () {
       expect(cubePointer.namedNode(targetCube())).to.matchShape({
         property: [{
           path: schema.version,
-          hasValue: $rdf.literal('2', xsd.integer),
+          hasValue: $rdf.literal('3', xsd.integer),
           minCount: 1,
           maxCount: 1,
         }],
@@ -164,8 +164,8 @@ describe('lib/commands/publish', function () {
       })
     })
 
-    it('"deprecates" previous cube', async function () {
-      expect(cubePointer.namedNode(ns.baseCube('1/'))).to.matchShape({
+    it('"deprecates" previous cubes', async function () {
+      expect(cubePointer.namedNode(ns.baseCube('1'))).to.matchShape({
         property: [{
           path: schema.validThrough,
           datatype: xsd.dateTime,

--- a/cli/test/lib/cube.test.ts
+++ b/cli/test/lib/cube.test.ts
@@ -85,48 +85,5 @@ describe('lib/cube', () => {
         expect(transformed.toArray()[0].subject).to.deep.eq($rdf.namedNode('http://example.com/cube/' + expected))
       })
     })
-
-    it('adds previous cube id to variables', async () => {
-      // given
-      const context = {
-        log,
-        variables: new Map<any, any>([
-          ['namespace', 'http://example.com/cube/foo/'],
-          ['revision', 5],
-        ]),
-      }
-      const quads = $rdf.dataset([
-        $rdf.quad($rdf.namedNode('http://example.com/cube/foo/'), rdf.type, cube.Cube),
-      ]).toStream()
-
-      // when
-      const transform = await injectRevision.call(context)
-      await $rdf.dataset().import(quads.pipe(transform))
-
-      // then
-      const previousCube = context.variables.get('previousCubes').get($rdf.namedNode('http://example.com/cube/foo/5/'))
-      expect(previousCube).to.deep.eq($rdf.namedNode('http://example.com/cube/foo/4/'))
-    })
-
-    it('does not add previous cube to variables on first publish', async () => {
-      // given
-      const context = {
-        log,
-        variables: new Map<any, any>([
-          ['namespace', 'http://example.com/cube/foo/'],
-          ['revision', 1],
-        ]),
-      }
-      const quads = $rdf.dataset([
-        $rdf.quad($rdf.namedNode('http://example.com/cube/foo/'), rdf.type, cube.Cube),
-      ]).toStream()
-
-      // when
-      const transform = await injectRevision.call(context)
-      await $rdf.dataset().import(quads.pipe(transform))
-
-      // then
-      expect(context.variables.get('previousCubes')).to.have.property('size', 0)
-    })
   })
 })

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -39,6 +39,9 @@ graph <cube-project/ubd> {
 
 <https://lindas.admin.ch/foen/cube> void:inDataset <ubd-example> .
 graph <https://lindas.admin.ch/foen/cube> {
+  <https://environment.ld.admin.ch/foen/ubd/28/>
+    schema:hasPart <https://environment.ld.admin.ch/foen/ubd/28/1> .
+
   <https://environment.ld.admin.ch/foen/ubd/28/1> a cube:Cube .
 }
 
@@ -697,7 +700,7 @@ graph <cube-project/ubd/csv-mapping/jobs/test-publish-job> {
     rdfs:seeAlso <https://github.com/zazuko/cube-creator/actions/runs/345020889> ;
     schema:actionStatus schema:PotentialActionStatus ;
     cc:publishGraph <https://lindas.admin.ch/foen/cube> ;
-    cc:revision 2 ;
+    cc:revision 3 ;
     schema:creativeWorkStatus <https://ld.admin.ch/definedTerm/CreativeWorkStatus/Draft> ;
     schema:workExample <https://ld.admin.ch/application/visualize> ;
   .
@@ -712,7 +715,7 @@ graph <cube-project/ubd/csv-mapping/jobs/finished-publish-job> {
     rdfs:seeAlso <https://github.com/zazuko/cube-creator/actions/runs/345020889> ;
     schema:actionStatus schema:CompletedActionStatus ;
     cc:publishGraph <https://lindas.admin.ch/foen/cube> ;
-    cc:revision 3 ;
+    cc:revision 1 ;
     schema:creativeWorkStatus <https://ld.admin.ch/definedTerm/CreativeWorkStatus/Draft> ;
     schema:workExample <https://ld.admin.ch/application/visualize> ;
   .


### PR DESCRIPTION
re https://github.com/visualize-admin/visualization-tool/issues/80#issuecomment-840374218

This improves how the previous versions are expired with `schema:validThrough`

The current implementation simply adds a triple where the subject is created as `/${version - 1}` but that falls short if the next version published shall skip a number for whatever reason.

Instead, the published store will be queried to find unversioned cubes of the given cube series, and set validity to all of them