### PR TITLE
Add endpoint to retrieve organization datasets

### DIFF
--- a/.changeset/old-ducks-act.md
+++ b/.changeset/old-ducks-act.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Add endpoint for CKAN harvester

--- a/apis/core/bootstrap/organizations.ts
+++ b/apis/core/bootstrap/organizations.ts
@@ -24,6 +24,7 @@ export const organizations = turtle`
     ${rdfs.label} "Federal Office for the Environment FOEN"@en ;
     ${dcat.accessURL} <https://environment.ld.admin.ch/query> ;
     ${_void.sparqlEndpoint} <https://environment.ld.admin.ch/sparql> ;
+    ${cc.datasets} <organization/bafu/datasets> ;
   .
 }
 `

--- a/apis/core/hydra/organization.ttl
+++ b/apis/core/hydra/organization.ttl
@@ -4,6 +4,7 @@ prefix hydra:     <http://www.w3.org/ns/hydra/core#>
 prefix hydra-box: <http://hydra-box.org/schema/>
 prefix code:      <https://code.described.at/>
 prefix query:     <http://hypermedia.app/query#>
+prefix rdf:       <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix sh:        <http://www.w3.org/ns/shacl#>
 PREFIX schema:    <http://schema.org/>
 PREFIX void:      <http://rdfs.org/ns/void#>
@@ -25,5 +26,22 @@ schema:Organization
           code:link
             <file:handlers/dataset#get> ;
         ] ;
-    ]
+    ] ;
+  hydra:supportedProperty
+    [ hydra:property cc:datasets ] ;
+.
+
+cc:datasets
+  a rdf:Property, hydra:Link ;
+  hydra:supportedOperation
+    [
+      a hydra:Operation ;
+      hydra:title "List organization datasets" ;
+      hydra:method "GET" ;
+      code:implementedBy
+        [
+          a code:EcmaScript ;
+          code:link <file:handlers/organization#getDatasets> ;
+        ] ;
+    ] ;
 .

--- a/apis/core/lib/domain/organization/datasets.ts
+++ b/apis/core/lib/domain/organization/datasets.ts
@@ -1,0 +1,129 @@
+import { dcat, dcterms, rdf } from '@tpluscode/rdf-ns-builders'
+import clownface, { GraphPointer, MultiPointer } from 'clownface'
+import { BlankNode, Literal, NamedNode } from 'rdf-js'
+import $rdf from 'rdf-ext'
+import { create as createXml } from 'xmlbuilder2'
+import { fetchOrganizationDatasets } from './query'
+import { shrink } from '@zazuko/rdf-vocabularies'
+import TermSet from '@rdfjs/term-set'
+
+export async function getOrganizationDatasets(organization: NamedNode): Promise<string> {
+  const quads = await fetchOrganizationDatasets(organization)
+  const pointer = clownface({ dataset: $rdf.dataset(quads) })
+
+  const datasetsPointer = pointer.node(dcat.Dataset).in(rdf.type)
+
+  const rdfns = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+  const dcatns = 'http://www.w3.org/ns/dcat#'
+  const dctermsns = 'http://purl.org/dc/terms/'
+
+  const xml = createXml({
+    version: '1.0',
+    encoding: 'utf-8',
+    namespaceAlias: {
+      rdf: rdfns,
+      dcat: dcatns,
+      dcterms: dctermsns,
+    },
+  }, {
+    'rdf:RDF': {
+      '@': {
+        'xmlns:rdf': rdfns,
+        'xmlns:dcat': dcatns,
+      },
+      'dcat:Catalog': {
+        'dcat:dataset': datasetsPointer.map((dataset) => ({
+          'dcat:Dataset': {
+            'dcterms:identifier': serializeTerm(dataset.out(dcterms.identifier)),
+            'dcterms:title': serializeTerm(dataset.out(dcterms.title)),
+            'dcterms:description': serializeTerm(dataset.out(dcterms.description)),
+            'dcterms:license': serializeTerm(dataset.out(dcterms.license)),
+            'dcterms:issued': serializeTerm(dataset.out(dcterms.issued)),
+            'dcterms:modified': serializeTerm(dataset.out(dcterms.modified)),
+            'dcterms:publisher': serializeTerm(dataset.out(dcterms.publisher)),
+            'dcterms:creator': serializeTerm(dataset.out(dcterms.creator)),
+            'dcat:contactPoint': serializeTerm(dataset.out(dcat.contactPoint)),
+            'dcat:theme': serializeTerm(dataset.out(dcat.theme)),
+            'dcterms:language': serializeTerm(dataset.out(dcterms.language)),
+            'dcterms:relation': serializeTerm(dataset.out(dcterms.relation)),
+            'dcat:keyword': serializeTerm(dataset.out(dcat.keyword)),
+            'dcat:landingPage': serializeTerm(dataset.out(dcat.landingPage)),
+            'dcterms:spacial': serializeTerm(dataset.out(dcterms.spacial)),
+            'dcterms:coverage': serializeTerm(dataset.out(dcterms.coverage)),
+            'dcterms:temporal': serializeTerm(dataset.out(dcterms.temporal)),
+            'dcat:distribution': serializeTerm(dataset.out(dcterms.distribution)),
+            'dcterms:accrualPeriodicity': serializeTerm(dataset.out(dcterms.accrualPeriodicity)),
+          },
+        })),
+      },
+    },
+  }).doc()
+
+  return xml.end({ prettyPrint: true })
+}
+
+function serializeTerm(pointer: MultiPointer): Record<string, any> {
+  return pointer.map((value) => {
+    if (isLiteral(value)) {
+      return serializeLiteral(value)
+    } else if (isNamedNode(value)) {
+      return serializeNamedNode(value)
+    } else if (isBlankNode(value)) {
+      return serializeBlankNode(value)
+    } else {
+      return {}
+    }
+  })
+}
+
+function isLiteral(pointer: GraphPointer): pointer is GraphPointer<Literal> {
+  return pointer.term.termType === 'Literal'
+}
+
+function isNamedNode(pointer: GraphPointer): pointer is GraphPointer<NamedNode> {
+  return pointer.term.termType === 'NamedNode'
+}
+
+function isBlankNode(pointer: GraphPointer): pointer is GraphPointer<BlankNode> {
+  return pointer.term.termType === 'BlankNode'
+}
+
+function serializeLiteral({ term }: GraphPointer<Literal>) {
+  const attrs: Record<string, string> = {}
+
+  if (term.language) {
+    attrs['xml:lang'] = term.language
+  }
+
+  if (term.datatype) {
+    attrs['xml:datatype'] = term.datatype.value
+  }
+
+  return {
+    '@': attrs,
+    '#': term.value,
+  }
+}
+
+function serializeNamedNode({ value }: GraphPointer<NamedNode>) {
+  return {
+    '@': { 'rdf:resource': value },
+  }
+}
+
+function serializeBlankNode(pointer: GraphPointer<BlankNode>) {
+  const type = pointer.out(rdf.type).value
+
+  if (!type) return {}
+
+  const properties = new TermSet([...pointer.dataset.match(pointer.term)]
+    .map(({ predicate }) => predicate)
+    .filter((term) => !term.equals(rdf.type)))
+
+  const resource = [...properties].reduce((acc, property) =>
+    ({ ...acc, [shrink(property.value)]: serializeTerm(pointer.out(property)) }), {})
+
+  return {
+    [shrink(type)]: resource,
+  }
+}

