### PR TITLE
fix: validation shared dimension requests

### DIFF
--- a/.changeset/silver-olives-hug.md
+++ b/.changeset/silver-olives-hug.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Validation would not fire when creating shared dimension

--- a/apis/shared-dimensions/lib/middleware/shacl.ts
+++ b/apis/shared-dimensions/lib/middleware/shacl.ts
@@ -5,7 +5,9 @@ import env from '../env'
 
 export const shaclValidate = shaclMiddleware({
   async loadResource(id) {
-    return shapes.get(id)?.() || null
+    const mappedId = $rdf.namedNode(id.value.replace(env.MANAGED_DIMENSIONS_API_BASE, env.MANAGED_DIMENSIONS_BASE))
+
+    return shapes.get(mappedId)?.() || null
   },
   async loadResourcesTypes() {
     return []

--- a/e2e-tests/shared-dimensions/term-set.hydra
+++ b/e2e-tests/shared-dimensions/term-set.hydra
@@ -39,6 +39,25 @@ With Class meta:SharedDimension {
             Expect Property schema:validFrom
             Expect Property schema:validThrough
         }
+
+        Invoke {
+            Content-Type "text/turtle"
+
+            ```
+            prefix schema: <http://schema.org/>
+            prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+            prefix qudt: <http://qudt.org/schema/qudt/>
+            prefix meta: <https://cube.link/meta/>
+            prefix sh: <http://www.w3.org/ns/shacl#>
+            prefix dcterms: <http://purl.org/dc/terms/>
+
+            <> schema:name "node.js"@en ;
+               dcterms:identifier "NodeJs" ;
+               schema:validThrough "2022-01-01T00:00:00Z"^^xsd:dateTime .
+            ```
+        } => {
+            Expect Status 400
+        }
     }
 
     Expect Operation schema:ReplaceAction {


### PR DESCRIPTION
Validation would not happen because the SHACL middleware looked for the shapes using wrong identifiers

The y need to be mapped from the canonical namespace (ld.admin.ch) to API namespace, similarly to he reverse done in `getTargetNode`