### PR TITLE
fix: shared dim export without shape

### DIFF
--- a/.changeset/gentle-lions-impress.md
+++ b/.changeset/gentle-lions-impress.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Simplifies the Shared Dimension export to not include the SHACL shapes and resolve the `Every term and term set must have a shape` error on import

--- a/apis/shared-dimensions/lib/domain/shared-dimension/importShapes.ttl
+++ b/apis/shared-dimensions/lib/domain/shared-dimension/importShapes.ttl
@@ -122,16 +122,6 @@
   sh:targetClass md:SharedDimension, md:SharedDimensionTerm ;
   sh:property
     [
-      sh:name "Target Node" ;
-      sh:path
-        [
-          sh:inversePath sh:targetNode ;
-        ] ;
-      sh:minCount 1 ;
-      sh:maxCount 1 ;
-      sh:message "Every term and term set must have a shape" ;
-    ],
-    [
       sh:path schema:validFrom ;
       sh:datatype xsd:dateTime ;
       sh:maxCount 1 ;

--- a/apis/shared-dimensions/lib/handlers/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimension.ts
@@ -64,6 +64,7 @@ export const getExport = protectedResource(cors({ exposedHeaders: 'content-dispo
       schema: ns.schema().value,
       sh: ns.sh().value,
       rdf: ns.rdf().value,
+      rdfs: ns.rdfs().value,
       xsd: ns.xsd().value,
       hydra: ns.hydra().value,
     },

--- a/apis/shared-dimensions/lib/resource.ts
+++ b/apis/shared-dimensions/lib/resource.ts
@@ -1,0 +1,81 @@
+import { sparql, SparqlTemplateResult } from '@tpluscode/rdf-string'
+import { sh } from '@tpluscode/rdf-ns-builders'
+import { BlankNode, NamedNode, Term } from 'rdf-js'
+import clownface, { AnyPointer, GraphPointer } from 'clownface'
+import { nanoid } from 'nanoid'
+import TermSet from '@rdfjs/term-set'
+import $rdf from 'rdf-ext'
+
+export function resourceQueryPatterns(resourceOrPattern: NamedNode | SparqlTemplateResult, strict: boolean) {
+  let rootPropPatterns = sparql`?term ?rootProp ?rootObject .`
+  if (!strict) {
+    rootPropPatterns = sparql`OPTIONAL { ${rootPropPatterns} }`
+  }
+
+  const termPattern = 'termType' in resourceOrPattern
+    ? sparql`BIND( ${resourceOrPattern} as ?term )`
+    : resourceOrPattern
+
+  return sparql`
+    ${termPattern}
+
+    ?rootShape ${sh.targetNode} ?term .
+    MINUS {
+      # Exclude shapes which are children of property shapes
+      ?propertyShape ${sh.node} ?rootShape .
+    }
+
+    OPTIONAL { ?rootShape ${sh.property}/${sh.path} ?rootProp . }
+    ${rootPropPatterns}
+
+    OPTIONAL {
+      ?rootShape (${sh.property}/${sh.node})+ ?childPropShape .
+      ?childPropShape ${sh.targetNode} ?child .
+      ?childPropShape ${sh.property}/${sh.path} ?childProp .
+      ?child ?childProp ?childObject .
+    }`
+}
+
+function isResource(arg: Term): arg is NamedNode | BlankNode {
+  return arg.termType === 'BlankNode' || arg.termType === 'NamedNode'
+}
+
+export function extractShape(
+  resource: GraphPointer,
+  ptr: AnyPointer = clownface({ dataset: $rdf.dataset() }),
+  visited = new TermSet(),
+): GraphPointer {
+  const shape = ptr.namedNode(`urn:shape:${nanoid()}`)
+  if (visited.has(resource.term)) {
+    return shape
+  }
+
+  visited.add(resource.term)
+  if (!resource.out().terms.length) {
+    return shape
+  }
+
+  shape.addOut(sh.targetNode, resource.term)
+  const visitedPredicates = new TermSet()
+  for (const { predicate, object } of resource.dataset.match(resource.term)) {
+    if (!isResource(object) && visitedPredicates.has(predicate)) {
+      continue
+    }
+
+    visitedPredicates.add(predicate)
+    shape.addOut(sh.property, $rdf.namedNode(`urn:shape:${nanoid()}`), property => {
+      property.addOut(sh.path, predicate)
+
+      if (isResource(object)) {
+        const childShape = extractShape(resource.node(object), ptr, visited)
+
+        if (childShape.out().terms.length) {
+          property.addOut(sh.node, childShape)
+        }
+      }
+    })
+  }
+
+  shape.addOut(sh.targetNode, resource)
+  return shape
+}

--- a/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
+++ b/apis/shared-dimensions/test/lib/domain/managed-dimension.test.ts
@@ -227,16 +227,6 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       expect(termSet.in(schema.inDefinedTermSet).terms).to.have.length(3)
     })
 
-    it('exports shapes for set and terms', () => {
-      const graph = clownface({ dataset })
-      const termSet = graph.node(termSetId)
-      const terms = termSet.in(schema.inDefinedTermSet)
-      const haveShape = graph.node([termSet, ...terms.toArray()])
-
-      // then
-      expect(haveShape.in(sh.targetNode).terms).to.have.length(4)
-    })
-
     it('exports dimension properties', () => {
       const dimension = clownface({ dataset }).node(termSetId)
 
@@ -287,7 +277,7 @@ describe('@cube-creator/shared-dimensions-api/lib/domain/shared-dimension', () =
       const report = await validateTermSet(termSet)
 
       // then
-      const messages = report.results.flatMap(({ message }) => message.map(({ value }) => value))
+      const messages = report.results.flatMap(({ path, message }) => `${path?.value}: ${message.map(({ value }) => value)}`)
       expect(report.conforms).to.eq(true, messages.join('\n'))
     })
   })

--- a/fuseki/shared-dimensions.trig
+++ b/fuseki/shared-dimensions.trig
@@ -76,7 +76,7 @@ graph <https://lindas.admin.ch/cube/dimension> {
     a schema:DefinedTermSet, meta:SharedDimension, hydra:Resource, md:SharedDimension ;
     schema:name "Technologies"@en ;
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
-    sh:property [] ;
+    sh:property <urn:technologies:defaultMetadata> ;
   .
 
   [
@@ -84,7 +84,8 @@ graph <https://lindas.admin.ch/cube/dimension> {
     sh:property
       [ sh:path schema:name ],
       [ sh:path rdf:type ],
-      [ sh:path schema:validFrom ] ;
+      [ sh:path schema:validFrom ] ,
+      [ sh:path sh:property ] ;
   ] .
 
   <technologies/rdf>


### PR DESCRIPTION
This finally improves the shared dimension export:

1. No longer export the generated shapes describing resource (only resource data). The shapes will be recalculated on import (see the extracted function `extractShape`)
2. The exported resources are loaded from store in the same way we do for `GET` requests, hence re-used the `resourceQueryPatterns` method

This PR is instrumental in completing #970 so that the dynamic properties will be properly exported but I did not want to mix up these changes