### PR TITLE
fix(ui): showing correct term URI

### DIFF
--- a/.changeset/hip-jobs-switch.md
+++ b/.changeset/hip-jobs-switch.md
@@ -1,0 +1,6 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+"@cube-creator/ui": patch
+---
+
+Displaying the canonical term URI on Shared Dimension screen (closes #787)

--- a/apis/shared-dimensions/index.ts
+++ b/apis/shared-dimensions/index.ts
@@ -7,6 +7,7 @@ import env from './lib/env'
 import bootstrap from './bootstrap'
 import Loader from './lib/loader'
 import { sparql, parsingClient, streamClient } from './lib/sparql'
+import { patchResponseStream } from './lib/middleware/canonicalRewrite'
 
 const apiPath = path.resolve(__dirname, 'hydra')
 const codePath = path.resolve(__dirname, 'lib')
@@ -18,18 +19,20 @@ export async function sharedDimensions(): Promise<Router> {
   return Router()
     .use(camouflage({
       url: baseUri,
-      rewriteContent: true,
       rewriteHeaders: true,
     }))
     .use(await hydraBox({
       apiPath,
       codePath,
-      baseUri,
+      baseUri: env.MANAGED_DIMENSIONS_API_BASE,
       loader: new Loader({
         graph: $rdf.namedNode(env.MANAGED_DIMENSIONS_GRAPH),
         sparql: parsingClient,
         stream: streamClient,
       }),
       sparql,
+      middleware: {
+        resource: patchResponseStream,
+      },
     }))
 }

--- a/apis/shared-dimensions/lib/handlers/shared-dimension-term.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimension-term.ts
@@ -4,12 +4,15 @@ import { updateTerm } from '../domain/shared-dimension-term'
 import { store } from '../store'
 import { shaclValidate } from '../middleware/shacl'
 import { rewrite } from '../rewrite'
+import { oa } from '@tpluscode/rdf-ns-builders'
 
 export const put = protectedResource(shaclValidate, asyncMiddleware(async (req, res) => {
   const pointer = await updateTerm({
     store: store(),
     term: rewrite(await req.resource()),
   })
+
+  pointer.addOut(oa.canonical, pointer)
 
   return res.dataset(pointer.dataset)
 }))

--- a/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
@@ -82,7 +82,7 @@ export const getTerms = asyncMiddleware(async (req, res, next) => {
 
   collection.out(hydra.member)
     .forEach((member: GraphPointer) => {
-      member.addOut(oa.canonical, member.value.replace('https://', ''))
+      member.addOut(oa.canonical, member)
     })
 
   res.setLink(collection.value, 'canonical')

--- a/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
@@ -1,9 +1,9 @@
-import { hydra, rdf, schema } from '@tpluscode/rdf-ns-builders'
+import { hydra, oa, rdf, schema } from '@tpluscode/rdf-ns-builders'
 import { asyncMiddleware } from 'middleware-async'
 import { protectedResource } from '@hydrofoil/labyrinth/resource'
 import { Enrichment } from '@hydrofoil/labyrinth/lib/middleware/preprocessResource'
 import httpError from 'http-errors'
-import clownface from 'clownface'
+import clownface, { GraphPointer } from 'clownface'
 import $rdf from 'rdf-ext'
 import { NamedNode, Quad, Term } from 'rdf-js'
 import { md } from '@cube-creator/core/namespace'
@@ -79,6 +79,11 @@ export const getTerms = asyncMiddleware(async (req, res, next) => {
     collectionType: md.SharedDimensionTerms,
     collection: termsCollectionId(term, queryParams.freetextQuery),
   })
+
+  collection.out(hydra.member)
+    .forEach((member: GraphPointer) => {
+      member.addOut(oa.canonical, member.value.replace('https://', ''))
+    })
 
   res.setLink(collection.value, 'canonical')
   return res.dataset(collection.dataset)

--- a/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
+++ b/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
@@ -1,0 +1,44 @@
+import express from 'express'
+import asyncMiddleware from 'middleware-async'
+import through2 from 'through2'
+import { Quad, Stream, Term } from 'rdf-js'
+import { Readable } from 'stream'
+import { oa } from '@tpluscode/rdf-ns-builders'
+import $rdf from 'rdf-ext'
+import env from '../env'
+
+export function rewriteTerm<T extends Term>(term: T): T {
+  if (term.termType === 'NamedNode') {
+    return $rdf.namedNode(term.value.replace(env.MANAGED_DIMENSIONS_BASE, env.MANAGED_DIMENSIONS_API_BASE)) as any
+  }
+
+  return term
+}
+
+/**
+ * Rewrites quad to change canonical URIs with API namespace with the exception of oa:canonical property
+ */
+function rewriteQuad({ subject, predicate, object, graph }: Quad): Quad {
+  return $rdf.quad(
+    rewriteTerm(subject),
+    rewriteTerm(predicate),
+    predicate.equals(oa.canonical) ? object : rewriteTerm(object),
+    rewriteTerm(graph),
+  )
+}
+
+export const patchResponseStream: express.RequestHandler = asyncMiddleware(async (req, res, next) => {
+  const { quadStream } = res
+
+  res.quadStream = (stream: Stream & Readable) => {
+    const rewriteTerms = through2.obj(function (chunk: Quad, enc, callback) {
+      this.push(rewriteQuad(chunk))
+
+      callback()
+    })
+
+    return quadStream(stream.pipe(rewriteTerms))
+  }
+
+  next()
+})

--- a/apis/shared-dimensions/package.json
+++ b/apis/shared-dimensions/package.json
@@ -29,7 +29,8 @@
     "once": "^1.4.0",
     "rdf-ext": "^1.3.0",
     "rdf-literal": "^1.2.0",
-    "sparql-http-client": "^2.2.2"
+    "sparql-http-client": "^2.2.2",
+    "through2": "^2.0.5"
   },
   "devDependencies": {
     "@cube-creator/testing": "^0.1.18",

--- a/ui/src/store/serializers.ts
+++ b/ui/src/store/serializers.ts
@@ -218,17 +218,12 @@ export function serializeSharedDimension (dimension: RdfResource): SharedDimensi
 export function serializeSharedDimensionTerm (term: RdfResource): SharedDimensionTerm {
   const validThrough = term.pointer.out(schema.validThrough).value
 
-  let canonical
-  if (term.pointer.out(oa.canonical).term) {
-    canonical = term.pointer.namedNode(`https://${term.pointer.out(oa.canonical).value}`)
-  }
-
   return Object.freeze({
     ...serializeResource(term),
     name: term.pointer.out(schema.name).terms,
     identifiers: term.pointer.out(schema.identifier).values,
     validThrough: validThrough ? new Date(validThrough) : undefined,
-    canonical: canonical?.term,
+    canonical: term.pointer.out(oa.canonical).term,
   })
 }
 

--- a/ui/src/store/serializers.ts
+++ b/ui/src/store/serializers.ts
@@ -16,7 +16,7 @@ import {
 } from '@cube-creator/model'
 import { IdentifierMapping, LiteralColumnMapping, ReferenceColumnMapping } from '@cube-creator/model/ColumnMapping'
 import { Link } from '@cube-creator/model/lib/Link'
-import { dcterms, rdf, rdfs, schema } from '@tpluscode/rdf-ns-builders'
+import { dcterms, oa, rdf, rdfs, schema } from '@tpluscode/rdf-ns-builders'
 import { RdfResource } from '@tpluscode/rdfine/RdfResource'
 import { Collection } from 'alcaeus'
 import { SharedDimension, SharedDimensionTerm } from './types'
@@ -218,11 +218,17 @@ export function serializeSharedDimension (dimension: RdfResource): SharedDimensi
 export function serializeSharedDimensionTerm (term: RdfResource): SharedDimensionTerm {
   const validThrough = term.pointer.out(schema.validThrough).value
 
+  let canonical
+  if (term.pointer.out(oa.canonical).term) {
+    canonical = term.pointer.namedNode(`https://${term.pointer.out(oa.canonical).value}`)
+  }
+
   return Object.freeze({
     ...serializeResource(term),
     name: term.pointer.out(schema.name).terms,
     identifiers: term.pointer.out(schema.identifier).values,
     validThrough: validThrough ? new Date(validThrough) : undefined,
+    canonical: canonical?.term,
   })
 }
 

--- a/ui/src/store/types.ts
+++ b/ui/src/store/types.ts
@@ -39,4 +39,5 @@ export interface SharedDimensionTerm extends Resource {
   name: Term[]
   identifiers: string[]
   validThrough?: Date
+  canonical: Term | undefined
 }

--- a/ui/src/views/SharedDimension.vue
+++ b/ui/src/views/SharedDimension.vue
@@ -38,7 +38,7 @@
         <tbody>
           <tr v-for="term in terms" :key="term.clientPath">
             <td class="has-text-sm">
-              <term-display :term="term.id" />
+              <term-display :term="term.canonical || term.id" />
             </td>
             <td>
               <p v-for="(name, index) in term.name" :key="index">

--- a/yarn.lock
+++ b/yarn.lock
@@ -12707,7 +12707,7 @@ through2-reduce@1.1.1:
     through2 "~2.0.0"
     xtend "~4.0.1"
 
-through2@^2.0.0, through2@^2.0.3, through2@~2.0.0:
+through2@^2.0.0, through2@^2.0.3, through2@^2.0.5, through2@~2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==


### PR DESCRIPTION
I am not stoked about this.

Because `camouflage-rewrite` replaces all occurrences of the `ld.admin` URIs from the responses, I had to add a maimed URI as the "canonical" and fix it back on the UI so that it does not get replaced with local API identifiers like the rest of it... 