### PR TITLE
Unhandled rejections should fail job

### DIFF
--- a/.changeset/lemon-roses-promise.md
+++ b/.changeset/lemon-roses-promise.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Pipeline would not fail on `ECONNRESET` fetch error (closes #782)

--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -45,4 +45,4 @@ COPY --from=builder /app/dist/packages/ ./packages/
 ARG COMMIT
 ENV SENTRY_RELEASE=cube-creator-cli@$COMMIT
 
-ENTRYPOINT ["node", "cli/index.js"]
+ENTRYPOINT ["node", "--unhandled-rejections=strict", "cli/index.js"]

--- a/cli/package.json
+++ b/cli/package.json
@@ -52,7 +52,7 @@
     "rdf-stream-to-dataset-stream": "^1.0.0",
     "rdf-validate-datatype": "^0.1.3",
     "readable-stream": "^3.6.0",
-    "sparql-http-client": "^2.2",
+    "sparql-http-client": "^2.4.0",
     "string-to-stream": "^3.0.1",
     "through2": "^4.0.2",
     "through2-reduce": "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12137,10 +12137,10 @@ source-map@^0.7.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sparql-http-client@^2.2, sparql-http-client@^2.2.2:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/sparql-http-client/-/sparql-http-client-2.3.1.tgz#3daf2acf8c8625ea77dae1f738108179b1f2274b"
-  integrity sha512-vkkHF7YUYoSz5Xg9JrfHv23sCodDat4AOpa2U4rX3Gy4y1T1WyXVjI2B177ZISfHXdvOm8uTjlxXp3Os+hqj9w==
+sparql-http-client@^2.2.2, sparql-http-client@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/sparql-http-client/-/sparql-http-client-2.4.0.tgz#ebc8373dc16da06a557a344e82052d4b814d6985"
+  integrity sha512-/mOs4l2tfXJ2DnjmXMe3Gzihp68JGT239OZLiO678xSXU2g6ZZbcCmImkCy9zs6hw3ft6exFo4NIJn6sIDMoIA==
   dependencies:
     "@rdfjs/data-model" "^1.1.2"
     "@rdfjs/parser-n3" "^1.1.3"


### PR DESCRIPTION
In the end, handling the `unhandledRejection` event serves the purpose of actually ending the process gracefully and marking the job resource as failed

Thus, the `--unhandled-rejections=strict` flag and newer version of `sparql-http-client` are unnecessary but won't hurt either. I can revert...