### PR TITLE
fix(ui): do not "lose" selected shared term

### DIFF
--- a/.changeset/forty-penguins-add.md
+++ b/.changeset/forty-penguins-add.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Selected shared term disappeared if result of search

--- a/ui/src/forms/editors/AutoCompleteEditor.vue
+++ b/ui/src/forms/editors/AutoCompleteEditor.vue
@@ -38,6 +38,7 @@ export default class extends Vue {
   @Prop() options?: [GraphPointer, string][]
 
   searchValue = ''
+  initialLoaded = false
 
   get _options (): Option[] {
     const options = this.options ?? []
@@ -53,7 +54,12 @@ export default class extends Vue {
   }
 
   onSearch (freetextQuery: string, loading: () => void): void {
+    if (this.initialLoaded && !freetextQuery) {
+      return
+    }
+
     this.searchValue = freetextQuery
+    this.initialLoaded = true
     this.$emit('search', freetextQuery, loading)
   }
 


### PR DESCRIPTION
Prevents the selected option from being replaced by its URI

This happens because the select box search text was cleared, causing it to run a query again, with empty string. Because there is no explicit "display value" property, this means that the selected item would not appear in the retrieved items

The change is to prevent the "empty search" and only allow it on the initial load