### PR TITLE
build: update lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -66,9 +66,6 @@ services:
       environment:
         TS_NODE_TRANSPILE_ONLY: "true"
         NODE_TLS_REJECT_UNAUTHORIZED: 0
-        # Requires override because port must be used in internal communication
-        GRAPH_STORE_ENDPOINT: http://db.cube-creator.lndo.site/cube-creator/data
-        PUBLISH_GRAPH_STORE_ENDPOINT: http://db.cube-creator.lndo.site/cube-creator/data
     moreHttpPorts:
           - 45681
 

--- a/.lando.yml
+++ b/.lando.yml
@@ -8,7 +8,6 @@ services:
     build:
       - npm i -g nodemon
     command: nodemon -w packages -w apis --verbose --ext ts,ttl,js,trig --ignore **/*.test.ts --ignore **/*.spec-graphs.ts --exec node --inspect=0.0.0.0:45671 -r ts-node/register --inspect apis/core/index.ts
-    port: 45670
     ssl: true
     overrides:
       image: node:14
@@ -50,8 +49,6 @@ services:
     ssl: false
     services:
       image: minio/minio:RELEASE.2020-12-03T05-49-24Z
-      ports:
-        - '9000:9000'
       command: usr/bin/docker-entrypoint.sh server /data
       environment:
         MINIO_ACCESS_KEY: minio
@@ -66,14 +63,12 @@ services:
     port: 80
     overrides:
       image: node:14
-      ports:
-        - '45681:45681'
       environment:
         TS_NODE_TRANSPILE_ONLY: "true"
         NODE_TLS_REJECT_UNAUTHORIZED: 0
         # Requires override because port must be used in internal communication
-        GRAPH_STORE_ENDPOINT: http://db.cube-creator.lndo.site:3030/cube-creator/data
-        PUBLISH_GRAPH_STORE_ENDPOINT: http://db.cube-creator.lndo.site:3030/cube-creator/data
+        GRAPH_STORE_ENDPOINT: http://db.cube-creator.lndo.site/cube-creator/data
+        PUBLISH_GRAPH_STORE_ENDPOINT: http://db.cube-creator.lndo.site/cube-creator/data
     moreHttpPorts:
           - 45681
 

--- a/.local.env
+++ b/.local.env
@@ -5,9 +5,9 @@ API_CORE_BASE=https://cube-creator.lndo.site/
 UI_BASE=https://app.cube-creator.lndo.site/
 
 # SPARQL endpoints
-STORE_QUERY_ENDPOINT=http://store:3030/cube-creator/query
-STORE_UPDATE_ENDPOINT=http://store:3030/cube-creator/update
-STORE_GRAPH_ENDPOINT=http://store:3030/cube-creator/data
+STORE_QUERY_ENDPOINT=http://db.cube-creator.lndo.site/cube-creator/query
+STORE_UPDATE_ENDPOINT=http://db.cube-creator.lndo.site/cube-creator/update
+STORE_GRAPH_ENDPOINT=http://db.cube-creator.lndo.site/cube-creator/data
 PUBLIC_QUERY_ENDPOINT=https://test.lindas.admin.ch/query
 TRIFID_UI=https://lindas.admin.ch/sparql
 
@@ -24,7 +24,7 @@ VUE_APP_AUTH_CLIENT_ID=cube-creator
 VUE_APP_API_CORE_BASE=https://cube-creator.lndo.site/
 
 # S3 config
-AWS_S3_ENDPOINT=http://s3.cube-creator.lndo.site:9000
+AWS_S3_ENDPOINT=http://s3.cube-creator.lndo.site
 AWS_S3_BUCKET=cube-creator
 AWS_ACCESS_KEY_ID=minio
 AWS_SECRET_ACCESS_KEY=password
@@ -37,9 +37,9 @@ PIPELINE_URI=http://pipeline.cube-creator.lndo.site
 MANAGED_DIMENSIONS_GRAPH=https://lindas.admin.ch/cube/dimension
 MANAGED_DIMENSIONS_API_BASE=https://cube-creator.lndo.site/
 MANAGED_DIMENSIONS_BASE=https://ld.admin.ch/cube/
-MANAGED_DIMENSIONS_STORE_QUERY_ENDPOINT=http://store:3030/shared-dimensions/query
-MANAGED_DIMENSIONS_STORE_UPDATE_ENDPOINT=http://store:3030/shared-dimensions/update
-MANAGED_DIMENSIONS_STORE_GRAPH_ENDPOINT=http://store:3030/shared-dimensions/data
+MANAGED_DIMENSIONS_STORE_QUERY_ENDPOINT=http://db.cube-creator.lndo.site/shared-dimensions/query
+MANAGED_DIMENSIONS_STORE_UPDATE_ENDPOINT=http://db.cube-creator.lndo.site/shared-dimensions/update
+MANAGED_DIMENSIONS_STORE_GRAPH_ENDPOINT=http://db.cube-creator.lndo.site/shared-dimensions/data
 
 # PX Cube sample
 PX_CUBE_BASE=https://environment.ld.admin.ch/foen/example/px-cube/

