### PR TITLE
fix: improve queries for /dataset resource

### DIFF
--- a/.changeset/nasty-brooms-wash.md
+++ b/.changeset/nasty-brooms-wash.md
@@ -2,4 +2,4 @@
 "@cube-creator/core-api": patch
 ---
 
-Cube Designer tab failed to load for large cubes. Reworked the source queries
+Cube Designer tab failed to load for large cubes. Reworked the source queries (closes #586)

--- a/.changeset/nasty-brooms-wash.md
+++ b/.changeset/nasty-brooms-wash.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Cube Designer tab failed to load for large cubes. Reworked the source queries

--- a/apis/core/lib/domain/queries/cube.ts
+++ b/apis/core/lib/domain/queries/cube.ts
@@ -1,4 +1,4 @@
-import { CONSTRUCT, DESCRIBE, SELECT } from '@tpluscode/sparql-builder'
+import { CONSTRUCT, SELECT } from '@tpluscode/sparql-builder'
 import StreamClient from 'sparql-http-client/StreamClient'
 import * as ns from '@cube-creator/core/namespace'
 import { NamedNode, Stream, Term } from 'rdf-js'

--- a/apis/core/lib/handlers/dataset.ts
+++ b/apis/core/lib/handlers/dataset.ts
@@ -12,7 +12,7 @@ import { fromPointer } from '@rdfine/hydra/lib/IriTemplate'
 import { shaclValidate } from '../middleware/shacl'
 import { update } from '../domain/dataset/update'
 import { loadCubeShapes } from '../domain/queries/cube'
-import { streamClient } from '../query-client'
+import * as clients from '../query-client'
 import env from '@cube-creator/core/env'
 import { getCubesAndGraphs } from '../domain/dataset/queries'
 
@@ -33,7 +33,7 @@ export const put = protectedResource(
 
 export const get = protectedResource(asyncMiddleware(async (req, res) => {
   const dataset = await req.hydra.resource.clownface()
-  const shapeStream = await loadCubeShapes(req.hydra.resource.term, streamClient)
+  const shapeStream = await loadCubeShapes(req.hydra.resource.term, clients)
   const outStream = new PassThrough({
     objectMode: true,
   })


### PR DESCRIPTION
I completely rewrote the query which loads the cube/shape/properties for the `/dataset` resource

Now it is done in 2 separate queries which are much faster combined than the previous, especially for large cubes.