### PR TITLE
fix: importing project must correct cube URIs

### DIFF
--- a/.changeset/purple-crews-argue.md
+++ b/.changeset/purple-crews-argue.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": minor
+---
+
+Option to change the identifier of imported project (fixes #878)

--- a/.changeset/weak-colts-judge.md
+++ b/.changeset/weak-colts-judge.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Import: Ensure that all cube-related URIs are correct if a different organization profile is selected when importing

--- a/apis/core/bootstrap/shapes/cube-project.ts
+++ b/apis/core/bootstrap/shapes/cube-project.ts
@@ -125,6 +125,15 @@ const projectProperties = turtle`
         ${sh.maxCount} 1 ;
         ${sh.order} 40 ;
       ];
+      ${sh.property} [
+        ${sh.name} "Cube identifier" ;
+        ${sh.description} "Needed only when it is different from exported project's identifier" ;
+        ${sh.path} ${dcterms.identifier} ;
+        ${sh.pattern} ${cubeIdPattern} ;
+        ${sh.minLength} 1 ;
+        ${sh.maxCount} 1 ;
+        ${sh.order} 50 ;
+      ];
     ]
   ) ;`
 


### PR DESCRIPTION
Related to #878, I realised that when a different organisation is selected, the cube and dimension URIs are not corrected.

This PR fixes that and also adds the ability to change the identifier, being the other configurable component of the cube URIs