### PR TITLE
fix(ui): refresh cube dimensions when needed

### DIFF
--- a/.changeset/shiny-bats-train.md
+++ b/.changeset/shiny-bats-train.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Fix Cube Designer refresh button when dimensions were not loaded at page load (fix #764)

--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -110,7 +110,7 @@
                 </b-select>
               </b-tooltip>
               <b-tooltip label="Refresh data">
-                <b-button icon-left="sync" @click="fetchCubeData" />
+                <b-button icon-left="sync" @click="refreshData" />
               </b-tooltip>
             </div>
           </td>
@@ -187,6 +187,14 @@ export default class extends Vue {
     }
 
     return null
+  }
+
+  async refreshData (): Promise<void> {
+    if (this.dimensions.length === 0) {
+      this.$emit('refreshDimensions')
+    }
+
+    return this.fetchCubeData()
   }
 
   @Watch('pageSize')

--- a/ui/src/views/CubeDesigner.vue
+++ b/ui/src/views/CubeDesigner.vue
@@ -5,6 +5,7 @@
       :dimensions="dimensions"
       :selected-language="selectedLanguage"
       @selectLanguage="selectLanguage"
+      @refreshDimensions="refreshDimensions"
     />
 
     <router-view :key="$route.fullPath" />
@@ -37,6 +38,10 @@ export default class CubeDesignerView extends Vue {
 
   selectLanguage (language: string): void {
     this.$store.dispatch('project/selectLanguage', language)
+  }
+
+  refreshDimensions (): void {
+    this.$store.dispatch('project/fetchDimensionMetadataCollection')
   }
 }
 </script>


### PR DESCRIPTION
If the Cube Designer was opened before the cube had any dimension (if a
job is running for example), refreshing the data would not display
observations properly. It will now refresh the dimensions if needed.