### PR TITLE
feat: track last transformed row

### DIFF
--- a/.changeset/spicy-shirts-boil.md
+++ b/.changeset/spicy-shirts-boil.md
@@ -1,0 +1,6 @@
+---
+"@cube-creator/cli": minor
+"@cube-creator/ui": minor
+---
+
+CSV transformation: track the last processed row and display if job failed

--- a/cli/lib/commands/runner.ts
+++ b/cli/lib/commands/runner.ts
@@ -108,8 +108,9 @@ export function create<TOptions extends RunOptions>({ pipelineSources, prepare }
     bufferDebug(run.pipeline, jobUri, { interval: 100 })
 
     await updateJobStatus({
+      jobUri,
       modified: new Date(),
-      variables,
+      executionUrl: variables.get('executionUrl'),
       status: schema.ActiveActionStatus,
       apiClient,
     })
@@ -117,7 +118,9 @@ export function create<TOptions extends RunOptions>({ pipelineSources, prepare }
     async function jobFailed(error: Error) {
       await updateJobStatus({
         modified: timestamp,
-        variables: run.pipeline.context.variables,
+        jobUri: run.pipeline.context.variables.get('jobUri'),
+        executionUrl: run.pipeline.context.variables.get('executionUrl'),
+        lastTransformed: run.pipeline.context.variables.get('lastTransformed'),
         status: schema.FailedActionStatus,
         error,
         apiClient,
@@ -132,7 +135,8 @@ export function create<TOptions extends RunOptions>({ pipelineSources, prepare }
       .then(() =>
         updateJobStatus({
           modified: timestamp,
-          variables: run.pipeline.context.variables,
+          jobUri: run.pipeline.context.variables.get('jobUri'),
+          executionUrl: run.pipeline.context.variables.get('executionUrl'),
           status: schema.CompletedActionStatus,
           apiClient,
         }))

--- a/cli/lib/commands/runner.ts
+++ b/cli/lib/commands/runner.ts
@@ -108,9 +108,8 @@ export function create<TOptions extends RunOptions>({ pipelineSources, prepare }
     bufferDebug(run.pipeline, jobUri, { interval: 100 })
 
     await updateJobStatus({
-      jobUri,
       modified: new Date(),
-      executionUrl: variables.get('executionUrl'),
+      variables,
       status: schema.ActiveActionStatus,
       apiClient,
     })
@@ -118,8 +117,7 @@ export function create<TOptions extends RunOptions>({ pipelineSources, prepare }
     async function jobFailed(error: Error) {
       await updateJobStatus({
         modified: timestamp,
-        jobUri: run.pipeline.context.variables.get('jobUri'),
-        executionUrl: run.pipeline.context.variables.get('executionUrl'),
+        variables: run.pipeline.context.variables,
         status: schema.FailedActionStatus,
         error,
         apiClient,
@@ -134,8 +132,7 @@ export function create<TOptions extends RunOptions>({ pipelineSources, prepare }
       .then(() =>
         updateJobStatus({
           modified: timestamp,
-          jobUri: run.pipeline.context.variables.get('jobUri'),
-          executionUrl: run.pipeline.context.variables.get('executionUrl'),
+          variables: run.pipeline.context.variables,
           status: schema.CompletedActionStatus,
           apiClient,
         }))

--- a/cli/lib/commands/transform.ts
+++ b/cli/lib/commands/transform.ts
@@ -12,6 +12,8 @@ export default runner.create<TransformRunOptions>({
     return ['main', 'from-api', `to-${to}`, 'validate']
   },
   prepare(_, variable) {
+    variable.set('lastTransformed', {})
+
     const Hydra = variable.get('apiClient')
 
     Hydra.resources.factory.addMixin(...Object.values(Csvw))

--- a/cli/lib/counters.ts
+++ b/cli/lib/counters.ts
@@ -1,5 +1,8 @@
 import type { Context } from 'barnard59-core/lib/Pipeline'
 import { PassThrough } from 'readable-stream'
+import through2 from 'through2'
+import { Quad } from 'rdf-js'
+import { csvw } from '@tpluscode/rdf-ns-builders/strict'
 import { quadCounter } from './otel/metrics'
 
 export function quads(this: Context, name: string) {
@@ -17,4 +20,17 @@ export function quads(this: Context, name: string) {
   })
 
   return forwarder
+}
+
+export function observeCsvwMetadata(this: Context) {
+  const lastTransformed = this.variables.get('lastTransformed')
+
+  return through2.obj(function (chunk: Quad, enc, callback) {
+    if (chunk.predicate.equals(csvw.rownum)) {
+      lastTransformed.row = Number.parseInt(chunk.object.value, 10)
+    }
+
+    this.push(chunk)
+    callback()
+  })
 }

--- a/cli/lib/csv.ts
+++ b/cli/lib/csv.ts
@@ -10,6 +10,7 @@ export function openFromCsvw(this: Context) {
   const csvStream = new PassThrough()
   const Hydra = this.variables.get('apiClient')
   const csvw = this.variables.get('transformed').csvwResource
+  const lastTransformed = this.variables.get('lastTransformed')
 
   Promise.resolve().then(async () => {
     const { response, representation } = await Hydra.loadResource<CsvSource>(csvw.url!)
@@ -31,7 +32,10 @@ export function openFromCsvw(this: Context) {
       return
     }
 
-    (csvResponse.body as any).pipe(csvStream)
+    lastTransformed.csv = representation.root.name
+    lastTransformed.row = 0
+
+    ;(csvResponse.body as any).pipe(csvStream)
   })
 
   return readable(csvStream)

--- a/cli/lib/job.ts
+++ b/cli/lib/job.ts
@@ -35,18 +35,16 @@ async function loadTransformJob(jobUri: string, log: Logger, variables: Params['
 }
 
 interface JobStatusUpdate {
+  jobUri: string
+  executionUrl: string | undefined
   status: Schema.ActionStatusType
   modified: Date
   error?: Error | string
   apiClient: HydraClient
-  variables: VariableMap
+  lastTransformed?: { csv?: string; row?: number }
 }
 
-export async function updateJobStatus({ variables, status, error, modified, apiClient }: JobStatusUpdate) {
-  const jobUri = variables.get('jobUri')
-  const executionUrl = variables.get('executionUrl')
-  const lastTransformed = variables.get('lastTransformed')
-
+export async function updateJobStatus({ jobUri, executionUrl, lastTransformed, status, error, modified, apiClient }: JobStatusUpdate) {
   try {
     const { representation } = await apiClient.loadResource<Job | TransformJob>(jobUri)
     const job = representation?.root

--- a/cli/lib/variables.ts
+++ b/cli/lib/variables.ts
@@ -32,5 +32,6 @@ declare module 'barnard59-core' {
     metadataResource: string
     datasetResource: string
     transformed: { csvwResource: Csvw.Table<DatasetExt> ; isObservationTable: boolean }
+    lastTransformed: { csv?: string; row?: number }
   }
 }

--- a/cli/pipelines/main.ttl
+++ b/cli/pipelines/main.ttl
@@ -58,6 +58,7 @@
   :steps [ :stepList (
                        <#LoadCsv>
                        <#parse>
+                       <#inspectCsvw>
                        <#substituteUndefined>
                        <#filterObservationTable>
                        <#mapDimensions>
@@ -74,6 +75,7 @@
   :steps [ :stepList (
                        <#LoadCsv>
                        <#parse>
+                       <#inspectCsvw>
                        <#filterNonObservationTable>
                        <#setGraph>
                      ) ] .
@@ -86,6 +88,15 @@
   code:implementedBy [ code:link <node:barnard59-formats/csvw.js#parse> ;
                        a         code:EcmaScriptModule ] ;
   code:arguments     ( <#parseMetadata> ) .
+
+<#inspectCsvw>
+  a :Step ;
+  code:implementedBy
+    [
+      code:link <file:../lib/counters#observeCsvwMetadata> ;
+      a code:EcmaScript
+    ] ;
+.
 
 <#substituteUndefined>
   a                  :Step ;

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -683,6 +683,7 @@ graph <cube-project/ubd/jobs> {
 graph <cube-project/ubd/csv-mapping/jobs/test-job> {
   <cube-project/ubd/csv-mapping/jobs/test-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
+    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "cli-test" ;
@@ -693,10 +694,33 @@ graph <cube-project/ubd/csv-mapping/jobs/test-job> {
   .
 }
 
+<cube-project/ubd/csv-mapping/jobs/failed-job> void:inDataset <ubd-example> .
+graph <cube-project/ubd/csv-mapping/jobs/failed-job> {
+  <cube-project/ubd/csv-mapping/jobs/failed-job>
+    a hydra:Resource, cc:Job, cc:TransformJob ;
+    cc:project <cube-project/ubd> ;
+    cc:tables <cube-project/ubd/csv-mapping/tables> ;
+    cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
+    schema:name "failed job" ;
+    cc:cubeGraph <cube-project/ubd/cube-data> ;
+    dcterms:created "2020-10-29T11:01:54"^^xsd:dateTime ;
+    rdfs:seeAlso <https://github.com/zazuko/cube-creator/actions/runs/345020887> ;
+    schema:actionStatus schema:FailedActionStatus ;
+    schema:error
+      [
+        a schema:Thing ;
+        schema:name "Tast error" ;
+        schema:disambiguatingDescription "Failed to process for 1234" ;
+        schema:description "The error stack trace" ;
+      ] ;
+  .
+}
+
 <cube-project/ubd/csv-mapping/jobs/hung-job> void:inDataset <ubd-example> .
 graph <cube-project/ubd/csv-mapping/jobs/hung-job> {
   <cube-project/ubd/csv-mapping/jobs/hung-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
+    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "hung job" ;
@@ -712,6 +736,7 @@ graph <cube-project/ubd/csv-mapping/jobs/active-job> {
   <cube-project/ubd/csv-mapping/jobs/active-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
+    cc:project <cube-project/ubd> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "active job job" ;
     cc:cubeGraph <cube-project/ubd/cube-data> ;
@@ -728,6 +753,7 @@ graph <cube-project/ubd/csv-mapping/jobs/broken-job> {
     cc:tables <cube-project/ubd/csv-mapping/no-tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "cli-test" ;
+    cc:project <cube-project/ubd> ;
   .
 }
 

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -5,6 +5,7 @@ import { RdfResourceCore } from '@tpluscode/rdfine/RdfResource'
 import { hydra, sh } from '@tpluscode/rdf-ns-builders'
 import { ShapeBundle } from '@rdfine/shacl/bundles'
 import type { Shape } from '@rdfine/shacl'
+import { ThingMixin } from '@rdfine/schema'
 import { Store } from 'vuex'
 import store from '@/store'
 import { RootState } from '@/store/types'
@@ -36,6 +37,7 @@ Hydra.resources.factory.addMixin(TableMixin)
 Hydra.resources.factory.addMixin(JobCollectionMixin)
 Hydra.resources.factory.addMixin(OperationMixin)
 Hydra.resources.factory.addMixin(...ShapeBundle)
+Hydra.resources.factory.addMixin(ThingMixin)
 
 // Inject the access token in all requests if present
 Hydra.defaultHeaders = ({ uri }) => prepareHeaders(uri, store)

--- a/ui/src/views/Job.vue
+++ b/ui/src/views/Job.vue
@@ -8,6 +8,9 @@
       <p class="has-text-grey-dark">
         Triggered at {{ job.created | format-date }}
       </p>
+      <p v-if="job.error && job.error.disambiguatingDescription" class="has-background-danger-light">
+        {{ job.error.disambiguatingDescription }}
+      </p>
     </header>
     <div class="is-flex gap-1">
       <b-tag v-if="job.revision">
@@ -42,8 +45,8 @@
         <b-icon icon="book" />
         <span>View full log</span>
       </a>
-      <pre v-show="error" class="has-background-danger-light">
-        {{ error }}
+      <pre v-if="error" v-show="error" class="has-background-danger-light">
+        {{ error.description }}
       </pre>
     </div>
   </div>
@@ -52,7 +55,7 @@
 
 <script lang="ts">
 import { Job } from '@cube-creator/model'
-import { CreativeWork } from '@rdfine/schema'
+import type { CreativeWork, Thing } from '@rdfine/schema'
 import { schema } from '@tpluscode/rdf-ns-builders'
 import { Component, Vue } from 'vue-property-decorator'
 import ExternalTerm from '@/components/ExternalTerm.vue'
@@ -80,8 +83,8 @@ export default class JobView extends Vue {
     return this.job?.link?.id.value
   }
 
-  get error (): string | undefined {
-    return this.job?.error?.pointer.out(schema.description).value
+  get error (): Thing | undefined {
+    return this.job?.error
   }
 }
 </script>


### PR DESCRIPTION
As the transformation job runs, this inspects the `csvw:rownum` quads and keeps track of where in the CSV the pipeline is at any given moment

In case of an error, this information is added to the job and displayed in the UI