### PR TITLE
Remove `sh:targetClass` from nested shape

### DIFF
--- a/apis/core/bootstrap/shapes/dataset.ts
+++ b/apis/core/bootstrap/shapes/dataset.ts
@@ -320,22 +320,22 @@ ${shapeId} {
   .
 
   ${vcardOrganization} a ${sh.NodeShape} ;
-  ${rdfs.label} "Organization" ;
-  ${sh.property} [
-    ${sh.name} "Name" ;
-    ${sh.path} ${vcard.fn} ;
-    ${sh.minCount} 1 ;
-    ${sh.maxCount} 1 ;
-    ${sh.order} 10 ;
+    ${rdfs.label} "Organization" ;
+    ${sh.property} [
+      ${sh.name} "Name" ;
+      ${sh.path} ${vcard.fn} ;
+      ${sh.minCount} 1 ;
+      ${sh.maxCount} 1 ;
+      ${sh.order} 10 ;
+      ] ;
+    ${sh.property} [
+      ${sh.name} "Email " ;
+      ${sh.path} ${vcard.hasEmail} ;
+      ${sh.minCount} 1 ;
+      ${sh.maxCount} 1 ;
+      ${sh.order} 20 ;
     ] ;
-  ${sh.property} [
-    ${sh.name} "Email " ;
-    ${sh.path} ${vcard.hasEmail} ;
-    ${sh.minCount} 1 ;
-    ${sh.maxCount} 1 ;
-    ${sh.order} 20 ;
-  ] ;
-.
+  .
 
 
 <https://ld.admin.ch/application/visualize> a skos:Concept ;

--- a/apis/core/bootstrap/shapes/dataset.ts
+++ b/apis/core/bootstrap/shapes/dataset.ts
@@ -300,7 +300,6 @@ ${shapeId} {
   .
 
   ${temporalFromTo} a ${sh.NodeShape} ;
-    ${sh.targetClass} ${dcterms.PeriodOfTime} ;
     ${rdfs.label} "Data converage" ;
     ${sh.property} [
       ${sh.name} "Start date" ;
@@ -321,7 +320,6 @@ ${shapeId} {
   .
 
   ${vcardOrganization} a ${sh.NodeShape} ;
-  ${sh.targetClass} ${vcard.Organization} ;
   ${rdfs.label} "Organization" ;
   ${sh.property} [
     ${sh.name} "Name" ;


### PR DESCRIPTION
I noticed the issue while tested the new nested validation results. `sh:targetClass` would cause the nested shape to be applied twice: once because of `sh:node` and once because of `sh:targetClass`. The validation results would also appear twice: once at the root of the report because of `sh:targetClass`, and once nested because of `sh:node`.