### PR TITLE
Get SPARQL/query endpoints from maintainer instead of creator

### DIFF
--- a/.changeset/beige-ads-jump.md
+++ b/.changeset/beige-ads-jump.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Fix saving cube metadata

--- a/apis/core/lib/domain/cube-projects/queries.ts
+++ b/apis/core/lib/domain/cube-projects/queries.ts
@@ -23,6 +23,19 @@ export async function findProject(metadataCollection: DimensionMetadataCollectio
   return result[0]?.project as any
 }
 
+export async function findProjectMaintainerForDataset(datasetId: NamedNode): Promise<NamedNode | undefined> {
+  const result = await SELECT`?maintainer`
+    .WHERE`
+      GRAPH ?maintainer {
+        ?project ${cc.dataset} ${datasetId} .
+        ?project ${schema.maintainer} ?maintainer .
+      }
+    `
+    .execute(parsingClient.query)
+
+  return result[0]?.maintainer as any
+}
+
 export function exists(cubeIdentifierOrUri: string | NamedNode, maintainer: Term, client = parsingClient): Promise<boolean> {
   let patterns: SparqlTemplateResult[]
 

--- a/apis/core/lib/domain/cube-projects/queries.ts
+++ b/apis/core/lib/domain/cube-projects/queries.ts
@@ -23,19 +23,6 @@ export async function findProject(metadataCollection: DimensionMetadataCollectio
   return result[0]?.project as any
 }
 
-export async function findProjectMaintainerForDataset(datasetId: NamedNode): Promise<NamedNode | undefined> {
-  const result = await SELECT`?maintainer`
-    .WHERE`
-      GRAPH ?maintainer {
-        ?project ${cc.dataset} ${datasetId} .
-        ?project ${schema.maintainer} ?maintainer .
-      }
-    `
-    .execute(parsingClient.query)
-
-  return result[0]?.maintainer as any
-}
-
 export function exists(cubeIdentifierOrUri: string | NamedNode, maintainer: Term, client = parsingClient): Promise<boolean> {
   let patterns: SparqlTemplateResult[]
 

--- a/apis/core/lib/domain/dataset/update.ts
+++ b/apis/core/lib/domain/dataset/update.ts
@@ -1,20 +1,23 @@
 import { cc, lindas } from '@cube-creator/core/namespace'
 import { Draft, Published } from '@cube-creator/model/Cube'
-import { dcat, dcterms, hydra, rdf, schema, vcard, _void } from '@tpluscode/rdf-ns-builders'
+import { dcat, hydra, rdf, schema, vcard, _void } from '@tpluscode/rdf-ns-builders'
 import { GraphPointer } from 'clownface'
 import { NamedNode } from 'rdf-js'
 import { ResourceStore } from '../../ResourceStore'
+import { findProjectMaintainerForDataset } from '../cube-projects/queries'
 
 interface AddMetaDataCommand {
   dataset: GraphPointer<NamedNode>
   resource: GraphPointer
   store: ResourceStore
+  findMaintainer?: (dataset: NamedNode) => Promise<NamedNode | undefined>
 }
 
 export async function update({
   dataset,
   resource,
   store,
+  findMaintainer = findProjectMaintainerForDataset,
 }: AddMetaDataCommand): Promise<GraphPointer> {
   const datasetResource = await store.get(dataset.term)
 
@@ -55,7 +58,7 @@ export async function update({
   })
 
   // Set LINDAS query interface and sparql endpoint
-  const organizationId = datasetResource.out(dcterms.creator).term
+  const organizationId = await findMaintainer(dataset.term)
   if (organizationId) {
     const organization = await store.get(organizationId)
 

--- a/apis/core/test/domain/dataset/update.test.ts
+++ b/apis/core/test/domain/dataset/update.test.ts
@@ -15,10 +15,6 @@ describe('domain/dataset/update', () => {
   let store: TestResourceStore
   let dataset: GraphPointer<NamedNode, DatasetExt>
   let organization: GraphPointer<NamedNode, DatasetExt>
-  const maintainer = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('organization/my-maintainer-org') })
-    .addOut(dcat.accessURL, $rdf.namedNode('https://myorg/query'))
-    .addOut(_void.sparqlEndpoint, $rdf.namedNode('https://myorg/sparql'))
-  const findMaintainer: () => Promise<NamedNode> = () => new Promise((resolve) => resolve(maintainer.term))
 
   beforeEach(() => {
     dataset = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('dataset') })
@@ -31,7 +27,6 @@ describe('domain/dataset/update', () => {
     store = new TestResourceStore([
       dataset,
       organization,
-      maintainer,
     ])
   })
 
@@ -44,7 +39,7 @@ describe('domain/dataset/update', () => {
       .addOut(dcterms.description, description)
 
     // when
-    const result = await update({ dataset, resource: updatedResource, store, findMaintainer })
+    const result = await update({ dataset, resource: updatedResource, store })
 
     // then
     expect(result.out(dcterms.title).value).to.eq(title)
@@ -67,7 +62,7 @@ describe('domain/dataset/update', () => {
       .addOut(schema.creativeWorkStatus, Published)
 
     // when
-    const result = await update({ dataset, resource: updatedResource, store, findMaintainer })
+    const result = await update({ dataset, resource: updatedResource, store })
 
     // then
     const statuses = result.out(schema.creativeWorkStatus).values
@@ -91,7 +86,7 @@ describe('domain/dataset/update', () => {
       })
 
     // when
-    const result = await update({ dataset, resource: updatedResource, store, findMaintainer })
+    const result = await update({ dataset, resource: updatedResource, store })
 
     // then
     expect(result).to.matchShape({
@@ -135,7 +130,7 @@ describe('domain/dataset/update', () => {
       })
 
     // when
-    const result = await update({ dataset, resource: updatedResource, store, findMaintainer })
+    const result = await update({ dataset, resource: updatedResource, store })
 
     // then
     const cubeTriples = result.dataset.match(dataset.namedNode('cube').term)
@@ -147,10 +142,9 @@ describe('domain/dataset/update', () => {
     dataset.namedNode('foo').addOut(rdf.type, schema.Person)
     const updatedResource = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('dataset') })
       .addOut(dcterms.title, 'title')
-    const findMaintainer: () => Promise<undefined> = () => new Promise((resolve) => resolve(undefined))
 
     // when
-    const result = await update({ dataset, resource: updatedResource, store, findMaintainer })
+    const result = await update({ dataset, resource: updatedResource, store })
 
     // then
     expect(result.namedNode('foo').out().terms).to.have.length(0)
@@ -176,7 +170,7 @@ describe('domain/dataset/update', () => {
       .addOut(cc.dimensionMetadata, ex.Bar)
 
     // when
-    const result = await update({ dataset, resource: updatedResource, store, findMaintainer })
+    const result = await update({ dataset, resource: updatedResource, store })
 
     // then
     expect(result.out(schema.hasPart).terms).to.not.deep.contain.members([ex.Foo])
@@ -195,7 +189,7 @@ describe('domain/dataset/update', () => {
       })
 
     // when
-    const result = await update({ dataset, resource: updatedResource, store, findMaintainer })
+    const result = await update({ dataset, resource: updatedResource, store })
 
     // then
     expect(result).to.matchShape({
@@ -221,30 +215,6 @@ describe('domain/dataset/update', () => {
             maxCount: 1,
           }],
         },
-      }],
-    })
-  })
-
-  it('populates lindas query URIs from organization', async () => {
-    // given
-    const updatedResource = clownface({ dataset: $rdf.dataset(), term: $rdf.namedNode('dataset') })
-      .addOut(dcterms.title, 'title')
-
-    // when
-    const result = await update({ dataset, resource: updatedResource, store, findMaintainer })
-
-    // then
-    expect(result).to.matchShape({
-      property: [{
-        path: dcat.accessURL,
-        minCount: 1,
-        maxCount: 1,
-        hasValue: $rdf.namedNode('https://myorg/query'),
-      }, {
-        path: _void.sparqlEndpoint,
-        minCount: 1,
-        maxCount: 1,
-        hasValue: $rdf.namedNode('https://myorg/sparql'),
       }],
     })
   })

--- a/cli/lib/metadata.ts
+++ b/cli/lib/metadata.ts
@@ -1,7 +1,7 @@
 import { obj } from 'through2'
 import { Quad, Quad_Object as QuadObject, Quad_Subject as QuadSubject } from 'rdf-js'
 import $rdf from 'rdf-ext'
-import { dcterms, rdf, schema, sh, xsd } from '@tpluscode/rdf-ns-builders'
+import { dcat, dcterms, rdf, schema, sh, xsd, _void } from '@tpluscode/rdf-ns-builders'
 import { cc, cube } from '@cube-creator/core/namespace'
 import { Project, PublishJob } from '@cube-creator/model'
 import { HydraClient } from 'alcaeus/alcaeus'
@@ -74,6 +74,10 @@ export async function injectMetadata(this: Context, jobUri: string) {
       this.push($rdf.quad(quad.subject, dcterms.identifier, $rdf.literal(cubeIdentifier)))
       this.push($rdf.quad(baseCube, schema.hasPart, quad.subject))
       this.push($rdf.quad(baseCube, rdf.type, schema.CreativeWork))
+
+      // Set LINDAS query interface and sparql endpoint
+      this.push($rdf.quad(quad.subject, dcat.accessURL, maintainer.accessURL))
+      this.push($rdf.quad(quad.subject, _void.sparqlEndpoint, maintainer.sparqlEndpoint))
 
       if (revision.value === '1') {
         this.push($rdf.quad(quad.subject, schema.datePublished, timestamp))

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -3,7 +3,7 @@ import { before, describe, it } from 'mocha'
 import { expect } from 'chai'
 import $rdf from 'rdf-ext'
 import { ASK, CONSTRUCT, DELETE, SELECT, WITH } from '@tpluscode/sparql-builder'
-import { csvw, dcat, dcterms, qudt, rdf, schema, sh, vcard, xsd } from '@tpluscode/rdf-ns-builders'
+import { csvw, dcat, dcterms, qudt, rdf, schema, sh, vcard, xsd, _void } from '@tpluscode/rdf-ns-builders'
 import { setupEnv } from '../../support/env'
 import { ccClients } from '@cube-creator/testing/lib'
 import { insertTestProject } from '@cube-creator/testing/lib/seedData'
@@ -184,6 +184,22 @@ describe('@cube-creator/cli/lib/commands/publish', function () {
           hasValue: $rdf.literal('ubd/28'),
           minCount: 1,
           maxCount: 1,
+        }],
+      })
+    })
+
+    it('adds lindas query URIs from maintainer', async () => {
+      expect(cubePointer.namedNode(targetCube())).to.matchShape({
+        property: [{
+          path: dcat.accessURL,
+          minCount: 1,
+          maxCount: 1,
+          hasValue: $rdf.namedNode('https://environment.ld.admin.ch/query'),
+        }, {
+          path: _void.sparqlEndpoint,
+          minCount: 1,
+          maxCount: 1,
+          hasValue: $rdf.namedNode('https://environment.ld.admin.ch/sparql'),
         }],
       })
     })

--- a/packages/model/Organization.ts
+++ b/packages/model/Organization.ts
@@ -2,7 +2,7 @@ import { DatasetCore, NamedNode, Term } from 'rdf-js'
 import { Organization, OrganizationMixin as SchemaOrganizationMixin } from '@rdfine/schema'
 import { Constructor, namespace, property, ResourceIdentifier } from '@tpluscode/rdfine'
 import { cc } from '@cube-creator/core/namespace'
-import { schema } from '@tpluscode/rdf-ns-builders'
+import { dcat, schema, _void } from '@tpluscode/rdf-ns-builders'
 import RdfResourceImpl, { Initializer, RdfResourceCore } from '@tpluscode/rdfine/RdfResource'
 import type { GraphPointer } from 'clownface'
 
@@ -15,6 +15,8 @@ interface OrganizationEx {
   publishGraph: NamedNode
   namespace: NamedNode
   dataset?: NamedNode
+  accessURL: NamedNode
+  sparqlEndpoint: NamedNode
   createIdentifier(params: CreateIdentifier): NamedNode
 }
 
@@ -34,6 +36,12 @@ export function OrganizationMixin<Base extends Constructor<Omit<Organization, ke
 
     @property({ path: schema.dataset })
     dataset?: NamedNode
+
+    @property({ path: dcat.accessURL })
+    accessURL!: NamedNode
+
+    @property({ path: _void.sparqlEndpoint })
+    sparqlEndpoint!: NamedNode
 
     createIdentifier({ cubeIdentifier, termName }: CreateIdentifier): NamedNode {
       const namespace = this.namespace.value.match(/[/#]$/) ? this.namespace.value : `${this.namespace.value}/`


### PR DESCRIPTION
Maintainer and creator organization can be different. But the SPARQL endpoint to retrieve a published cube must come from the maintainer, since it's the one used when publishing.

Fixes #852 