### PR TITLE
fix: cube:Undefined for broken references

### DIFF
--- a/.changeset/seven-moose-develop.md
+++ b/.changeset/seven-moose-develop.md
@@ -1,0 +1,6 @@
+---
+"@cube-creator/core-api": patch
+"@cube-creator/cli": patch
+---
+
+Reference columns would produce incorrect URLs when referenced columns were empty (fixes #789)

--- a/apis/core/lib/csvw-builder/index.ts
+++ b/apis/core/lib/csvw-builder/index.ts
@@ -20,6 +20,7 @@ import { warning } from '../log'
 import { Term } from 'rdf-js'
 import { findOrganization } from '../domain/organization/query'
 import { DefaultCsvwLiteral } from '@cube-creator/core/mapping'
+import { qudt } from '@tpluscode/rdf-ns-builders/strict'
 
 RdfResource.factory.addMixin(
   ...Object.values(Csvw),
@@ -107,9 +108,10 @@ async function mappedReferenceColumn({ cubeIdentifier, organization, columnMappi
       }
     })
 
-    csvwColumn.valueUrl = uriTemplate.toAbsoluteUrl(organization.createIdentifier({
-      cubeIdentifier,
-    }).value)
+    const valueBase = organization.createIdentifier({ cubeIdentifier }).value
+    csvwColumn.valueUrl = uriTemplate.toAbsoluteUrl(valueBase)
+
+    csvwColumn[qudt.pattern.value] = uriTemplate.toRegex(valueBase)
   }
 
   return csvwColumn

--- a/cli/pipelines/main.ttl
+++ b/cli/pipelines/main.ttl
@@ -60,6 +60,7 @@
                        <#parse>
                        <#inspectCsvw>
                        <#substituteUndefined>
+                       <#substituteUndefinedReferences>
                        <#filterObservationTable>
                        <#mapDimensions>
                        <#toDataset>
@@ -77,6 +78,7 @@
                        <#parse>
                        <#inspectCsvw>
                        <#filterNonObservationTable>
+                       <#substituteUndefinedReferences>
                        <#setGraph>
                      ) ] .
 
@@ -104,6 +106,11 @@
                        a         code:EcmaScriptModule ] ;
   code:arguments     ( [ code:link <file:../lib/output-mapper#substituteUndefined> ;
                          a         code:EcmaScript ] ) .
+
+<#substituteUndefinedReferences>
+  a                  :Step ;
+  code:implementedBy [ code:link <file:../lib/output-mapper#substituteUndefinedReferences> ;
+                         a         code:EcmaScript ] .
 
 <#parseMetadata>
   a      :Pipeline, :ReadableObjectMode ;

--- a/cli/test/lib/commands/transform.test.ts
+++ b/cli/test/lib/commands/transform.test.ts
@@ -6,7 +6,7 @@ import clownface from 'clownface'
 import { ASK, DESCRIBE, SELECT } from '@tpluscode/sparql-builder'
 import namespace from '@rdfjs/namespace'
 import { Hydra } from 'alcaeus/node'
-import { csvw, rdf, rdfs, schema, sh, xsd } from '@tpluscode/rdf-ns-builders'
+import { csvw, rdf, rdfs, schema, sh, unit, xsd } from '@tpluscode/rdf-ns-builders/strict'
 import runner from '../../../lib/commands/transform'
 import { setupEnv } from '../../support/env'
 import { ccClients } from '@cube-creator/testing/lib'
@@ -72,6 +72,36 @@ describe('@cube-creator/cli/lib/commands/transform', function () {
         }, {
           path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/station'),
           hasValue: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/station/blBAS'),
+          minCount: 1,
+          maxCount: 1,
+        }, {
+          path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/canton'),
+          hasValue: cube.Undefined,
+          minCount: 1,
+          maxCount: 1,
+        }, {
+          path: rdfs.comment,
+          hasValue: $rdf.literal('', cube.Undefined),
+          minCount: 1,
+          maxCount: 1,
+        }, {
+          path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/aggregation'),
+          hasValue: 'annualmean',
+          minCount: 1,
+          maxCount: 1,
+        }, {
+          path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/dimension/limitvalue'),
+          hasValue: 30,
+          minCount: 1,
+          maxCount: 1,
+        }, {
+          path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/pollutant'),
+          hasValue: 'so2',
+          minCount: 1,
+          maxCount: 1,
+        }, {
+          path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/unit'),
+          hasValue: unit['MicroGM-PER-M3'],
           minCount: 1,
           maxCount: 1,
         }],

