### PR TITLE
Switch to GHCR

### DIFF
--- a/.changeset/rich-parrots-decide.md
+++ b/.changeset/rich-parrots-decide.md
@@ -1,0 +1,7 @@
+---
+"@cube-creator/core-api": patch
+"@cube-creator/cli": patch
+"@cube-creator/ui": patch
+---
+
+Switch to GHCR

--- a/.github/workflows/docker-api.yaml
+++ b/.github/workflows/docker-api.yaml
@@ -26,18 +26,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-api-
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         if: github.event_name != 'pull_request'
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate image metadata
         uses: zazuko/action-docker-meta@main
         id: docker_meta
         with:
-          images: zazuko/cube-creator-api
+          images: ghcr.io/zazuko/cube-creator-api
           strip-tag-prefix: cube-creator-api/
 
       - name: Build and push

--- a/.github/workflows/docker-app.yaml
+++ b/.github/workflows/docker-app.yaml
@@ -26,18 +26,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-app-
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         if: github.event_name != 'pull_request'
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate image metadata
         uses: zazuko/action-docker-meta@main
         id: docker_meta
         with:
-          images: zazuko/cube-creator-app
+          images: ghcr.io/zazuko/cube-creator-app
           strip-tag-prefix: cube-creator-app/
 
       - name: Build and push

--- a/.github/workflows/docker-cli.yaml
+++ b/.github/workflows/docker-cli.yaml
@@ -26,18 +26,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-cli-
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         if: github.event_name != 'pull_request'
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate image metadata
         uses: zazuko/action-docker-meta@main
         id: docker_meta
         with:
-          images: zazuko/cube-creator-cli
+          images: ghcr.io/zazuko/cube-creator-cli
           strip-tag-prefix: cube-creator-cli/
 
       - name: Build and push


### PR DESCRIPTION
Due to some limitations of Docker Hub, we switch to the GitHub Container Registry.