### PR TITLE
fix(ui): clear stale OIDC cookies on login

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -55,6 +55,17 @@ export default class App extends Vue {
 
   mounted (): void {
     this.$store.dispatch('app/loadCommonRDFProperties')
+
+    window.addEventListener('vuexoidc:userLoaded', this.onUserLoaded)
+  }
+
+  destroyed (): void {
+    window.removeEventListener('vuexoidc:userLoaded', this.onUserLoaded)
+  }
+
+  onUserLoaded (): void {
+    // Clear stale state in OIDC store to avoid "Request Header Or Cookie Too Large" error
+    this.$store.dispatch('auth/clearStaleState')
   }
 
   dismissMessage (message: Message): void {

--- a/ui/src/components/auth/SignOutButton.vue
+++ b/ui/src/components/auth/SignOutButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="user">
-    <b-button @click="logout" icon-right="power-off" title="Sign out">
+    <b-button @click="signOut" icon-right="power-off" title="Sign out">
       {{ user.name }}
     </b-button>
   </div>
@@ -22,13 +22,7 @@ export default Vue.extend({
   methods: {
     ...mapActions({
       signOut: 'auth/signOutOidc',
-      clearStaleState: 'auth/clearStaleState',
     }),
-
-    logout () {
-      this.clearStaleState()
-      return this.signOut()
-    },
   },
 })
 </script>

--- a/ui/src/store/modules/auth.ts
+++ b/ui/src/store/modules/auth.ts
@@ -29,5 +29,6 @@ export function auth (): Module<VuexOidcState, RootState> {
     namespaced: true,
     publicRoutePaths: ['/oidc-error', '/logout'],
     routeBase: process.env.BASE_URL,
+    dispatchEventsOnWindow: true,
   })
 }


### PR DESCRIPTION
Follow-up to #768 

Clearing the state on logout wasn't a great idea because users don't usually use the logout button. This will clear the state without requiring any user action.

Should help with #767 