--- a/e2e-tests/cube-projects/create-invalid.hydra
+++ b/e2e-tests/cube-projects/create-invalid.hydra
@@ -122,7 +122,7 @@ With Class api:EntryPoint {
                 <> cc:projectSourceKind <https://cube-creator.lndo.site/shape/cube-project/create#ExistingCube> ;
                    rdfs:label "Test Project" ;
                    CubeProject:sourceCube <https://environment.ld.admin.ch/foen/ubd/28> ;
-                   CubeProject:sourceEndpoint <http://store:3030/px-cube> ;
+                   CubeProject:sourceEndpoint <http://db.cube-creator.lndo.site/px-cube> ;
                    schema:maintainer <https://cube-creator.lndo.site/organization/bafu> .
                 ```
             } => {
@@ -142,7 +142,7 @@ With Class api:EntryPoint {
                 <> cc:projectSourceKind <https://cube-creator.lndo.site/shape/cube-project/create#ExistingCube> ;
                    rdfs:label "Test Project" ;
                    CubeProject:sourceCube <https://environment.ld.admin.ch/foen/example/px-cube> ;
-                   CubeProject:sourceEndpoint <http://store:3030/px-cube> ;
+                   CubeProject:sourceEndpoint <http://db.cube-creator.lndo.site/px-cube> ;
                    schema:maintainer <https://cube-creator.lndo.site/organization/bafu> .
                 ```
             } => {
@@ -162,7 +162,7 @@ With Class api:EntryPoint {
                 <> cc:projectSourceKind <https://cube-creator.lndo.site/shape/cube-project/create#ExistingCube> ;
                    rdfs:label "Test Project" ;
                    CubeProject:sourceCube <https://environment.ld.admin.ch/bafu/example/px2> ;
-                   CubeProject:sourceEndpoint <http://store:3030/px-cube> ;
+                   CubeProject:sourceEndpoint <http://db.cube-creator.lndo.site/px-cube> ;
                    schema:maintainer <https://cube-creator.lndo.site/organization/bafu> .
                 ```
             } => {

--- a/e2e-tests/install-lando.sh
+++ b/e2e-tests/install-lando.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-curl -fsSL -o /tmp/lando-latest.deb https://github.com/lando/lando/releases/download/v3.0.18/lando-v3.0.18.deb
+curl -fsSL -o /tmp/lando-latest.deb https://github.com/lando/lando/releases/download/v3.1.4/lando-v3.1.4.deb
 sudo dpkg -i /tmp/lando-latest.deb
 lando version

--- a/fuseki/sample-px.trig
+++ b/fuseki/sample-px.trig
@@ -31,7 +31,7 @@ graph <cube-project/px> {
     cc:projectSourceKind <https://cube-creator.lndo.site/shape/cube-project/create#ExistingCube> ;
     CubeProject:sourceCube <https://environment.ld.admin.ch/foen/example/px-cube> ;
     CubeProject:sourceGraph <http://example.org/px-cube> ;
-    CubeProject:sourceEndpoint <http://store:3030/px-cube> ;
+    CubeProject:sourceEndpoint <http://db.cube-creator.lndo.site/px-cube> ;
 }
 
 <cube-project/px/cube-data> void:inDataset <px-example> .

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -316,7 +316,7 @@ graph <cube-project/ubd/csv-source/ubd> {
   <cube-project/ubd/csv-source/ubd>
     a cc:CSVSource, hydra:Resource ;
     schema:associatedMedia  [ a  schema:MediaObject ;
-                              schema:contentUrl <http://s3:9000/cube-creator/test-data/ubd28/input_CH_yearly_air_immission_basetable.csv> ;
+                              schema:contentUrl <http://s3.cube-creator.lndo.site/cube-creator/test-data/ubd28/input_CH_yearly_air_immission_basetable.csv> ;
                               schema:identifier "test-data/ubd28/input_CH_yearly_air_immission_basetable.csv";
                             ] ;
     schema:name "ubd.csv" ;
@@ -414,7 +414,7 @@ graph <cube-project/ubd/csv-source/stations> {
     a cc:CSVSource, hydra:Resource ;
     cc:csvMapping <cube-project/ubd/csv-mapping> ;
     schema:associatedMedia  [ a  schema:MediaObject ;
-                              schema:contentUrl <http://s3:9000/cube-creator/test-data/ubd28/input_CH_yearly_air_immission_basetable.csv> ;
+                              schema:contentUrl <http://s3.cube-creator.lndo.site/cube-creator/test-data/ubd28/input_CH_yearly_air_immission_basetable.csv> ;
                               schema:identifier "test-data/ubd28/input_CH_yearly_air_immission_basetable.csv";
                             ] ;
     schema:name "stations.csv" ;


### PR DESCRIPTION
At long last, an update to lando finally allows the proxied hosts to be used for all inter-service communication nada without using ports

This potentially breaking change came in a patch release, because why not.