### PR TITLE
fix(import): import mirrored cube meta properties

### DIFF
--- a/.changeset/weak-pants-double.md
+++ b/.changeset/weak-pants-double.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Better import cube metadata

--- a/apis/core/bootstrap/shapes/dataset.ts
+++ b/apis/core/bootstrap/shapes/dataset.ts
@@ -67,6 +67,11 @@ const orgQuery = sparql`construct {
   }
 }`
 
+/*
+ * Properties which are synchronised using `sh:equal` should also be added
+ * to `cli/lib/import/cubeMetadata.ts` so that importing a cube ensures
+ * both mirrored predicates are set
+ */
 export const DatasetShape = turtle`
 @prefix cld: <http://purl.org/cld/terms/> .
 @prefix dcam: <http://purl.org/dc/dcam/> .

--- a/cli/package.json
+++ b/cli/package.json
@@ -23,7 +23,7 @@
     "@sentry/tracing": "^6.2.0",
     "@tpluscode/rdf-ns-builders": "^0.4",
     "@tpluscode/rdfine": "^0.5.19",
-    "@tpluscode/sparql-builder": "^0.3.12",
+    "@tpluscode/sparql-builder": "^0.3.13",
     "alcaeus": "^1.0.1",
     "aws-sdk": "^2.559.0",
     "barnard59": "^0.1.2",

--- a/cli/test/lib/commands/import.test.ts
+++ b/cli/test/lib/commands/import.test.ts
@@ -260,4 +260,17 @@ describe('@cube-creator/cli/lib/commands/import', function () {
       $rdf.literal('Nombre, ha, m3', 'fr'),
     ])
   })
+
+  it('adds values for mirrored properties', async () => {
+    const hasValues = await ASK`
+      ?dataset ${schema.hasPart} ${cube} ;
+               ${schema.name} ?title ;
+               ${dcterms.title} ?title ;
+               ${schema.description} ?desc ;
+               ${dcterms.description} ?desc ;
+     `.FROM(resource('cube-project/px/dataset'))
+      .execute(ccClients.parsingClient.query)
+
+    expect(hasValues).to.be.true
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1928,10 +1928,10 @@
     clownface "^1"
     once "^1.4.0"
 
-"@tpluscode/sparql-builder@^0.3.11", "@tpluscode/sparql-builder@^0.3.12", "@tpluscode/sparql-builder@^0.3.9":
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/@tpluscode/sparql-builder/-/sparql-builder-0.3.12.tgz#0d017911969a15e956f180eddaf6bea74efb86da"
-  integrity sha512-sPXADwCs+pdN10IPw6EeMNGFZnanP0Ab6gmlo8HEAooCOZs6ZlVpl1S358/7U4zbdLjfnWeyUTdRlR5Ok2Y+IQ==
+"@tpluscode/sparql-builder@^0.3.11", "@tpluscode/sparql-builder@^0.3.12", "@tpluscode/sparql-builder@^0.3.13", "@tpluscode/sparql-builder@^0.3.9":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@tpluscode/sparql-builder/-/sparql-builder-0.3.13.tgz#6161562055415cd0e033e2c26d69a036857fee15"
+  integrity sha512-wzlE+c0EAMjpi+GVJq9AF3UOq8bxOzkOGyi/gSC1yf+SO0iQbR4kGWJxL/T2FeS6xiB5pB6fdRrJqrWz8yYMpA==
   dependencies:
     "@rdf-esm/data-model" "^0.5.4"
     "@rdf-esm/term-set" "^0.5.0"


### PR DESCRIPTION
We have some cube meta properties which are hidden in the form UI, and required to mirror value of another predicate

This PR ensures that when importing a cube, we construct the mirrored values, thus preventing confusing validation errors in the APP