### PR TITLE
chore: avoid duplicate test runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   unit-test:


### PR DESCRIPTION
This should avoid running all the workflows twice in each pull request.