### PR TITLE
feat: handle large files when replacing CSV file

### DIFF
--- a/apis/core/hydra/csv-source.ttl
+++ b/apis/core/hydra/csv-source.ttl
@@ -98,9 +98,12 @@ cc:CSVSource
         hydra:Operation,
           cc:ReplaceCSVAction ;
       hydra:title
-        "Replace CSV-File" ;
+        "Replace CSV file" ;
       hydra:method
         "PATCH" ;
+      hydra:expects
+        schema:MediaObject,
+        <shape/csv-source/create> ;
       code:implementedBy
         [
           a

--- a/apis/core/lib/domain/csv-source/replace.ts
+++ b/apis/core/lib/domain/csv-source/replace.ts
@@ -1,29 +1,28 @@
 import { GraphPointer } from 'clownface'
-import { Readable } from 'stream'
 import { NamedNode } from 'rdf-js'
 import * as s3 from '../../storage/s3'
 import { ResourceStore } from '../../ResourceStore'
 import { loadFileHeadString } from '../csv/file-head'
 import { parse } from '../csv'
 import { CsvSource } from '@cube-creator/model'
-import { nanoid } from 'nanoid'
 import { createOrUpdateColumns } from './update'
 import { DomainError } from '@cube-creator/api-errors'
+import { schema } from '@tpluscode/rdf-ns-builders'
 
 interface ReplaceCSVCommand {
-  file: Readable | Buffer
-  resource: NamedNode
+  csvSourceId: NamedNode
+  resource: GraphPointer
   store: ResourceStore
   fileStorage?: s3.FileStorage
 }
 
 export async function replaceFile({
-  file,
+  csvSourceId,
   resource,
   store,
   fileStorage = s3,
 }: ReplaceCSVCommand): Promise<GraphPointer> {
-  const csvSource = await store.getResource<CsvSource>(resource)
+  const csvSource = await store.getResource<CsvSource>(csvSourceId)
 
   // Remove any previous error
   csvSource.error = undefined
@@ -33,10 +32,7 @@ export async function replaceFile({
     throw new DomainError(`S3 key is missing for ${resource}`)
   }
 
-  const tempKey = `temp/${nanoid()}`
-
-  // Upload file to temp location
-  await fileStorage.saveFile(tempKey, file)
+  const tempKey = resource.out(schema.identifier).value!
 
   try {
     // Check header

--- a/apis/core/lib/handlers/csv-source.ts
+++ b/apis/core/lib/handlers/csv-source.ts
@@ -91,8 +91,8 @@ export const replace = labyrinth.protectedResource(
   shaclValidate,
   asyncMiddleware(async (req, res) => {
     const csvSource = await replaceFile({
-      file: req,
-      resource: req.hydra.resource.term,
+      csvSourceId: req.hydra.resource.term,
+      resource: await req.resource(),
       store: req.resourceStore(),
     })
     await req.resourceStore().save()

--- a/apis/core/test/domain/csv-source/replace.test.ts
+++ b/apis/core/test/domain/csv-source/replace.test.ts
@@ -18,6 +18,11 @@ describe('domain/csv-sources/replace', () => {
   let fileStorage: FileStorage
   let csvSource: GraphPointer<NamedNode, DatasetExt>
   let csvMapping: GraphPointer<NamedNode, DatasetExt>
+  const data = clownface({ dataset: $rdf.dataset() })
+    .namedNode('')
+    .addOut(schema.name, $rdf.literal('source.csv'))
+    .addOut(schema.identifier, $rdf.literal('test/source.csv'))
+    .addOut(schema.contentUrl, $rdf.namedNode('http://s3/test/source.csv'))
 
   beforeEach(() => {
     const getfileStream = () => fs.createReadStream(path.resolve(__dirname, '../../fixtures/CH_yearly_air_immission_unit_id.csv'))
@@ -66,16 +71,15 @@ describe('domain/csv-sources/replace', () => {
             .addOut(dtype.order, 2)
         })
 
-      const file = Buffer.alloc(0)
       const store = new TestResourceStore([
         csvSource,
       ])
 
       // when
       csvSourceUpdate = await replaceFile({
-        resource: csvSource.term,
+        csvSourceId: csvSource.term,
+        resource: data,
         store,
-        file,
         fileStorage,
       })
     })
@@ -127,8 +131,8 @@ describe('domain/csv-sources/replace', () => {
     })
 
     it('File handler have been called', () => {
-      // save temp and save permanant
-      expect(fileStorage.saveFile).has.been.calledTwice
+      // copy temp to permanant
+      expect(fileStorage.saveFile).has.been.calledOnce
       // read temp, copy file, read columns and sample
       expect(fileStorage.loadFile).has.been.calledThrice
       // delete old file, delete temp
@@ -209,16 +213,15 @@ describe('domain/csv-sources/replace', () => {
             .addOut(dtype.order, 3)
         })
 
-      const file = Buffer.alloc(0)
       const store = new TestResourceStore([
         csvSource,
       ])
 
       // when
       csvSourceUpdate = await replaceFile({
-        resource: csvSource.term,
+        csvSourceId: csvSource.term,
+        resource: data,
         store,
-        file,
         fileStorage,
       })
     })
@@ -261,8 +264,8 @@ describe('domain/csv-sources/replace', () => {
     })
 
     it('File handler have been called', () => {
-      // save temp and save permanant
-      expect(fileStorage.saveFile).has.been.calledTwice
+      // copy temp to permanant
+      expect(fileStorage.saveFile).has.been.calledOnce
       // read temp, copy file, read columns and sample
       expect(fileStorage.loadFile).has.been.calledThrice
       // delete old file, delete temp
@@ -336,16 +339,15 @@ describe('domain/csv-sources/replace', () => {
             .addOut(dtype.order, 2)
         })
 
-      const file = Buffer.alloc(0)
       const store = new TestResourceStore([
         csvSource,
       ])
 
       // when
       const csvSourceUpdate = replaceFile({
-        resource: csvSource.term,
+        csvSourceId: csvSource.term,
+        resource: data,
         store,
-        file,
         fileStorage,
       })
 

--- a/e2e-tests/csv-source/replace.hydra
+++ b/e2e-tests/csv-source/replace.hydra
@@ -17,8 +17,8 @@ With Class cc:CSVSourceCollection {
             prefix schema: <http://schema.org/>
 
             <> schema:name "original.csv" ;
-                schema:contentUrl <http://s3.cube-creator.lndo.site/cube-creator/test-data/replace-test-cube/original.csv> ;
-                schema:identifier "test-data/replace-test-cube/original.csv" ;
+               schema:contentUrl <http://s3.cube-creator.lndo.site/cube-creator/test-data/replace-test-cube/original.csv> ;
+               schema:identifier "test-data/replace-test-cube/original.csv" ;
             ```
         } => {
             Expect Status 201
@@ -29,23 +29,28 @@ With Class cc:CSVSourceCollection {
 With Class cc:CSVSource {
     Expect Operation cc:ReplaceCSVAction {
         Invoke {
-            Content-Type "text/csv"
+            Content-Type "text/turtle"
+
             ```
-            column1,column4
-            2010,1
+            prefix schema: <http://schema.org/>
+
+            <> schema:name "replacement_invalid.csv" ;
+               schema:contentUrl <http://s3.cube-creator.lndo.site/cube-creator/test-data/replace-test-cube/replacement_invalid.csv> ;
+               schema:identifier "test-data/replace-test-cube/replacement_invalid.csv" ;
             ```
         } => {
             Expect Status 400
         }
 
         Invoke {
-            Content-Type "text/csv"
+            Content-Type "text/turtle"
+
             ```
-            column1,column2,column3,column4
-            1,2,test,a
-            1,2,test,b
-            1,2,test1,c
-            1,2,test2,a
+            prefix schema: <http://schema.org/>
+
+            <> schema:name "replacement_valid.csv" ;
+               schema:contentUrl <http://s3.cube-creator.lndo.site/cube-creator/test-data/replace-test-cube/replacement_valid.csv> ;
+               schema:identifier "test-data/replace-test-cube/replacement_valid.csv" ;
             ```
         } => {
             Expect Status 200

--- a/ui/src/store/modules/project.ts
+++ b/ui/src/store/modules/project.ts
@@ -219,14 +219,6 @@ const actions: ActionTree<ProjectState, RootState> = {
     return freshCollection
   },
 
-  async replaceCSV (context, { source, file }) {
-    const operation = source.actions.replace
-    const headers = {
-      'content-type': 'text/csv',
-    }
-    return api.invokeSaveOperation(operation, file, headers)
-  },
-
   async fetchCubeMetadata (context) {
     const project = context.state.project
 

--- a/ui/src/styles/utilities.scss
+++ b/ui/src/styles/utilities.scss
@@ -40,3 +40,11 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.list-disc {
+    list-style-type: disc;
+}
+
+.list-inside {
+    list-style-position: inside;
+}


### PR DESCRIPTION
Implements the same mechanism as #794 for the "replace CSV file" feature. I didn't add a changeset because the main feature hasn't been released yet.

I think it won't cause a memory issue, but we'll see when we deploy...