### PR TITLE
fix: expire cubes correctly based on cube status

### DIFF
--- a/.changeset/tough-trees-fetch.md
+++ b/.changeset/tough-trees-fetch.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Publishing draft cube marked latest non-draft as expired

--- a/cli/lib/cube.ts
+++ b/cli/lib/cube.ts
@@ -7,7 +7,7 @@ import { obj } from 'through2'
 import { CONSTRUCT, sparql } from '@tpluscode/sparql-builder'
 import { IN } from '@tpluscode/sparql-builder/expressions'
 import { schema, sh } from '@tpluscode/rdf-ns-builders'
-import { Dataset } from '@cube-creator/model'
+import { Dataset, PublishJob } from '@cube-creator/model'
 import StreamClient from 'sparql-http-client/StreamClient'
 import { Draft } from '@cube-creator/model/Cube'
 import { loadDataset } from './metadata'
@@ -35,9 +35,9 @@ export function expirePreviousVersions(this: Pick<Context, 'variables' | 'log'>)
     password: this.variables.get('publish-graph-store-password'),
   })
 
-  const job = this.variables.get('publish-job')
   let onlyDraftCubes = sparql``
-  if (Draft.equals(job?.status)) {
+  const publishJob: PublishJob | undefined = this.variables.get('publish-job')
+  if (publishJob && Draft.equals(publishJob.status)) {
     onlyDraftCubes = sparql`
       ?cube ${schema.creativeWorkStatus} ?status .
 

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -68,7 +68,7 @@ describe('@cube-creator/cli/lib/commands/publish', function () {
 
   describe('publishing published', () => {
     before(resetData)
-    before(() => {
+    before(function makeCubePublished() {
       return WITH(job, DELETE`
         ${job} ${schema.creativeWorkStatus} ?status
       `.INSERT`
@@ -85,6 +85,25 @@ describe('@cube-creator/cli/lib/commands/publish', function () {
         .execute(ccClients.streamClient.query)
 
       expect(hasVoidLink).to.be.true
+    })
+
+    it('"deprecates" all previous cubes', async function () {
+      expect(cubePointer.namedNode(ns.baseCube('1'))).to.matchShape({
+        property: [{
+          path: schema.expires,
+          datatype: xsd.dateTime,
+          minCount: 1,
+          maxCount: 1,
+        }],
+      })
+      expect(cubePointer.namedNode(ns.baseCube('2'))).to.matchShape({
+        property: [{
+          path: schema.expires,
+          datatype: xsd.dateTime,
+          minCount: 1,
+          maxCount: 1,
+        }],
+      })
     })
   })
 
@@ -204,13 +223,20 @@ describe('@cube-creator/cli/lib/commands/publish', function () {
       })
     })
 
-    it('"deprecates" previous cubes', async function () {
+    it('"deprecates" only previous draft cubes', async function () {
       expect(cubePointer.namedNode(ns.baseCube('1'))).to.matchShape({
         property: [{
           path: schema.expires,
           datatype: xsd.dateTime,
           minCount: 1,
           maxCount: 1,
+        }],
+      })
+      expect(cubePointer.namedNode(ns.baseCube('2'))).to.matchShape({
+        property: [{
+          path: schema.expires,
+          datatype: xsd.dateTime,
+          maxCount: 0,
         }],
       })
     })

--- a/cli/test/lib/commands/unlist.test.ts
+++ b/cli/test/lib/commands/unlist.test.ts
@@ -74,5 +74,13 @@ describe.only('@cube-creator/cli/lib/commands/unlist', function () {
         maxCount: 1,
       }],
     })
+    expect(cubePointer.namedNode(ns.baseCube('2'))).to.matchShape({
+      property: [{
+        path: schema.expires,
+        datatype: xsd.dateTime,
+        minCount: 1,
+        maxCount: 1,
+      }],
+    })
   })
 })

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -41,9 +41,13 @@ graph <cube-project/ubd> {
 <https://lindas.admin.ch/foen/cube> void:inDataset <ubd-example> .
 graph <https://lindas.admin.ch/foen/cube> {
   <https://environment.ld.admin.ch/foen/ubd/28/>
-    schema:hasPart <https://environment.ld.admin.ch/foen/ubd/28/1> .
+    schema:hasPart <https://environment.ld.admin.ch/foen/ubd/28/1> ;
+    schema:hasPart <https://environment.ld.admin.ch/foen/ubd/28/2> .
 
-  <https://environment.ld.admin.ch/foen/ubd/28/1> a cube:Cube .
+  <https://environment.ld.admin.ch/foen/ubd/28/1> a cube:Cube ;
+    schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Draft> .
+  <https://environment.ld.admin.ch/foen/ubd/28/2> a cube:Cube ;
+    schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published> .
 }
 
 <cube-project/ubd/dataset> void:inDataset <ubd-example> .


### PR DESCRIPTION
As mentioned in #821, the `schema:expires` should be set depending on the status of published cube

- Publishing a "Published" cube does expire all former cubes.
- Publishing a "Draft" does expire all former "Draft" cubes and does not touch the "Published" cube.

Until now all cube would have been expired regardless of the status. This PR fixes that