### PR TITLE
refactor: no blanks in shared dimensions

### DIFF
--- a/.changeset/many-walls-kick.md
+++ b/.changeset/many-walls-kick.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Techy: resources are stored without any blank nodes to avoid conflicts

--- a/apis/shared-dimensions/lib/rewrite.ts
+++ b/apis/shared-dimensions/lib/rewrite.ts
@@ -1,6 +1,11 @@
-import { Quad, Term } from 'rdf-js'
+import { NamedNode, Quad, Term } from 'rdf-js'
 import $rdf from 'rdf-ext'
 import clownface, { GraphPointer } from 'clownface'
+import TermMap from '@rdfjs/term-map'
+import BlankNodeExt from 'rdf-ext/lib/BlankNode'
+import NamedNodeExt from 'rdf-ext/lib/NamedNode'
+import QuadExt from 'rdf-ext/lib/Quad'
+import { nanoid } from 'nanoid'
 import env from './env'
 
 export function rewriteTerm<T extends Term>(term: T): T {
@@ -27,4 +32,28 @@ export function rewrite<T extends Term>(pointer: GraphPointer<T>): GraphPointer<
   return clownface({
     dataset: $rdf.dataset([...pointer.dataset].map(rewriteQuad)),
   }).node(rewriteTerm<T>(pointer.term as any))
+}
+
+export function removeBnodes(pointer: GraphPointer<NamedNode>): GraphPointer<NamedNode> {
+  const map = new TermMap<BlankNodeExt, NamedNodeExt>()
+  function replaceBlank(quad: QuadExt) {
+    if (quad.subject.termType !== 'BlankNode' && quad.object.termType !== 'BlankNode') {
+      return quad
+    }
+
+    let { subject, object } = quad
+    if (quad.subject.termType === 'BlankNode') {
+      subject = map.get(quad.subject) || $rdf.namedNode(`urn:shape:${nanoid()}`)
+      map.set(quad.subject, subject)
+    }
+    if (quad.object.termType === 'BlankNode') {
+      object = map.get(quad.object) || $rdf.namedNode(`urn:shape:${nanoid()}`)
+      map.set(quad.object, object)
+    }
+
+    return $rdf.quad(subject, quad.predicate, object, quad.graph)
+  }
+
+  const dataset = $rdf.dataset([...pointer.dataset]).map(replaceBlank)
+  return clownface({ dataset }).namedNode(pointer.term)
 }

--- a/apis/shared-dimensions/lib/shapes/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/shapes/shared-dimension.ts
@@ -32,7 +32,7 @@ const properties: Initializer<PropertyShape>[] = [{
   path: sh.property,
   minCount: 1,
   maxCount: 1,
-  nodeKind: sh.BlankNode,
+  nodeKind: sh.BlankNodeOrIRI,
   defaultValue: $rdf.blankNode(),
   order: 30,
   node: {
@@ -65,7 +65,7 @@ const properties: Initializer<PropertyShape>[] = [{
       name: 'Data kind',
       path: meta.dataKind,
       maxCount: 1,
-      nodeKind: sh.BlankNode,
+      nodeKind: sh.BlankNodeOrIRI,
       order: 30,
       node: {
         property: [{

--- a/apis/shared-dimensions/package.json
+++ b/apis/shared-dimensions/package.json
@@ -25,6 +25,7 @@
     "http-status": "^1.5.0",
     "hydra-box-middleware-shacl": "1.0.0",
     "middleware-async": "^1.2.7",
+    "nanoid": "^3.1.23",
     "once": "^1.4.0",
     "rdf-ext": "^1.3.0",
     "rdf-literal": "^1.2.0",


### PR DESCRIPTION
1. Rewrite any blank nodes in resources as `urn:shape:...`
2. Do not use blank nodes in extracted shapes

This could mitigate some of the issues we've been having with synchronisation between cluster nodes