### PR TITLE
feat(cli): cut-off point for sh:in size

### DIFF
--- a/.changeset/red-zebras-boil.md
+++ b/.changeset/red-zebras-boil.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": minor
+---
+
+Do not produce overly large RDF lists in Cube's constraint shape (fixes #966)

--- a/cli/lib/toCubeShape/Cube.js
+++ b/cli/lib/toCubeShape/Cube.js
@@ -13,11 +13,11 @@ class Cube {
     this.dimensions = new TermMap()
   }
 
-  dimension({ predicate, object }) {
+  dimension({ predicate, object }, { inListThreshold }) {
     let dimension = this.dimensions.get(predicate)
 
     if (!dimension) {
-      dimension = new Dimension({ predicate, object })
+      dimension = new Dimension({ predicate, object }, { inListThreshold })
 
       this.dimensions.set(predicate, dimension)
     }
@@ -25,8 +25,8 @@ class Cube {
     return dimension
   }
 
-  update({ predicate, object }) {
-    this.dimension({ predicate, object }).update({ predicate, object })
+  update({ predicate, object }, { inListThreshold }) {
+    this.dimension({ predicate, object }, { inListThreshold }).update({ predicate, object })
   }
 
   toDataset() {

--- a/cli/lib/toCubeShape/Dimension.js
+++ b/cli/lib/toCubeShape/Dimension.js
@@ -1,4 +1,3 @@
-const { cube } = require('@cube-creator/core/namespace')
 const clownface = require('clownface')
 const rdf = require('rdf-ext')
 const TermSet = require('@rdfjs/term-set')
@@ -42,7 +41,7 @@ class Dimension {
       this.minValue = value
       this.max = object
       this.maxValue = value
-    } else if (!object.datatype || !cube.Undefined.equals(object.datatype)) {
+    } else {
       this.in = new TermSet()
     }
   }
@@ -93,10 +92,8 @@ class Dimension {
       ptr.addOut(ns.sh.datatype, datatypes[0])
     }
 
-    if (this.in) {
-      if (this.in.size < this.inListThreshold) {
-        ptr.addList(ns.sh.in, [...this.in.values()])
-      }
+    if (!this.min && !this.max && this.in?.size < this.inListThreshold) {
+      ptr.addList(ns.sh.in, [...this.in.values()])
     }
 
     if (this.min) {

--- a/cli/lib/toCubeShape/Dimension.js
+++ b/cli/lib/toCubeShape/Dimension.js
@@ -23,10 +23,11 @@ const datatypeParsers = (datatype) => {
 }
 
 class Dimension {
-  constructor({ predicate, object }) {
+  constructor({ predicate, object }, { inListThreshold }) {
     this.predicate = predicate
     this.termType = object.termType
     this.datatypes = new TermSet()
+    this.inListThreshold = inListThreshold
 
     if (object.datatype) {
       this.datatypes.add(object.datatype)
@@ -93,7 +94,11 @@ class Dimension {
     }
 
     if (this.in) {
-      ptr.addList(ns.sh.in, [...this.in.values()])
+      if (this.in.size < this.inListThreshold) {
+        ptr.addList(ns.sh.in, [...this.in.values()])
+      }
+
+      ptr.addOut(cube.dimensionSize, this.in.size)
     }
 
     if (this.min) {

--- a/cli/lib/toCubeShape/Dimension.js
+++ b/cli/lib/toCubeShape/Dimension.js
@@ -97,8 +97,6 @@ class Dimension {
       if (this.in.size < this.inListThreshold) {
         ptr.addList(ns.sh.in, [...this.in.values()])
       }
-
-      ptr.addOut(cube.dimensionSize, this.in.size)
     }
 
     if (this.min) {

--- a/cli/lib/toCubeShape/index.js
+++ b/cli/lib/toCubeShape/index.js
@@ -33,7 +33,7 @@ function defaultShape({ term }) {
 }
 
 class ToCubeShape extends Transform {
-  constructor({ cube, excludeValuesOf } = {}) {
+  constructor({ cube, excludeValuesOf, inListThreshold = 100 } = {}) {
     super({ objectMode: true })
 
     this.options = {
@@ -41,6 +41,7 @@ class ToCubeShape extends Transform {
       cube: cube || defaultCube,
       shape: defaultShape,
       excludeValuesOf: new TermSet(excludeValuesOf ? excludeValuesOf.map(v => rdf.namedNode(v)) : []),
+      inListThreshold,
     }
   }
 
@@ -69,7 +70,7 @@ class ToCubeShape extends Transform {
 
     for (const quad of context.dataset.match(context.ptr.term)) {
       if (!this.options.excludeValuesOf.has(quad.predicate)) {
-        context.cube.update(quad)
+        context.cube.update(quad, { inListThreshold: this.options.inListThreshold })
       }
     }
 

--- a/cli/lib/toCubeShape/index.js
+++ b/cli/lib/toCubeShape/index.js
@@ -33,7 +33,7 @@ function defaultShape({ term }) {
 }
 
 class ToCubeShape extends Transform {
-  constructor({ cube, excludeValuesOf, inListThreshold = 100 } = {}) {
+  constructor({ cube, excludeValuesOf, inListThreshold } = {}) {
     super({ objectMode: true })
 
     this.options = {
@@ -86,8 +86,8 @@ class ToCubeShape extends Transform {
   }
 }
 
-function toCubeShape({ cube, excludeValuesOf } = {}) {
-  return new ToCubeShape({ cube, excludeValuesOf })
+function toCubeShape({ cube, excludeValuesOf, inListThreshold = 100 } = {}) {
+  return new ToCubeShape({ cube, excludeValuesOf, inListThreshold })
 }
 
 module.exports = toCubeShape


### PR DESCRIPTION
This PR excludes dimension's `sh:in` constraint when the number of distinct values exceeds a configurable threshold. By default `100`