### PR TITLE
Switch schema:validThrough -> schema:expires for cubes

### DIFF
--- a/.changeset/thin-walls-shake.md
+++ b/.changeset/thin-walls-shake.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Use schema:expires instead of schema:validThrough to expire cubes

--- a/cli/lib/cube.ts
+++ b/cli/lib/cube.ts
@@ -34,14 +34,14 @@ export function expirePreviousVersions(this: Pick<Context, 'variables' | 'log'>)
   })
 
   return CONSTRUCT`
-    ?cube ${schema.validThrough} ${timestamp}
+    ?cube ${schema.expires} ${timestamp} .
   `.WHERE`
     ${baseCube} ${schema.hasPart} ?cube .
 
-    OPTIONAL { ?cube ${schema.validThrough} ?validThrough }
+    OPTIONAL { ?cube ${schema.expires} ?expires }
 
     filter (
-      !bound(?validThrough)
+      !bound(?expires)
     )
   `.FROM($rdf.namedNode(this.variables.get('target-graph')))
     .execute(client.query)

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -191,7 +191,7 @@ describe('@cube-creator/cli/lib/commands/publish', function () {
     it('"deprecates" previous cubes', async function () {
       expect(cubePointer.namedNode(ns.baseCube('1'))).to.matchShape({
         property: [{
-          path: schema.validThrough,
+          path: schema.expires,
           datatype: xsd.dateTime,
           minCount: 1,
           maxCount: 1,


### PR DESCRIPTION
`schema:expires` is semantically more correct.

Part of #821 