### PR TITLE
fix(api): update project without changing identifier

### DIFF
--- a/.changeset/hip-comics-worry.md
+++ b/.changeset/hip-comics-worry.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Regression: changing name of CSV Project was impossible (fixes #749)

--- a/apis/core/lib/domain/cube-projects/update.ts
+++ b/apis/core/lib/domain/cube-projects/update.ts
@@ -37,9 +37,6 @@ export async function updateProject({
 
   if (isCsvProject(project)) {
     const identifier = project.updateCubeIdentifier(resource.out(dcterms.identifier).value)
-    if (await exists(identifier.after, maintainer.after)) {
-      throw new DomainError('Another project is already using same identifier')
-    }
 
     currentCube = organization.createIdentifier({
       cubeIdentifier: identifier.after,
@@ -47,6 +44,12 @@ export async function updateProject({
     previousCube = previousOrganization.createIdentifier({
       cubeIdentifier: identifier.before,
     })
+
+    if (identifier.after !== identifier.before) {
+      if (await exists(identifier.after, maintainer.after)) {
+        throw new DomainError('Another project is already using same identifier')
+      }
+    }
   } else {
     const cubeId = project.updateImportCube(resource.out(cc['CubeProject/sourceCube']).term)
     currentCube = cubeId.after

--- a/apis/core/lib/handlers/cube-projects.ts
+++ b/apis/core/lib/handlers/cube-projects.ts
@@ -50,8 +50,7 @@ export const put = protectedResource(
     })
     await req.resourceStore().save()
 
-    res.status(201)
-    res.header('Location', project.value)
+    res.status(200)
     await res.dataset(project.dataset)
   }),
 )

--- a/apis/core/lib/handlers/cube-projects.ts
+++ b/apis/core/lib/handlers/cube-projects.ts
@@ -43,15 +43,14 @@ export const post = protectedResource(
 export const put = protectedResource(
   shaclValidate,
   asyncMiddleware(async (req, res) => {
-    const project = await req.hydra.resource.clownface()
-    await updateProject({
+    const project = await updateProject({
       resource: await req.resource(),
       store: req.resourceStore(),
     })
     await req.resourceStore().save()
 
     res.status(200)
-    await res.dataset(project.dataset)
+    await res.dataset(project.pointer.dataset)
   }),
 )
 

--- a/e2e-tests/cube-projects/update.hydra
+++ b/e2e-tests/cube-projects/update.hydra
@@ -1,0 +1,46 @@
+PREFIX api: <https://cube-creator.zazuko.com/vocab#>
+PREFIX hydra: <http://www.w3.org/ns/hydra/core#>
+PREFIX cc: <https://cube-creator.zazuko.com/vocab#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX schema: <http://schema.org/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+ENTRYPOINT "cube-project/ubd"
+
+HEADERS {
+  x-user "john-doe"
+  x-permission "pipelines:write"
+}
+
+With Class cc:CubeProject {
+    With Operation schema:UpdateAction {
+        Invoke {
+            Content-Type "text/turtle"
+
+            ```
+            base <https://cube-creator.lndo.site/>
+            prefix dcterms: <http://purl.org/dc/terms/>
+            prefix cc: <https://cube-creator.zazuko.com/vocab#>
+            prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            prefix schema: <http://schema.org/>
+
+            <cube-project/ubd> a cc:CubeProject ;
+               rdfs:label "UBD28" ;
+               dcterms:creator <user> ;
+               dcterms:identifier "ubd/28" ;
+               schema:maintainer <organization/bafu> ;
+               cc:csvMapping <cube-project/ubd/csv-mapping> ;
+               cc:cubeGraph <cube-project/ubd/cube-data> ;
+               cc:dataset <cube-project/ubd/dataset> ;
+               cc:jobCollection <cube-project/ubd/jobs> ;
+               cc:latestPublishedRevision 1 ;
+               cc:projectSourceKind <shape/cube-project/create#CSV> .
+            ```
+        } => {
+            Expect Status 200
+
+            Expect Property rdfs:label "UBD28"
+        }
+    }
+}


### PR DESCRIPTION
I broke updating csv projects by calling the `exists` check unnecessarily