### PR TITLE
feat(publish): add link void dataset link to published cubes

### DIFF
--- a/.changeset/new-badgers-leave.md
+++ b/.changeset/new-badgers-leave.md
@@ -1,0 +1,7 @@
+---
+"@cube-creator/core-api": patch
+"@cube-creator/cli": minor
+"@cube-creator/model": patch
+---
+
+Add void dataset link to cubes published with "Published" status (re. #730)

--- a/apis/core/bootstrap/organizations.ts
+++ b/apis/core/bootstrap/organizations.ts
@@ -17,6 +17,7 @@ export const organizations = turtle`
     a ${schema.Organization} ;
     ${cc.publishGraph}  <https://lindas.admin.ch/foen/cube> ;
     ${cc.namespace} <https://environment.ld.admin.ch/foen/> ;
+    ${schema.dataset} <https://environment.ld.admin.ch/.well-known/void> ;
     ${rdfs.label} "Bundesamt für Umwelt BAFU"@de ;
     ${rdfs.label} "Office fédéral de l'environnement OFEV"@fr ;
     ${rdfs.label} "Ufficio federale dell'ambiente UFAM"@it ;

--- a/apis/core/bootstrap/shapes/dataset.ts
+++ b/apis/core/bootstrap/shapes/dataset.ts
@@ -4,6 +4,7 @@ import { hydra, rdfs, sh, dcat, dcterms, xsd, rdf, vcard, schema, _void, dash } 
 import { sparql, turtle } from '@tpluscode/rdf-string'
 import $rdf from 'rdf-ext'
 import { lindasQuery } from '../lib/query'
+import { Draft, Published } from '@cube-creator/model/Cube'
 
 const shapeId = shape('dataset/edit-metadata')
 const temporalFromTo = $rdf.namedNode(shapeId.value + '#temporalFromTo')
@@ -140,10 +141,10 @@ ${shapeId} {
       ${sh.nodeKind} ${sh.IRI} ;
       ${sh.in}
           (
-              <https://ld.admin.ch/definedTerm/CreativeWorkStatus/Draft>
-              <https://ld.admin.ch/definedTerm/CreativeWorkStatus/Published>
+              ${Draft}
+              ${Published}
           ) ;
-      ${sh.defaultValue} <https://ld.admin.ch/definedTerm/CreativeWorkStatus/Draft> ;
+      ${sh.defaultValue} ${Draft} ;
       ${sh.order} 30 ;
       ${sh.description} "Only published datasets will be listed in the external tools. A draft will be nevertheless be public." ;
     ] ;

--- a/apis/core/hydra/organization.ttl
+++ b/apis/core/hydra/organization.ttl
@@ -1,0 +1,29 @@
+BASE <urn:hydra-box:api>
+PREFIX cc:        <https://cube-creator.zazuko.com/vocab#>
+prefix hydra:     <http://www.w3.org/ns/hydra/core#>
+prefix hydra-box: <http://hydra-box.org/schema/>
+prefix code:      <https://code.described.at/>
+prefix query:     <http://hypermedia.app/query#>
+prefix sh:        <http://www.w3.org/ns/shacl#>
+PREFIX schema:    <http://schema.org/>
+PREFIX void:      <http://rdfs.org/ns/void#>
+prefix view:      <https://cube.link/view/>
+
+schema:Organization
+  a
+    hydra:Class ;
+  hydra:supportedOperation
+    [
+      a
+        hydra:Operation ;
+      hydra:method
+        "GET" ;
+      code:implementedBy
+        [
+          a
+            code:EcmaScript ;
+          code:link
+            <file:handlers/dataset#get> ;
+        ] ;
+    ]
+.

--- a/cli/lib/commands/publish.ts
+++ b/cli/lib/commands/publish.ts
@@ -24,6 +24,7 @@ export default runner.create<PublishRunOptions>({
 
     const { job, namespace, cubeIdentifier } = await getJob(jobUri, Hydra)
 
+    variable.set('publish-job', job)
     variable.set('publish-graph-store-endpoint', publishStore?.endpoint || process.env.PUBLISH_GRAPH_STORE_ENDPOINT)
     variable.set('publish-graph-query-endpoint', publishStore?.endpoint || process.env.PUBLISH_GRAPH_QUERY_ENDPOINT)
     variable.set('publish-graph-store-user', publishStore?.user || process.env.PUBLISH_GRAPH_STORE_USER)

--- a/cli/lib/variables.ts
+++ b/cli/lib/variables.ts
@@ -1,5 +1,6 @@
 import { Literal, NamedNode, Term } from 'rdf-js'
 import { HydraClient } from 'alcaeus/alcaeus'
+import { PublishJob } from '../../packages/model/Job'
 
 declare module 'barnard59-core/lib/Pipeline' {
   interface VariableNames {
@@ -13,6 +14,7 @@ declare module 'barnard59-core/lib/Pipeline' {
     'publish-graph-store-endpoint': string
     'publish-graph-store-user': string
     'publish-graph-store-password': string
+    'publish-job': PublishJob
     'target-graph': string
     revision: number
     namespace: string

--- a/packages/model/Cube.ts
+++ b/packages/model/Cube.ts
@@ -6,6 +6,10 @@ import { dcterms, schema, xsd } from '@tpluscode/rdf-ns-builders'
 import { cc, cube } from '@cube-creator/core/namespace'
 import { initializer } from './lib/initializer'
 import { NamedNode } from 'rdf-js'
+import { namedNode } from '@rdf-esm/data-model'
+
+export const Draft = namedNode('https://ld.admin.ch/definedTerm/CreativeWorkStatus/Draft')
+export const Published = namedNode('https://ld.admin.ch/definedTerm/CreativeWorkStatus/Published')
 
 export interface Cube extends RdfResourceCore {
   dateCreated: Date

--- a/packages/model/Organization.ts
+++ b/packages/model/Organization.ts
@@ -14,6 +14,7 @@ interface CreateIdentifier {
 interface OrganizationEx {
   publishGraph: NamedNode
   namespace: NamedNode
+  dataset?: NamedNode
   createIdentifier(params: CreateIdentifier): NamedNode
 }
 
@@ -30,6 +31,9 @@ export function OrganizationMixin<Base extends Constructor<Omit<Organization, ke
 
     @property()
     namespace!: NamedNode
+
+    @property({ path: schema.dataset })
+    dataset?: NamedNode
 
     createIdentifier({ cubeIdentifier, termName }: CreateIdentifier): NamedNode {
       const namespace = this.namespace.value.match(/[/#]$/) ? this.namespace.value : `${this.namespace.value}/`


### PR DESCRIPTION
Adds `schema:dataset` to organisation profile

When present, its value will be published to link the void resource to cube with "Published" status