### PR TITLE
chore: inform about the "soft" dimension type sync

### DIFF
--- a/.changeset/neat-months-teach.md
+++ b/.changeset/neat-months-teach.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Inform on Cube Designer that dimension kind has default value (re #920)

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -108,6 +108,7 @@ ${shape('dimension/metadata')} {
       ${sh.order} 15 ;
     ] , [
       ${sh.name} "Dimension type" ;
+      ${sh.description} "The type is preselected to match the same selection made in the CSV Mapping tab (when applicable)" ;
       ${sh.path} ${rdf.type} ;
       ${sh.in} (
         ${cube.MeasureDimension}


### PR DESCRIPTION
The new description will be shown on the dimension metadata form