### PR TITLE
fix: `md:terms` property should not have been saved

### DIFF
--- a/.changeset/silent-trainers-teach.md
+++ b/.changeset/silent-trainers-teach.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Remove ignored properties when saving shared dimension

--- a/apis/shared-dimensions/lib/domain/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension.ts
@@ -83,7 +83,7 @@ export async function createTerm({ termSet, resource, store }: CreateTerm): Prom
 interface UpdateSharedDimension {
   resource: GraphPointer<NamedNode>
   store: SharedDimensionsStore
-  shape: MultiPointer
+  shape: MultiPointer | undefined
 }
 
 function removeSubgraph(pointer: GraphPointer, predicate?: Term) {
@@ -97,7 +97,7 @@ function removeSubgraph(pointer: GraphPointer, predicate?: Term) {
 
 export async function update({ resource, store, shape }: UpdateSharedDimension): Promise<GraphPointer> {
   const ignoredProperties = shape
-    .out(sh.ignoredProperties)
+    ?.out(sh.ignoredProperties)
     .list() || []
 
   for (const ignoredProperty of ignoredProperties) {

--- a/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
@@ -47,7 +47,7 @@ export const get = asyncMiddleware(async (req, res) => {
 
 function termsCollectionId(dimension: Term, search?: string) {
   const uri = new URL(`${env.MANAGED_DIMENSIONS_BASE}dimension/_terms`)
-  uri.searchParams.set('dimensions', dimension.value)
+  uri.searchParams.set('dimension', dimension.value)
 
   if (search) {
     uri.searchParams.set('q', search)


### PR DESCRIPTION
While working on #814 I noticed that `md:terms` was getting persisted with the data which should not have been the case (was meant to be removed, being listed in `sh:ignoredProperties`)

The reason was that the actual shape would not have been loaded (`hydra:expect` Is obviously just the identifier 🤦)

And there was also a type, which is how I noticed...