### PR TITLE
fix: optimize loading of property operations

### DIFF
--- a/.changeset/heavy-laws-reply.md
+++ b/.changeset/heavy-laws-reply.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Performance boost for some requests (project details, metadata, export)

--- a/apis/core/index.ts
+++ b/apis/core/index.ts
@@ -19,10 +19,16 @@ import { expectsDisambiguate, preferHydraCollection } from './lib/middleware/ope
 import { errorMappers } from '@cube-creator/api-errors'
 import './lib/domain'
 import upload from './lib/upload'
+import Loader from './lib/Loader'
 
 const apiPath = path.resolve(__dirname, 'hydra')
 const codePath = path.resolve(__dirname, 'lib')
 const baseUri = env.API_CORE_BASE
+const endpointUrl = env.STORE_QUERY_ENDPOINT
+const updateUrl = env.STORE_UPDATE_ENDPOINT
+const storeUrl = env.STORE_GRAPH_ENDPOINT
+const user = env.maybe.STORE_ENDPOINTS_USERNAME
+const password = env.maybe.STORE_ENDPOINTS_PASSWORD
 
 async function main() {
   log('Starting Core API. Environment %s', env.production ? 'production' : 'development')
@@ -75,11 +81,11 @@ async function main() {
     codePath,
     baseUri,
     sparql: {
-      endpointUrl: env.STORE_QUERY_ENDPOINT,
-      updateUrl: env.STORE_UPDATE_ENDPOINT,
-      storeUrl: env.STORE_GRAPH_ENDPOINT,
-      user: env.maybe.STORE_ENDPOINTS_USERNAME,
-      password: env.maybe.STORE_ENDPOINTS_PASSWORD,
+      endpointUrl,
+      updateUrl,
+      storeUrl,
+      user,
+      password,
     },
     middleware: {
       operations: [
@@ -87,6 +93,11 @@ async function main() {
         expectsDisambiguate,
       ],
     },
+    loader: new Loader({
+      endpointUrl,
+      user,
+      password,
+    }),
   }))
 
   app.use(Sentry.Handlers.errorHandler())

--- a/apis/core/lib/Loader.ts
+++ b/apis/core/lib/Loader.ts
@@ -1,0 +1,68 @@
+import { SparqlQueryLoader } from '@hydrofoil/labyrinth/lib/loader'
+import { NamedNode } from 'rdf-js'
+import { PropertyResource, Resource } from 'hydra-box'
+import ParsingClient from 'sparql-http-client/ParsingClient'
+import { SELECT } from '@tpluscode/sparql-builder'
+import $rdf from 'rdf-ext'
+import TermSet from '@rdfjs/term-set'
+import TermMap from '@rdfjs/term-map'
+
+interface CreateResourceGetters {
+  (term: NamedNode): Pick<Resource, 'dataset' | 'quadStream'>
+}
+
+export default class Loader extends SparqlQueryLoader {
+  async forPropertyOperation(term: NamedNode): Promise<PropertyResource[]> {
+    const client: ParsingClient = (this as any).__client
+    const createDatasetGetters: CreateResourceGetters = (this as any).__createDatasetGetters.bind(this)
+
+    const links = await SELECT`?parent ?link`
+      .WHERE`
+        graph ?parent {
+          ?parent ?link ${term}
+        }
+      `.execute(client.query)
+
+    const resources = links.reduce((set, { parent, link }) => {
+      if (parent.termType !== 'NamedNode' || link.termType !== 'NamedNode') {
+        return set
+      }
+
+      const resource = set.get(parent) || {
+        term: parent,
+        property: link,
+        object: term,
+        prefetchDataset: $rdf.dataset(),
+        types: new TermSet(),
+        ...createDatasetGetters(parent),
+      }
+
+      resource.prefetchDataset.add($rdf.quad(parent, link, term))
+
+      return set.set(parent, resource)
+    }, new TermMap<NamedNode, PropertyResource>())
+
+    const typesQuery = [...resources.keys()].reduce((query, graph) => {
+      return query.FROM().NAMED(graph)
+    }, SELECT`?parent ?type`
+      .WHERE`
+        graph ?parent {
+          ?parent a ?type
+        }
+      `)
+
+    const types = await typesQuery.execute(client.query)
+    for (const { parent, type } of types) {
+      if (parent.termType !== 'NamedNode' || type.termType !== 'NamedNode') {
+        continue
+      }
+      const resource = resources.get(parent)
+      resource?.types.add(type)
+      if (type.termType === 'NamedNode') {
+        resource?.types.add(type)
+      }
+    }
+
+    return [...resources.values()]
+  }
+}


### PR DESCRIPTION
Extends and reimplements the `forPropertyOperation` method of [SparqlQueryLoader](https://github.com/hypermedia-app/creta/blob/v0.4.1/lib/loader.ts#L71-L104)

By splitting the query in two we will greatly reduce the load times. In an example project the cut is from 3s to around 150 ms total