### PR TITLE
Provide dataset workExamples

### DIFF
--- a/.changeset/good-spoons-sneeze.md
+++ b/.changeset/good-spoons-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Show link to visualize on publish jobs

--- a/.changeset/silent-rats-shake.md
+++ b/.changeset/silent-rats-shake.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Provide links to visualize.admin.ch and lindas query UI on the published dataset (as work examples)

--- a/.local.env
+++ b/.local.env
@@ -10,6 +10,7 @@ STORE_UPDATE_ENDPOINT=http://db.cube-creator.lndo.site/cube-creator/update
 STORE_GRAPH_ENDPOINT=http://db.cube-creator.lndo.site/cube-creator/data
 PUBLIC_QUERY_ENDPOINT=https://test.lindas.admin.ch/query
 TRIFID_UI=https://lindas.admin.ch/sparql
+VISUALIZE_UI=https://visualize.admin.ch
 
 # AuthN config
 AUTH_AUDIENCE=cube-creator

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -97,7 +97,7 @@ export function prepareWorkExamples(cubeId: NamedNode, job: Job.PublishJob, data
   if (env.has('TRIFID_UI')) {
     workExamples.push({
       url: $rdf.namedNode(lindasWebQueryLink(cubeId, job.revision, job.publishGraph)),
-      encodingFormat: $rdf.literal('Application/Sparql-query'),
+      encodingFormat: $rdf.literal('application/sparql-query'),
       name: [
         $rdf.literal('SPARQL Endpoint mit Vorauswahl des Graph', 'de'),
         $rdf.literal('SPARQL Endpoint with graph preselection', 'en'),

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -1,13 +1,17 @@
+import $rdf from 'rdf-ext'
 import { cc } from '@cube-creator/core/namespace'
 import { GraphPointer } from 'clownface'
 import { NamedNode, Term } from 'rdf-js'
+import { DESCRIBE } from '@tpluscode/sparql-builder'
 import * as Job from '@cube-creator/model/Job'
 import * as ImportJob from '@cube-creator/model/ImportJob'
-import { CsvMapping, Project, Dataset, ImportProject } from '@cube-creator/model'
+import { CsvMapping, Project, Dataset, ImportProject, CsvProject } from '@cube-creator/model'
 import { ResourceStore } from '../../ResourceStore'
 import * as id from '../identifiers'
 import { DomainError } from '@cube-creator/api-errors'
+import env from '@cube-creator/core/env'
 import { schema } from '@tpluscode/rdf-ns-builders'
+import { isCsvProject } from '@cube-creator/model/Project'
 
 interface StartTransformationCommand {
   resource: NamedNode
@@ -55,7 +59,7 @@ export async function createPublishJob({
     throw new Error('Project not found from jobs collection')
   }
 
-  const project = await store.getResource<Project>(projectPointer)
+  const project = await store.getResource<CsvProject | ImportProject>(projectPointer)
   const organization = await store.getResource(project.maintainer)
 
   if (!organization.publishGraph) {
@@ -65,7 +69,7 @@ export async function createPublishJob({
   const metadata = await store.getResource(project.dataset)
 
   const jobPointer = await store.createMember(jobCollection.term, id.job(jobCollection))
-  Job.createPublish(jobPointer, {
+  const job = Job.createPublish(jobPointer, {
     project: projectPointer,
     name: 'Publish job',
     revision: project.nextRevision,
@@ -74,7 +78,73 @@ export async function createPublishJob({
     publishedTo: metadata?.pointer.out(schema.workExample).term,
   })
 
+  const cubeId = isCsvProject(project)
+    ? organization.createIdentifier({
+      cubeIdentifier: project.cubeIdentifier,
+    })
+    : project.sourceCube
+
+  const dataset = await store.getResource<Dataset>(project.dataset.id)
+  const workExamples = prepareWorkExamples(cubeId, job, dataset)
+  workExamples.forEach(workExample => job.addWorkExample(workExample))
+
   return jobPointer
+}
+
+export function prepareWorkExamples(cubeId: NamedNode, job: Job.PublishJob, dataset: Dataset): Job.WorkExampleInput[] {
+  const workExamples = []
+
+  if (env.has('TRIFID_UI')) {
+    workExamples.push({
+      url: $rdf.namedNode(lindasWebQueryLink(cubeId, job.revision, job.publishGraph)),
+      encodingFormat: $rdf.literal('Application/Sparql-query'),
+      name: [
+        $rdf.literal('SPARQL Endpoint mit Vorauswahl des Graph', 'de'),
+        $rdf.literal('SPARQL Endpoint with graph preselection', 'en'),
+        $rdf.literal('SPARQL Endpoint avec présélection du graphe', 'fr'),
+      ],
+    })
+  }
+
+  const visualize = $rdf.namedNode('https://ld.admin.ch/application/visualize')
+  const isPublishedToVisualize = dataset.pointer.has(schema.workExample, visualize).terms.length > 0
+  if (env.has('VISUALIZE_UI') && isPublishedToVisualize) {
+    workExamples.push({
+      url: $rdf.namedNode(visualizeLink(cubeId)),
+      encodingFormat: $rdf.literal('text/html'),
+      name: [
+        $rdf.literal('visualize.admin.ch'),
+      ],
+    })
+  }
+
+  return workExamples
+}
+
+function lindasWebQueryLink(cube: NamedNode, version: number, cubeGraph: NamedNode) {
+  const describe = DESCRIBE`?cube`
+    .FROM(cubeGraph)
+    .WHERE`
+      ${cube} ${schema.hasPart} ?cube .
+      ?cube ${schema.version} ${version} .
+    `.build()
+
+  const queryLink = new URL(env.TRIFID_UI)
+  queryLink.hash = new URLSearchParams([
+    ['query', describe],
+    ['endpoint', env.PUBLIC_QUERY_ENDPOINT],
+  ]).toString()
+
+  return queryLink.toString()
+}
+
+function visualizeLink(cube: NamedNode) {
+  const language = 'en'
+  const visualizeLink = new URL(`/${language}/create/new`, env.VISUALIZE_UI)
+
+  visualizeLink.searchParams.set('cube', cube.value)
+
+  return visualizeLink.toString()
 }
 
 export async function createImportJob({ store, resource }: StartImportCommand): Promise<GraphPointer<NamedNode>> {

--- a/apis/core/lib/domain/job/update.ts
+++ b/apis/core/lib/domain/job/update.ts
@@ -1,45 +1,14 @@
-import $rdf from 'rdf-ext'
 import { NamedNode } from 'rdf-js'
 import { GraphPointer } from 'clownface'
 import { Job, JobMixin, ImportProject, Dataset, CsvProject } from '@cube-creator/model'
-import { isPublishJob, PublishJob, WorkExampleInput } from '@cube-creator/model/Job'
+import { isPublishJob } from '@cube-creator/model/Job'
 import RdfResource from '@tpluscode/rdfine'
-import env from '@cube-creator/core/env'
-import { DESCRIBE } from '@tpluscode/sparql-builder'
-import type { Organization } from '@rdfine/schema'
 import { ResourceStore } from '../../ResourceStore'
 import { schema } from '@tpluscode/rdf-ns-builders'
-import { isCsvProject } from '@cube-creator/model/Project'
 
 interface JobUpdateParams {
   resource: GraphPointer<NamedNode>
   store: ResourceStore
-}
-
-function lindasWebQueryLink(cube: NamedNode, version: number, cubeGraph: NamedNode) {
-  const describe = DESCRIBE`?cube`
-    .FROM(cubeGraph)
-    .WHERE`
-      ${cube} ${schema.hasPart} ?cube .
-      ?cube ${schema.version} ${version} .
-    `.build()
-
-  const queryLink = new URL(env.TRIFID_UI)
-  queryLink.hash = new URLSearchParams([
-    ['query', describe],
-    ['endpoint', env.PUBLIC_QUERY_ENDPOINT],
-  ]).toString()
-
-  return queryLink.toString()
-}
-
-function visualizeLink(cube: NamedNode) {
-  const language = 'en'
-  const visualizeLink = new URL(`/${language}/create/new`, env.VISUALIZE_UI)
-
-  visualizeLink.searchParams.set('cube', cube.value)
-
-  return visualizeLink.toString()
 }
 
 export async function update({ resource, store }: JobUpdateParams): Promise<GraphPointer> {
@@ -59,16 +28,6 @@ export async function update({ resource, store }: JobUpdateParams): Promise<Grap
       if (job.revision === 1) {
         dataset.setPublishedDate(job.modified)
       }
-
-      const organization = await store.getResource<Organization>(project.maintainer)
-      const cubeId = isCsvProject(project)
-        ? organization.createIdentifier({
-          cubeIdentifier: project.cubeIdentifier,
-        })
-        : project.sourceCube
-
-      const workExamples = prepareWorkExamples(cubeId, job, dataset)
-      workExamples.forEach(workExample => job.addWorkExample(workExample))
     }
   }
 
@@ -87,34 +46,4 @@ export async function update({ resource, store }: JobUpdateParams): Promise<Grap
   }
 
   return job.pointer
-}
-
-export function prepareWorkExamples(cubeId: NamedNode, job: PublishJob, dataset: Dataset): WorkExampleInput[] {
-  const workExamples = []
-
-  if (env.has('TRIFID_UI')) {
-    workExamples.push({
-      url: $rdf.namedNode(lindasWebQueryLink(cubeId, job.revision, job.publishGraph)),
-      encodingFormat: $rdf.literal('Application/Sparql-query'),
-      name: [
-        $rdf.literal('SPARQL Endpoint mit Vorauswahl des Graph', 'de'),
-        $rdf.literal('SPARQL Endpoint with graph preselection', 'en'),
-        $rdf.literal('SPARQL Endpoint avec présélection du graphe', 'fr'),
-      ],
-    })
-  }
-
-  const visualize = $rdf.namedNode('https://ld.admin.ch/application/visualize')
-  const isPublishedToVisualize = dataset.pointer.has(schema.workExample, visualize).terms.length > 0
-  if (env.has('VISUALIZE_UI') && isPublishedToVisualize) {
-    workExamples.push({
-      url: $rdf.namedNode(visualizeLink(cubeId)),
-      encodingFormat: $rdf.literal('text/html'),
-      name: [
-        $rdf.literal('visualize.admin.ch'),
-      ],
-    })
-  }
-
-  return workExamples
 }

--- a/apis/core/lib/domain/job/update.ts
+++ b/apis/core/lib/domain/job/update.ts
@@ -61,7 +61,6 @@ export async function update({ resource, store }: JobUpdateParams): Promise<Grap
       }
 
       const organization = await store.getResource<Organization>(project.maintainer)
-
       const cubeId = isCsvProject(project)
         ? organization.createIdentifier({
           cubeIdentifier: project.cubeIdentifier,
@@ -69,13 +68,27 @@ export async function update({ resource, store }: JobUpdateParams): Promise<Grap
         : project.sourceCube
 
       if (env.has('TRIFID_UI')) {
-        job.query = lindasWebQueryLink(cubeId, job.revision, job.publishGraph)
+        job.addWorkExample({
+          url: $rdf.namedNode(lindasWebQueryLink(cubeId, job.revision, job.publishGraph)),
+          encodingFormat: 'Application/Sparql-query',
+          name: [
+            $rdf.literal('SPARQL Endpoint mit Vorauswahl des Graph', 'de'),
+            $rdf.literal('SPARQL Endpoint with graph preselection', 'en'),
+            $rdf.literal('SPARQL Endpoint avec présélection du graphe', 'fr'),
+          ],
+        })
       }
 
       const visualize = $rdf.namedNode('https://ld.admin.ch/application/visualize')
       const isPublishedToVisualize = dataset.pointer.has(schema.workExample, visualize).terms.length > 0
       if (env.has('VISUALIZE_UI') && isPublishedToVisualize) {
-        job.visualize = visualizeLink(cubeId)
+        job.addWorkExample({
+          url: $rdf.namedNode(visualizeLink(cubeId)),
+          encodingFormat: 'text/html',
+          name: [
+            $rdf.literal('visualize.admin.ch'),
+          ],
+        })
       }
     }
   }

--- a/apis/core/test/domain/job/create.test.ts
+++ b/apis/core/test/domain/job/create.test.ts
@@ -84,7 +84,7 @@ describe('domain/job/create', () => {
       expect(job.out(rdf.type).values).to.contain(cc.PublishJob.value)
       expect(job.out(cc.publishGraph).term).to.deep.eq($rdf.namedNode('publishGraph'))
       expect(job.out(schema.creativeWorkStatus).term).to.deep.eq(ex.Draft)
-      expect(job.out(schema.workExample).term).to.deep.eq(ex.Visualise)
+      expect(job.out(schema.workExample).values).to.include(ex.Visualise.value)
     })
 
     it('sets next revision to job resource', async () => {
@@ -96,6 +96,19 @@ describe('domain/job/create', () => {
 
       // then
       expect(job.out(cc.revision).term).to.deep.eq($rdf.literal('4', xsd.integer))
+    })
+
+    it('sets lindas web query link', async () => {
+      // when
+      const job = await createPublishJob({ resource: jobCollection.term, store })
+
+      // then
+      const links = job.out(schema.workExample).map(example => example.out(schema.url).value).filter(Boolean)
+      const linkUrl = links[0] || ''
+      const link = new URL(linkUrl)
+      const params = new URLSearchParams(link.hash)
+      expect(link.hostname).to.eq('lindas.admin.ch')
+      expect(params.get('endpoint')).to.be.ok
     })
 
     it('throws when organization has no publish graph', async () => {

--- a/apis/core/test/domain/job/update.test.ts
+++ b/apis/core/test/domain/job/update.test.ts
@@ -166,7 +166,9 @@ describe('domain/job/update', () => {
       })
 
       // then
-      const link = new URL(job.out(schema.query).value!)
+      const links = job.out(schema.workExample).map(example => example.out(schema.url).value).filter(Boolean)
+      const linkUrl = links[0] || ''
+      const link = new URL(linkUrl)
       const params = new URLSearchParams(link.hash)
       expect(link.hostname).to.eq('lindas.admin.ch')
       expect(params.get('endpoint')).to.be.ok

--- a/apis/core/test/domain/job/update.test.ts
+++ b/apis/core/test/domain/job/update.test.ts
@@ -153,27 +153,6 @@ describe('domain/job/update', () => {
         .addOut(cc.publishGraph, job.namedNode('http://example.com/publish-graph'))
     })
 
-    it('sets lindas web query link', async () => {
-      // given
-      const resource = clownface({ dataset: $rdf.dataset() })
-        .namedNode('job')
-        .addOut(schema.actionStatus, schema.CompletedActionStatus)
-
-      // when
-      await update({
-        resource,
-        store,
-      })
-
-      // then
-      const links = job.out(schema.workExample).map(example => example.out(schema.url).value).filter(Boolean)
-      const linkUrl = links[0] || ''
-      const link = new URL(linkUrl)
-      const params = new URLSearchParams(link.hash)
-      expect(link.hostname).to.eq('lindas.admin.ch')
-      expect(params.get('endpoint')).to.be.ok
-    })
-
     it("increments project's cc:publishedRevision when succeeded", async () => {
       // given
       const resource = clownface({ dataset: $rdf.dataset() })

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -235,6 +235,40 @@ describe('@cube-creator/cli/lib/commands/publish', function () {
       })
     })
 
+    it('adds work examples', async function () {
+      const cube = cubePointer.namedNode(targetCube())
+
+      const shape = clownface({ dataset: $rdf.dataset(), term: $rdf.blankNode() })
+        .addOut(sh.property, property => {
+          property
+            .addOut(sh.path, schema.workExample)
+            .addOut(sh.minCount, $rdf.literal('3', xsd.int))
+            .addOut(sh.maxCount, $rdf.literal('3', xsd.int))
+            .addList(sh.or, [
+              property.node($rdf.blankNode()).addOut(sh.hasValue, $rdf.namedNode('https://ld.admin.ch/application/visualize')),
+              // Link to visualize
+              property.node($rdf.blankNode()).addOut(sh.node, nodeVis => {
+                nodeVis
+                  .addOut(sh.property, prop => {
+                    prop
+                      .addOut(sh.path, schema.encodingFormat)
+                      .addOut(sh.hasValue, $rdf.literal('text/html'))
+                  })
+              }),
+              // Link to lindas query
+              property.node($rdf.blankNode()).addOut(sh.node, nodeSparql => {
+                nodeSparql
+                  .addOut(sh.property, prop => {
+                    prop
+                      .addOut(sh.path, schema.encodingFormat)
+                      .addOut(sh.hasValue, $rdf.literal('Application/Sparql-query'))
+                  })
+              }),
+            ])
+        })
+      expect(cube).to.matchShape(shape)
+    })
+
     it('emits organization as cube:observedBy value', async () => {
       const observedBy = cubePointer.has(cube.observedBy).out(cube.observedBy).terms
 

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -704,6 +704,16 @@ graph <cube-project/ubd/csv-mapping/jobs/test-publish-job> {
     cc:revision 3 ;
     schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Draft> ;
     schema:workExample <https://ld.admin.ch/application/visualize> ;
+    schema:workExample [
+      schema:name "LINDAS query UI"@en ;
+      schema:url "https://example.org/query/" ;
+      schema:encodingFormat "text/html" ;
+    ] ;
+    schema:workExample [
+      schema:name "visualize.admin.ch" ;
+      schema:url "https://visualize.admin.ch/create/new?cube=the-cube" ;
+      schema:encodingFormat "Application/Sparql-query" ;
+    ] ;
   .
 }
 

--- a/packages/core/env.ts
+++ b/packages/core/env.ts
@@ -45,6 +45,7 @@ type ENV_VARS =
   | 'PIPELINE_ENV'
   | 'PUBLIC_QUERY_ENDPOINT'
   | 'TRIFID_UI'
+  | 'VISUALIZE_UI'
 
 type KnownVariables<T extends string> = {
   /* eslint-disable-next-line no-unused-vars */

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -73,8 +73,7 @@ type CubeCreatorProperty =
   'CubeProject/sourceCube' |
   'CubeProject/sourceEndpoint' |
   'CubeProject/sourceGraph' |
-  'export' |
-  'visualize'
+  'export'
 
 type OtherTerms =
   'dash' |

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -73,7 +73,8 @@ type CubeCreatorProperty =
   'CubeProject/sourceCube' |
   'CubeProject/sourceEndpoint' |
   'CubeProject/sourceGraph' |
-  'export'
+  'export' |
+  'visualize'
 
 type OtherTerms =
   'dash' |

--- a/packages/model/Job.ts
+++ b/packages/model/Job.ts
@@ -3,12 +3,12 @@ import { Mixin } from '@tpluscode/rdfine/lib/ResourceFactory'
 import type { Collection } from '@rdfine/hydra'
 import type * as Rdfs from '@rdfine/rdfs'
 import { ResourceMixin } from '@rdfine/rdfs'
-import { Action, ActionMixin } from '@rdfine/schema'
+import { Action, ActionMixin, CreativeWork, CreativeWorkMixin } from '@rdfine/schema'
 import { cc } from '@cube-creator/core/namespace'
 import { TableCollection } from './Table'
 import { Link } from './lib/Link'
-import { NamedNode, Term } from 'rdf-js'
-import { schema, dcterms, rdfs } from '@tpluscode/rdf-ns-builders'
+import { Literal, NamedNode, Term } from 'rdf-js'
+import { schema, dcterms, rdfs, rdf } from '@tpluscode/rdf-ns-builders'
 import { initializer } from './lib/initializer'
 import { DimensionMetadataCollection } from './DimensionMetadata'
 
@@ -29,10 +29,11 @@ export interface PublishJob extends Job {
   project: NamedNode
   revision: number
   publishGraph: NamedNode
-  publishedTo?: Term
+  publishedTo: Term | undefined
   status?: Term
   query?: string
-  visualize?: string
+  workExamples?: CreativeWork[]
+  addWorkExample(attrs: any): void
 }
 
 export function isPublishJob(job: Job): job is PublishJob {
@@ -88,6 +89,12 @@ export const createTransform = initializer<TransformJob, RequiredProperties>(Tra
   actionStatus: schema.PotentialActionStatus,
 })
 
+interface WorkExampleInput {
+  name: Literal[]
+  url: NamedNode
+  encodingFormat: string
+}
+
 export function PublishJobMixin<Base extends Constructor<RdfResource>>(base: Base): Mixin {
   class Impl extends ResourceMixin(ActionMixin(base)) implements Partial<PublishJob> {
     @property({ path: cc.project })
@@ -99,17 +106,42 @@ export function PublishJobMixin<Base extends Constructor<RdfResource>>(base: Bas
     @property({ path: cc.publishGraph })
     publishGraph!: NamedNode
 
-    @property({ path: schema.workExample })
-    publishedTo?: NamedNode
-
     @property({ path: schema.creativeWorkStatus })
     status?: NamedNode
 
+    get publishedTo(): Term | undefined {
+      return this.pointer
+        .out(schema.workExample)
+        .filter(example => example.out(schema.encodingFormat).terms.length === 0)
+        .term
+    }
+
+    set publishedTo(term: Term | undefined) {
+      if (term) {
+        this.pointer.addOut(schema.workExample, term)
+      }
+    }
+
+    get workExamples(): CreativeWork[] {
+      return this.pointer
+        .out(schema.workExample)
+        .filter(example => example.out(schema.encodingFormat).terms.length > 0)
+        .map(workExampleP => new CreativeWorkMixin.Class(workExampleP as any) as CreativeWork)
+    }
+
+    addWorkExample(attrs: WorkExampleInput) {
+      return this.pointer.addOut(schema.workExample, workExample => {
+        workExample
+          .addOut(rdf.type, schema.CreativeWork)
+          .addOut(schema.name, attrs.name)
+          .addOut(schema.url, attrs.url)
+          .addOut(schema.encodingFormat, attrs.encodingFormat)
+      })
+    }
+
+    // Legacy. Kept to support old data.
     @property.literal({ path: schema.query })
     query?: string
-
-    @property.literal({ path: cc.visualize })
-    visualize?: string
   }
 
   return Impl

--- a/packages/model/Job.ts
+++ b/packages/model/Job.ts
@@ -32,6 +32,7 @@ export interface PublishJob extends Job {
   publishedTo?: Term
   status?: Term
   query?: string
+  visualize?: string
 }
 
 export function isPublishJob(job: Job): job is PublishJob {
@@ -106,6 +107,9 @@ export function PublishJobMixin<Base extends Constructor<RdfResource>>(base: Bas
 
     @property.literal({ path: schema.query })
     query?: string
+
+    @property.literal({ path: cc.visualize })
+    visualize?: string
   }
 
   return Impl

--- a/packages/model/Job.ts
+++ b/packages/model/Job.ts
@@ -32,7 +32,7 @@ export interface PublishJob extends Job {
   publishedTo: Term | undefined
   status?: Term
   query?: string
-  workExamples?: CreativeWork[]
+  workExamples: CreativeWork[]
   addWorkExample(attrs: any): void
 }
 
@@ -89,10 +89,10 @@ export const createTransform = initializer<TransformJob, RequiredProperties>(Tra
   actionStatus: schema.PotentialActionStatus,
 })
 
-interface WorkExampleInput {
+export interface WorkExampleInput {
   name: Literal[]
   url: NamedNode
-  encodingFormat: string
+  encodingFormat: Literal
 }
 
 export function PublishJobMixin<Base extends Constructor<RdfResource>>(base: Base): Mixin {

--- a/ui/src/store/modules/app.ts
+++ b/ui/src/store/modules/app.ts
@@ -9,14 +9,14 @@ export interface Message {
 }
 
 export interface AppState {
-  language: string
+  language: string[]
   messages: Message[]
   loading: boolean
   commonRDFProperties: string[]
 }
 
 const initialState = {
-  language: 'en',
+  language: ['en', '*'],
   messages: [],
   loading: false,
   commonRDFProperties: [],

--- a/ui/src/views/Publication.vue
+++ b/ui/src/views/Publication.vue
@@ -29,12 +29,20 @@
           </div>
 
           <template #actions>
+            <!-- Support for legacy job.query -->
             <a v-if="job.query" :href="job.query" target="_blank" rel="noopener" class="button is-small">
               <span>Open in LINDAS</span>
               <b-icon icon="chevron-right" />
             </a>
-            <a v-if="job.visualize" :href="job.visualize" target="_blank" rel="noopener" class="button is-small">
-              <span>Open in Visualize</span>
+            <a
+              v-for="workExample in job.workExamples"
+              :key="workExample.id.value"
+              :href="workExample.url.value"
+              target="_blank"
+              rel="noopener"
+              class="button is-small"
+            >
+              <span>{{ workExampleLabel(workExample) }}</span>
               <b-icon icon="chevron-right" />
             </a>
           </template>
@@ -56,15 +64,23 @@ import JobForm from '@/components/JobForm.vue'
 import JobItem from '@/components/JobItem.vue'
 import ExternalTerm from '@/components/ExternalTerm.vue'
 import { JobCollection, PublishJob } from '@cube-creator/model'
+import { schema } from '@tpluscode/rdf-ns-builders'
+import { CreativeWork } from '@rdfine/schema'
 
+const appNS = namespace('app')
 const projectNS = namespace('project')
 
 @Component({
   components: { ExternalTerm, LoadingBlock, JobForm, JobItem },
 })
 export default class PublicationView extends Vue {
+  @appNS.State('language') language!: string[]
   @projectNS.State('jobCollection') jobCollection!: JobCollection | null;
   @projectNS.Getter('publishJobs') jobs!: PublishJob[]
+
+  workExampleLabel (workExample: CreativeWork): string {
+    return workExample.pointer.out(schema.name, { language: this.language }).value || 'Example'
+  }
 }
 </script>
 

--- a/ui/src/views/Publication.vue
+++ b/ui/src/views/Publication.vue
@@ -33,6 +33,10 @@
               <span>Open in LINDAS</span>
               <b-icon icon="chevron-right" />
             </a>
+            <a v-if="job.visualize" :href="job.visualize" target="_blank" rel="noopener" class="button is-small">
+              <span>Open in Visualize</span>
+              <b-icon icon="chevron-right" />
+            </a>
           </template>
         </job-item>
       </div>

--- a/ui/src/views/SharedDimension.vue
+++ b/ui/src/views/SharedDimension.vue
@@ -103,7 +103,6 @@ import TermWithLanguage from '@/components/TermWithLanguage.vue'
 import DownloadButton from '@/components/DownloadButton.vue'
 import { SharedDimension, SharedDimensionTerm } from '@/store/types'
 
-const appNS = namespace('app')
 const sharedDimensionNS = namespace('sharedDimension')
 
 @Component({
@@ -118,7 +117,6 @@ const sharedDimensionNS = namespace('sharedDimension')
   },
 })
 export default class extends Vue {
-  @appNS.State('language') language!: string
   @sharedDimensionNS.State('dimension') dimension!: SharedDimension | null
   @sharedDimensionNS.State('terms') terms!: SharedDimensionTerm[] | null
 

--- a/ui/src/views/SharedDimensions.vue
+++ b/ui/src/views/SharedDimensions.vue
@@ -54,14 +54,12 @@ import SharedDimensionTags from '@/components/SharedDimensionTags.vue'
 import TermWithLanguage from '@/components/TermWithLanguage.vue'
 import { SharedDimension } from '@/store/types'
 
-const appNS = namespace('app')
 const sharedDimensionsNS = namespace('sharedDimensions')
 
 @Component({
   components: { PageContent, LoadingBlock, HydraOperationButton, SharedDimensionTags, TermWithLanguage },
 })
 export default class CubeProjectsView extends Vue {
-  @appNS.State('language') language!: string
   @sharedDimensionsNS.State('collection') collection!: Collection | null
   @sharedDimensionsNS.Getter('dimensions') dimensions!: SharedDimension[]
 


### PR DESCRIPTION
- [x] Display link to visualize.admin.ch on publication job when cube is published to visualize.
- [x] Add `workExample` for visualize and sparql endpoint on the dataset when publishing