--- a/apis/core/lib/domain/organization/query.ts
+++ b/apis/core/lib/domain/organization/query.ts
@@ -5,6 +5,7 @@ import { cc } from '@cube-creator/core/namespace'
 import { schema } from '@tpluscode/rdf-ns-builders'
 import { parsingClient } from '../../query-client'
 import $rdf from 'rdf-ext'
+import { Published } from '@cube-creator/model/Cube'
 
 type FindOrganization = {
   table: Table
@@ -68,6 +69,8 @@ export function fetchOrganizationDatasets(organization: NamedNode, client = pars
       }
       GRAPH ?dataset {
         ?s ?p ?o .
+        ?s ${schema.workExample} <https://ld.admin.ch/application/opendataswiss> .
+        ?s ${schema.creativeWorkStatus} ${Published} .
       }
     `.execute(client.query)
 }

--- a/apis/core/lib/domain/organization/query.ts
+++ b/apis/core/lib/domain/organization/query.ts
@@ -1,6 +1,6 @@
 import { CsvMapping, Table } from '@cube-creator/model'
-import { ASK, SELECT } from '@tpluscode/sparql-builder'
-import { NamedNode, Term } from 'rdf-js'
+import { ASK, CONSTRUCT, SELECT } from '@tpluscode/sparql-builder'
+import { NamedNode, Quad, Term } from 'rdf-js'
 import { cc } from '@cube-creator/core/namespace'
 import { schema } from '@tpluscode/rdf-ns-builders'
 import { parsingClient } from '../../query-client'
@@ -57,4 +57,17 @@ export function cubeNamespaceAllowed(cube: NamedNode, organization: Term, client
       STRSTARTS( str(${cube}), str(?ns) )
     )
   }`.execute(client.query)
+}
+
+export function fetchOrganizationDatasets(organization: NamedNode, client = parsingClient): Promise<Quad[]> {
+  return CONSTRUCT`?s ?p ?o`
+    .WHERE`
+      GRAPH ?project {
+        ?project ${schema.maintainer} ${organization} .
+        ?project ${cc.dataset} ?dataset .
+      }
+      GRAPH ?dataset {
+        ?s ?p ?o .
+      }
+    `.execute(client.query)
 }

