### PR TITLE
fix: better default for form fields with lang tag

### DIFF
--- a/.changeset/nice-wombats-exist.md
+++ b/.changeset/nice-wombats-exist.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+In some scenarios not all form translations were saved when adding metadata (fixes #893)

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -93,7 +93,7 @@ ${shape('dimension/metadata')} {
       ${sh.datatype} ${rdf.langString} ;
       ${sh.languageIn} ( ${supportedLanguages} ) ;
       ${sh.uniqueLang} true ;
-      ${sh.defaultValue} ""@en ;
+      ${sh.maxCount} ${supportedLanguages.length};
       ${sh.minLength} 1 ;
       ${sh.order} 10 ;
     ] , [
@@ -102,7 +102,7 @@ ${shape('dimension/metadata')} {
       ${sh.datatype} ${rdf.langString} ;
       ${sh.languageIn} ( ${supportedLanguages} ) ;
       ${sh.uniqueLang} true ;
-      ${sh.defaultValue} ""@en ;
+      ${sh.maxCount} ${supportedLanguages.length};
       ${sh.minLength} 1 ;
       ${dash.singleLine} false ;
       ${sh.order} 15 ;


### PR DESCRIPTION
WIth the default being a literal with language, when adding multiple values which only differ in language, the form could inadvertently remove the one with default `@en`

To illustrate, a typical order of operations starts as follows

1. Add value (`""@en`)
2. Rename it to `"Class"@en`
3. Add value (`""@en`)
4. Rename it to `"Class"@en`

At this point the form shows 2 values but the graph actually contains only 1 (both English literals are equal).
Now, changing the language to make one value `"Class"@it` seemingly removes the English, which is what was reported.

By removing `sh:defaultValue`, the form does immediately add a triple to graph, so no literal get overwritten
