### PR TITLE
fix(publish): emit dimension versions at end of stream

### DIFF
--- a/.changeset/quick-melons-lick.md
+++ b/.changeset/quick-melons-lick.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+In some cubes the `schema:version` was not applied to dimensions (re. #776)


### PR DESCRIPTION
I don't understand why, but somehow the timing as off here, and the code which would emit the `schema:version` came too early, when the dimensions to version were not yet determined.

By moving it to the flush callback, we can wait for the entire stream to pass and only then push these quads