--- a/apis/core/lib/handlers/organization.ts
+++ b/apis/core/lib/handlers/organization.ts
@@ -1,0 +1,12 @@
+import { protectedResource } from '@hydrofoil/labyrinth/resource'
+import asyncMiddleware from 'middleware-async'
+import { getOrganizationDatasets } from '../domain/organization/datasets'
+
+export const getDatasets = protectedResource(asyncMiddleware(async (req, res) => {
+  const organization = req.hydra.resource.term
+  const content = await getOrganizationDatasets(organization)
+
+  const format = 'application/rdf+xml'
+  res.setHeader('Content-Type', format)
+  return res.send(content)
+}))

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -15,13 +15,13 @@
     "@rdfine/hydra": "^0.7.0",
     "@rdfine/prov": "^0.1.1",
     "@rdfine/schema": "^0.6.3",
+    "@rdfjs-elements/formats-pretty": "^0.3.2",
     "@rdfjs/express-handler": "^1.2.1",
     "@rdfjs/fetch": "^2.1.0",
     "@rdfjs/namespace": "^1.1.0",
     "@rdfjs/parser-n3": "^1.1.4",
     "@rdfjs/term-map": "^1.0.0",
     "@rdfjs/term-set": "^1.0.1",
-    "@rdfjs-elements/formats-pretty": "^0.3.2",
     "@sentry/node": "^6.2.0",
     "@sentry/tracing": "^6.2.0",
     "@tpluscode/rdf-ns-builders": "^1.0.0",
@@ -65,7 +65,8 @@
     "string-to-stream": "^3.0.1",
     "through2": "^4.0.2",
     "uri-template": "^1.0.1",
-    "url-slugify": "^1.0.6"
+    "url-slugify": "^1.0.6",
+    "xmlbuilder2": "^3.0.2"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.11.5",

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -46,6 +46,7 @@ type CubeCreatorProperty =
   'identifierTemplate' |
   'project' |
   'dataset' |
+  'datasets' |
   'namespace' |
   'cubeGraph' |
   'columnMapping' |

--- a/yarn.lock
+++ b/yarn.lock
@@ -1530,6 +1530,35 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@oozcitak/dom@1.15.10":
+  version "1.15.10"
+  resolved "https://registry.yarnpkg.com/@oozcitak/dom/-/dom-1.15.10.tgz#dca7289f2b292cff2a901ea4fbbcc0a1ab0b05c2"
+  integrity sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==
+  dependencies:
+    "@oozcitak/infra" "1.0.8"
+    "@oozcitak/url" "1.0.4"
+    "@oozcitak/util" "8.3.8"
+
+"@oozcitak/infra@1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@oozcitak/infra/-/infra-1.0.8.tgz#b0b089421f7d0f6878687608301fbaba837a7d17"
+  integrity sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==
+  dependencies:
+    "@oozcitak/util" "8.3.8"
+
+"@oozcitak/url@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@oozcitak/url/-/url-1.0.4.tgz#ca8b1c876319cf5a648dfa1123600a6aa5cda6ba"
+  integrity sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==
+  dependencies:
+    "@oozcitak/infra" "1.0.8"
+    "@oozcitak/util" "8.3.8"
+
+"@oozcitak/util@8.3.8":
+  version "8.3.8"
+  resolved "https://registry.yarnpkg.com/@oozcitak/util/-/util-8.3.8.tgz#10f65fe1891fd8cde4957360835e78fd1936bfdd"
+  integrity sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==
+
 "@purest/config@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@purest/config/-/config-1.0.1.tgz#d7dc6a0629032fd98d4ae5f59bec26ba1465c8e0"
@@ -8885,6 +8914,14 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
+js-yaml@3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
@@ -14687,6 +14724,17 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xmlbuilder2@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder2/-/xmlbuilder2-3.0.2.tgz#fc499688b35a916f269e7b459c2fa02bb5c0822a"
+  integrity sha512-h4MUawGY21CTdhV4xm3DG9dgsqyhDkZvVJBx88beqX8wJs3VgyGQgAn5VreHuae6unTQxh115aMK5InCVmOIKw==
+  dependencies:
+    "@oozcitak/dom" "1.15.10"
+    "@oozcitak/infra" "1.0.8"
+    "@oozcitak/util" "8.3.8"
+    "@types/node" "*"
+    js-yaml "3.14.0"
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
Closes #823 

TODO:
- [ ] Query the org's `sparqlEndpoint` instead of cube-creator DB
        Or maybe Lindas directly so that we can query the relevant endpoint.
- [ ] Remove authentication for endpoint?
- [ ] Only provide "published" datasets