--- a/packages/model/lib/uriTemplateParser.d.ts
+++ b/packages/model/lib/uriTemplateParser.d.ts
@@ -4,6 +4,7 @@ export interface ParsedTemplate {
   toString(): string
   renameColumnVariable(from: string, to: string): boolean
   toAbsoluteUrl (baseUri: string): string
+  toRegex (baseUri: string): string
 }
 
 export function parse(template: string): ParsedTemplate

--- a/packages/model/lib/uriTemplateParser.js
+++ b/packages/model/lib/uriTemplateParser.js
@@ -40,6 +40,12 @@ class ParsedTemplateWrapper {
 
     return baseUri + this.toString()
   }
+
+  toRegex(baseUri) {
+    const absolute = this.toAbsoluteUrl(baseUri)
+
+    return '^' + absolute.replace(/{[^/]+}/g, '.+') + '$'
+  }
 }
 
 export function parse(template) {

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -18,6 +18,8 @@
   "devDependencies": {
     "@types/clownface": "^1",
     "@types/is-uri": "^1",
-    "@types/rdf-js": "^4.0.0"
+    "@types/rdf-js": "^4.0.0",
+    "chai": "^4.3.4",
+    "mocha": "^9.0.3"
   }
 }

--- a/packages/model/test/lib/uriTemplateParser.test.ts
+++ b/packages/model/test/lib/uriTemplateParser.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from 'mocha'
+import { expect } from 'chai'
+import { parse } from '../../lib/uriTemplateParser'
+
+describe('@cube-creator/model/lib/uriTemplateParser', () => {
+  describe('ParsedTemplateWrapper', () => {
+    describe('toRegex', () => {
+      it('creates pattern which does not match URI with missing segment in the middle', () => {
+        // given
+        const template = parse('{foo}/{bar}')
+
+        // when
+        const regex = new RegExp(template.toRegex('http://example.com'))
+
+        // then
+        expect('http://example.com//bar').not.to.match(regex)
+      })
+
+      it('creates pattern which does not match URI with missing segment at the end', () => {
+        // given
+        const template = parse('{foo}/{bar}')
+
+        // when
+        const regex = new RegExp(template.toRegex('http://example.com'))
+
+        // then
+        expect('http://example.com/foo/').not.to.match(regex)
+      })
+
+      it('creates pattern which matches correct URI', () => {
+        // given
+        const template = parse('{foo}/{bar}')
+
+        // when
+        const regex = new RegExp(template.toRegex('http://example.com'))
+
+        // then
+        expect('http://example.com/foo/bar').to.match(regex)
+      })
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -10476,16 +10476,16 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-mocha@^9.0.0:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.0.3.tgz#128cd6bbd3ee0adcdaef715f357f76ec1e6227c7"
-  integrity sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==
+mocha@^9.0.0, mocha@^9.0.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.1.3.tgz#8a623be6b323810493d8c8f6f7667440fa469fdb"
+  integrity sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==
   dependencies:
     "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
     chokidar "3.5.2"
-    debug "4.3.1"
+    debug "4.3.2"
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
@@ -10496,12 +10496,11 @@ mocha@^9.0.0:
     log-symbols "4.1.0"
     minimatch "3.0.4"
     ms "2.1.3"
-    nanoid "3.1.23"
+    nanoid "3.1.25"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
     which "2.0.2"
-    wide-align "1.1.3"
     workerpool "6.1.5"
     yargs "16.2.0"
     yargs-parser "20.2.4"
@@ -10641,7 +10640,7 @@ nanoid@3.1.23:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
   integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
 
-nanoid@^3.1.16, nanoid@^3.1.20, nanoid@^3.1.23:
+nanoid@3.1.25, nanoid@^3.1.16, nanoid@^3.1.20, nanoid@^3.1.23:
   version "3.1.25"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==


### PR DESCRIPTION
This will replace incomplete referenced URIs with `cube:Undefined` if any referenced column is empty

To do that, a regular expression will be added to the CSVW columns. For example, a template `/resource/{NAME}/{ID}` will add a regex pattern `^/resource/.+/.+$` (will actually include the full domain)

This way, transformed values for the column's property which do not satisfy that regex will be identified as incomplete, and replaced with `cube:Undefined`