### PR TITLE
fix: display all csv errors

### DIFF
--- a/.changeset/silent-oranges-worry.md
+++ b/.changeset/silent-oranges-worry.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Project with error messages on its CSV sources would fail to load after import

--- a/apis/core/lib/domain/csv-source/CsvSource.ts
+++ b/apis/core/lib/domain/csv-source/CsvSource.ts
@@ -15,7 +15,7 @@ interface CreateOrUpdateColumn {
 }
 
 interface ApiCsvSource {
-  error?: string
+  errors: string[]
 
   setUploadedFile(kind: NamedNode, key: string, contentUrl: NamedNode): void
   /**
@@ -33,8 +33,8 @@ declare module '@cube-creator/model' {
 
 export default function Mixin<Base extends Constructor<Omit<CsvSource, keyof ApiCsvSource>>>(Resource: Base) {
   class Impl extends Resource implements ApiCsvSource {
-    @property.literal({ path: schema.error })
-    error?: string
+    @property.literal({ path: schema.error, values: 'array' })
+    errors!: string[]
 
     setUploadedFile(sourceKind: NamedNode, key: string, contentUrl: NamedNode): void {
       if (this.associatedMedia) {

--- a/apis/core/lib/domain/csv-source/replace.ts
+++ b/apis/core/lib/domain/csv-source/replace.ts
@@ -28,7 +28,7 @@ export async function replaceFile({
   const csvSource = await store.getResource<CsvSource>(csvSourceId)
 
   // Remove any previous error
-  csvSource.error = undefined
+  csvSource.errors = []
 
   const newMedia = mediaObjectFromPointer(resource)
   const newStorage = getStorage(newMedia)

--- a/packages/model/CsvSource.ts
+++ b/packages/model/CsvSource.ts
@@ -18,7 +18,7 @@ import { MediaObjectMixin } from './MediaObject'
 export interface CsvSource extends RdfResource {
   associatedMedia: Schema.MediaObject
   name: string
-  error?: string
+  errors: string[]
   dialect: Csvw.Dialect
   csvMapping: Link<CsvMapping>
   columns: CsvColumn[]
@@ -37,8 +37,8 @@ export function CsvSourceMixin<Base extends Constructor>(base: Base): Mixin {
     @property.literal({ path: schema.name })
     name!: string
 
-    @property.literal({ path: schema.error })
-    error?: string
+    @property.literal({ path: schema.error, values: 'array' })
+    errors!: string[]
 
     @property.resource({ path: csvw.dialect, as: [DialectMixin], initial: () => blankNode() })
     dialect!: Csvw.Dialect

--- a/ui/src/components/CsvSourceMapping.vue
+++ b/ui/src/components/CsvSourceMapping.vue
@@ -44,9 +44,9 @@
             </b-dropdown>
           </div>
         </div>
-        <b-message v-if="source.error" type="is-danger" class="content">
+        <b-message v-if="source.errors.length" type="is-danger" class="content">
           <p>An error occurred while parsing the CSV file:</p>
-          <pre>{{ source.error }}</pre>
+          <pre v-for="error in source.errors" :key="error">{{ error }}</pre>
           <div class="content" v-if="source.actions.delete || source.actions.edit">
             <p>To fix the issue, you can:</p>
             <ul>

--- a/ui/src/store/serializers.ts
+++ b/ui/src/store/serializers.ts
@@ -46,7 +46,7 @@ export function serializeSource (source: CsvSource): CsvSource {
       download: source.actions.download,
     },
     name: source.name,
-    error: source.error,
+    errors: source.errors,
     columns: source.columns.map(serializeColumn),
     dialect: source.dialect,
     csvMapping: source.csvMapping,


### PR DESCRIPTION
When we import, we add an error message to the CSV Sources.

If an error was already set the mapping screen would fail to load (the property wanted only one error)