### PR TITLE
fix(ui): switch language for resource labels

### DIFF
--- a/.changeset/short-snakes-serve.md
+++ b/.changeset/short-snakes-serve.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Fix language switch for resource labels in Cube Preview

--- a/ui/src/components/ExternalTerm.vue
+++ b/ui/src/components/ExternalTerm.vue
@@ -49,7 +49,7 @@ export default class extends Vue {
 
   getLabels (pointer: GraphPointer | null): Literal[] {
     if (pointer) {
-      return pointer.out(schema.name, { language: [this.selectedLanguage, '*'] }).terms
+      return pointer.out(schema.name).terms.filter(isLiteral) as Literal[]
     }
 
     return []
@@ -115,5 +115,9 @@ export default class extends Vue {
 
     return pointer
   }
+}
+
+function isLiteral (term: Term): term is Literal {
+  return term.termType === 'Literal'
 }
 </script>


### PR DESCRIPTION
Should fix https://github.com/zazuko/cube-creator/issues/731