### PR TITLE
fix(ui): property description not updated

### DIFF
--- a/ui/src/forms/FormProperty.vue
+++ b/ui/src/forms/FormProperty.vue
@@ -4,9 +4,7 @@
       {{ property.name }}
     </span>
     <b-field v-if="property.shape.description">
-      <vue-markdown class="help" :anchor-attributes="linkAttrs">
-        {{ property.shape.description }}
-      </vue-markdown>
+      <vue-markdown class="help" :anchor-attributes="linkAttrs" :source="property.shape.description" />
     </b-field>
     <b-field v-if="property.selectedEditor">
       <render-wc-template :template-result="renderMultiEditor()" />


### PR DESCRIPTION
`VueMarkdown` does not refresh content from slot, which can be a problem for dynamically shown/hidden properties. 

Using property binding helps