### PR TITLE
fix: do not add trailing slash to cube URI on import

### DIFF
--- a/.changeset/forty-jeans-raise.md
+++ b/.changeset/forty-jeans-raise.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Project import would add an unwanted trailing slash to cube URI (fixes #910)

--- a/apis/core/lib/domain/cube-projects/import.ts
+++ b/apis/core/lib/domain/cube-projects/import.ts
@@ -158,7 +158,7 @@ export async function importProject({
 
     const orgProfile = await store.getResource<Organization>(maintainer)
     const cubeId = orgProfile.createIdentifier({ cubeIdentifier })
-    importedDataset = importedDataset.map(alignCubeNamespace(originalCubeId.value, cubeId.value + '/'))
+    importedDataset = importedDataset.map(alignCubeNamespace(originalCubeId.value, cubeId.value))
   }
 
   return {

--- a/apis/core/test/domain/cube-projects/import.test.ts
+++ b/apis/core/test/domain/cube-projects/import.test.ts
@@ -71,7 +71,7 @@ describe('@cube-creator/core-api/lib/domain/cube-projects/import', () => {
       await expect(promise).eventually.rejectedWith(BadRequest, /^Missing cube identifier/)
     })
 
-    it('throws identifier is already used', async () => {
+    it('throws when identifier is already used', async () => {
       // given
       const exported = (project: string) => {
         const dataset = $rdf.dataset()
@@ -197,7 +197,7 @@ describe('@cube-creator/core-api/lib/domain/cube-projects/import', () => {
         clownface({ dataset, graph: $rdf.namedNode(`${project}dataset`) })
           .namedNode(`${project}dataset`)
           .addOut(rdf.type, schema.Dataset)
-          .addOut(schema.hasPart, $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/'))
+          .addOut(schema.hasPart, $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28'))
 
         return dataset.toStream()
       }
@@ -248,8 +248,8 @@ describe('@cube-creator/core-api/lib/domain/cube-projects/import', () => {
         clownface({ dataset, graph: $rdf.namedNode(`${project}dataset`) })
           .namedNode(`${project}dataset`)
           .addOut(rdf.type, schema.Dataset)
-          .addOut(schema.hasPart, $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/'))
-          .namedNode('https://environment.ld.admin.ch/foen/ubd/28/')
+          .addOut(schema.hasPart, $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28'))
+          .namedNode('https://environment.ld.admin.ch/foen/ubd/28')
           .addOut(rdf.type, cube.Cube)
         clownface({ dataset, graph: $rdf.namedNode(`${project}dimensions-metadata`) })
           .namedNode(`${project}dimensions-metadata/dimension-year`)
@@ -276,9 +276,9 @@ describe('@cube-creator/core-api/lib/domain/cube-projects/import', () => {
       ).to.deep.equal($rdf.namedNode('https://test.ld.admin.ch/org/cube/id/dimension/year'))
       expect(
         data.namedNode(ns('/dataset')).out(schema.hasPart).term,
-      ).to.deep.equal($rdf.namedNode('https://test.ld.admin.ch/org/cube/id/'))
+      ).to.deep.equal($rdf.namedNode('https://test.ld.admin.ch/org/cube/id'))
       expect(
-        data.namedNode('https://test.ld.admin.ch/org/cube/id/').out(rdf.type).term,
+        data.namedNode('https://test.ld.admin.ch/org/cube/id').out(rdf.type).term,
       ).to.deep.equal(cube.Cube)
       expect(data.node(project.id)).to.matchShape({
         property: {
@@ -306,7 +306,7 @@ describe('@cube-creator/core-api/lib/domain/cube-projects/import', () => {
         clownface({ dataset, graph: $rdf.namedNode(`${project}dataset`) })
           .namedNode(`${project}dataset`)
           .addOut(rdf.type, schema.Dataset)
-          .addOut(schema.hasPart, $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/'))
+          .addOut(schema.hasPart, $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28'))
 
         return dataset.toStream()
       }
@@ -350,7 +350,7 @@ describe('@cube-creator/core-api/lib/domain/cube-projects/import', () => {
         clownface({ dataset, graph: $rdf.namedNode(`${project}dataset`) })
           .namedNode(`${project}dataset`)
           .addOut(rdf.type, schema.Dataset)
-          .addOut(schema.hasPart, $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/'))
+          .addOut(schema.hasPart, $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28'))
 
         return dataset.toStream()
       }

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -40,7 +40,7 @@ graph <cube-project/ubd> {
 
 <https://lindas.admin.ch/foen/cube> void:inDataset <ubd-example> .
 graph <https://lindas.admin.ch/foen/cube> {
-  <https://environment.ld.admin.ch/foen/ubd/28/>
+  <https://environment.ld.admin.ch/foen/ubd/28>
     schema:hasPart <https://environment.ld.admin.ch/foen/ubd/28/1> ;
     schema:hasPart <https://environment.ld.admin.ch/foen/ubd/28/2> .
 
@@ -54,7 +54,7 @@ graph <https://lindas.admin.ch/foen/cube> {
 graph <cube-project/ubd/dataset> {
   <cube-project/ubd/dataset>
     a void:Dataset, hydra:Resource, schema:Dataset, dcat:Dataset ;
-    schema:hasPart <https://environment.ld.admin.ch/foen/ubd/28/> ;
+    schema:hasPart <https://environment.ld.admin.ch/foen/ubd/28> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     dcterms:title 'UBD28' ;
     dcat:contactPoint [ vcard:fn 'Test Name' ;
@@ -63,7 +63,7 @@ graph <cube-project/ubd/dataset> {
     schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Draft> ;
   .
 
-  <https://environment.ld.admin.ch/foen/ubd/28/>
+  <https://environment.ld.admin.ch/foen/ubd/28>
     a cube:Cube ;
     schema:dateCreated "2015-08-06"^^xsd:date;
     dcterms:creator <user> ;
@@ -160,7 +160,7 @@ graph <cube-project/ubd/dimension-mapping/unit> {
 
 <cube-project/ubd/cube-data> void:inDataset <ubd-example> .
 graph <cube-project/ubd/cube-data> {
-  <https://environment.ld.admin.ch/foen/ubd/28/>
+  <https://environment.ld.admin.ch/foen/ubd/28>
     a cube:Cube ;
     cube:observationConstraint  <https://environment.ld.admin.ch/foen/ubd/28/shape/> ;
     cube:observationSet         <https://environment.ld.admin.ch/foen/ubd/28/observation/> ;


### PR DESCRIPTION
A correct cube identifier (URI) should not end with a slash

The import was incorrectly adding that slash to imported cubes