### PR TITLE
Expire jobs - improvements

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -64,9 +64,8 @@ async function main() {
   program
     .command('timeout-jobs')
     .description('Fails jobs which have been active for an excessive amount of time')
-    .requiredOption('--execution-url <executionUrl>', 'Link to job execution')
     .option('--duration <duration>', 'ISO8601 duration', 'PT6H')
-    .action(capture('Timeout', ({ executionUrl }) => ({ executionUrl }), timeoutJobs))
+    .action(capture('Timeout', () => ({ }), timeoutJobs))
 
   program
     .command('import')

--- a/cli/lib/commands/timeoutJobs.ts
+++ b/cli/lib/commands/timeoutJobs.ts
@@ -52,17 +52,15 @@ export async function timeoutJobs({
   apiClient.resources.factory.addMixin(...Object.values(Models))
   setupAuthentication({}, log, apiClient)
 
-  const updateRequests = overtimeJobs
-    .map(({ job }) => updateJob({
+  for (const { job } of overtimeJobs) {
+    await updateJob({
       jobUri: job.value,
       apiClient,
       modified: new Date(now()),
       status: schema.FailedActionStatus,
       executionUrl: undefined,
       error: 'Job exceeded maximum running time',
-    }).then(() => {
-      log('Updated job %s', job.value)
-    }).catch(log))
-
-  await Promise.all(updateRequests)
+    })
+    log('Updated job %s', job.value)
+  }
 }

--- a/cli/lib/commands/timeoutJobs.ts
+++ b/cli/lib/commands/timeoutJobs.ts
@@ -22,6 +22,8 @@ export async function timeoutJobs({
   now = Date.now,
   updateJob = updateJobStatus,
 }: TimeoutJobs): Promise<void> {
+  log.enabled = true
+
   const client = new ParsingClient({
     endpointUrl: process.env.GRAPH_QUERY_ENDPOINT!,
     user: process.env.GRAPH_STORE_USER,
@@ -30,6 +32,8 @@ export async function timeoutJobs({
 
   const timeout = toSeconds(parse(duration))
   const startDate = new Date(now() - (timeout * 1000))
+
+  log('Will expire jobs active since before %s', startDate.toISOString())
 
   const overtimeJobs = await SELECT`?job`
     .WHERE`

--- a/cli/lib/job.ts
+++ b/cli/lib/job.ts
@@ -39,7 +39,7 @@ interface JobStatusUpdate {
   executionUrl: string | undefined
   status: Schema.ActionStatusType
   modified: Date
-  error?: Error
+  error?: Error | string
   apiClient: HydraClient
 }
 
@@ -67,10 +67,13 @@ export async function updateJobStatus({ jobUri, executionUrl, status, error, mod
       job.seeAlso = $rdf.namedNode(executionUrl) as any
     }
     if (error) {
+      const name = error instanceof Error ? error.name : error
+      const description = error instanceof Error ? error.stack : ''
+
       job.error = {
         types: [schema.Thing],
-        name: error.message,
-        description: error.stack,
+        name,
+        description,
       } as any
     }
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,6 +7,7 @@
     "postinstall": "mkdir -p output; touch .env",
     "transform": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts transform --job \"$TRANSFORM_JOB\" --debug --to filesystem'",
     "publish": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts publish --job \"$PUBLISH_JOB\" --debug'",
+    "expire-timedout": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts timeout-jobs'",
     "build": "tsc"
   },
   "dependencies": {

--- a/cli/test/lib/commands/timeoutJobs.test.ts
+++ b/cli/test/lib/commands/timeoutJobs.test.ts
@@ -15,11 +15,9 @@ describe('@cube-creator/cli/lib/commands/timeoutJobs', () => {
   it('sets failed status to active jobs which were not updated since given duration', async () => {
     // given
     const updateJob = sinon.spy()
-    const executionUrl = 'http://example.com/job'
 
     // when
     await timeoutJobs({
-      executionUrl,
       duration: 'PT6H',
       now() {
         return Date.parse('2020-10-29T20:01:54')
@@ -32,7 +30,6 @@ describe('@cube-creator/cli/lib/commands/timeoutJobs', () => {
     expect(updateJob).to.have.been.calledWithMatch({
       jobUri: 'https://cube-creator.lndo.site/cube-project/ubd/csv-mapping/jobs/hung-job',
       status: schema.FailedActionStatus,
-      executionUrl,
     })
   })
 })


### PR DESCRIPTION
Quick changes to the jobs timeout CLI

1. do not overwrite the original job link (does not make sense to link to the "expire jobs" run)
2. run sequentially to prevent all updates requesting its own auth token
3. push a generic error message
4. make sure logging is enabled