### PR TITLE
Shared dimension mapping: improve loading time

### DIFF
--- a/.changeset/neat-pears-notice.md
+++ b/.changeset/neat-pears-notice.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Long loading times of dimension mapping drawer


### PR DESCRIPTION
Breaking up the query so that cube data graph is determined first. The use `FROM` instead of `GRAPH`

Removing the `DISTINCT` does not appear to improve much but still are redundant