### PR TITLE
fix: "disappearing" CSVs

### DIFF
--- a/.changeset/twenty-plums-grin.md
+++ b/.changeset/twenty-plums-grin.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+When projects were imported in same environment, newly uploaded CSVs would remove the originals exported project. (fixes #861)

--- a/apis/core/lib/domain/csv-source/delete.ts
+++ b/apis/core/lib/domain/csv-source/delete.ts
@@ -34,9 +34,10 @@ export async function deleteSource({
   }
 
   // Delete S3 resource
-  const storage = getStorage(csvSource.associatedMedia)
-  await storage.delete(csvSource.associatedMedia)
-
+  if (csvSource.associatedMedia) {
+    const storage = getStorage(csvSource.associatedMedia)
+    await storage.delete(csvSource.associatedMedia)
+  }
   // Delete links from in csv-mapping
   const csvMapping = csvSource.csvMapping.id
   if (csvMapping) {

--- a/apis/core/lib/domain/csv-source/replace.ts
+++ b/apis/core/lib/domain/csv-source/replace.ts
@@ -37,8 +37,10 @@ export async function replaceFile({
     await validateNewFile(csvSource, newMedia, newStorage)
 
     // Delete old file
-    const oldStorage = getStorage(csvSource.associatedMedia)
-    oldStorage.delete(csvSource.associatedMedia)
+    if (csvSource.associatedMedia) {
+      const oldStorage = getStorage(csvSource.associatedMedia)
+      await oldStorage.delete(csvSource.associatedMedia)
+    }
 
     const sourceKind = newMedia.sourceKind
     const key = newMedia.identifierLiteral
@@ -49,7 +51,7 @@ export async function replaceFile({
 
     return csvSource.pointer
   } catch (e) {
-    newStorage.delete(newMedia)
+    await newStorage.delete(newMedia)
     throw e
   }
 }

--- a/apis/core/lib/domain/csv-source/update.ts
+++ b/apis/core/lib/domain/csv-source/update.ts
@@ -26,7 +26,7 @@ export async function update({
   const csvSource = await store.getResource<CsvSource>(resource.term)
 
   csvSource.name = changed.name
-  if (csvSource.setDialect(changed.dialect) && csvSource.associatedMedia.identifierLiteral) {
+  if (csvSource.setDialect(changed.dialect) && csvSource.associatedMedia?.identifierLiteral) {
     csvSource.pointer.deleteOut(schema.error)
     csvSource.columns = []
 
@@ -37,6 +37,10 @@ export async function update({
 }
 
 export async function createOrUpdateColumns(csvSource: CsvSource, getStorage: GetMediaStorage): Promise<void> {
+  if (!csvSource.associatedMedia) {
+    return
+  }
+
   try {
     const storage = getStorage(csvSource.associatedMedia)
     const fileStream = await storage.getStream(csvSource.associatedMedia)

--- a/apis/core/lib/domain/csv-source/upload.ts
+++ b/apis/core/lib/domain/csv-source/upload.ts
@@ -44,23 +44,25 @@ export async function createCSVSource({
 
   try {
     const media = csvSource.associatedMedia
-    const storage = getStorage(media)
-    const fileStream = await storage.getStream(media)
-    const head = await loadFileHeadString(fileStream, 500)
-    const { dialect, header, rows } = await sniffParse(head)
-    const sampleCol = sampleValues(header, rows)
+    if (media) {
+      const storage = getStorage(media)
+      const fileStream = await storage.getStream(media)
+      const head = await loadFileHeadString(fileStream, 500)
+      const { dialect, header, rows } = await sniffParse(head)
+      const sampleCol = sampleValues(header, rows)
 
-    csvSource.setDialect({
-      quoteChar: dialect.quote,
-      delimiter: dialect.delimiter,
-      header: true,
-      headerRowCount: header.length,
-    })
+      csvSource.setDialect({
+        quoteChar: dialect.quote,
+        delimiter: dialect.delimiter,
+        header: true,
+        headerRowCount: header.length,
+      })
 
-    for (let index = 0; index < header.length; index++) {
-      const name = header[index]
-      const column = csvSource.appendOrUpdateColumn({ name, order: index })
-      column.samples = sampleCol[index]
+      for (let index = 0; index < header.length; index++) {
+        const name = header[index]
+        const column = csvSource.appendOrUpdateColumn({ name, order: index })
+        column.samples = sampleCol[index]
+      }
     }
   } catch (err) {
     error(err)

--- a/apis/core/lib/domain/cube-projects/export.ts
+++ b/apis/core/lib/domain/cube-projects/export.ts
@@ -52,6 +52,20 @@ export async function getExportedProject({ resource, store, client = streamClien
       ?g != ${project.id} || ?p NOT ${IN(dcterms.creator, schema.maintainer, cc.latestPublishedRevision, rdfs.label)}
     )
 
+    # Exclude source's link to S3
+    MINUS {
+      GRAPH ?g {
+        ?s a ${cc.CSVSource} .
+        ?o ^${schema.associatedMedia} ?s .
+      }
+    }
+    MINUS {
+      GRAPH ?g { ?s ?p ?o }
+      FILTER (
+        EXISTS { GRAPH ?g { [] ${schema.associatedMedia} ?s } }
+      )
+    }
+
     FILTER (
       # Exclude project creator
       ?g != ${project.id} || ( ?g = ${project.id} && ?s = ${project.id} )

--- a/apis/core/test/domain/cube-projects/export.test.ts
+++ b/apis/core/test/domain/cube-projects/export.test.ts
@@ -112,6 +112,19 @@ describe('@cube-creator/core-api/lib/domain/cube-projects/export @SPARQL', () =>
       // then
       expect(project.out(schema.maintainer).terms).to.have.length(0)
     })
+
+    it('does not export csv S3 links', () => {
+      // given
+      const sources = clownface({ dataset })
+        .has(rdf.type, cc.CSVSource)
+      const medias = clownface({ dataset })
+        .has(schema.associatedMedia)
+
+      // then
+      expect(sources.terms).not.to.be.empty
+      expect(sources.out(schema.associatedMedia).terms).to.be.empty
+      expect(medias.terms).to.be.empty
+    })
   })
 
   describe('cc:Job', () => {

--- a/cli/lib/csv.ts
+++ b/cli/lib/csv.ts
@@ -19,7 +19,7 @@ export function openFromCsvw(this: Context) {
       return
     }
 
-    if (!representation.root.associatedMedia.contentUrl) {
+    if (!representation.root.associatedMedia?.contentUrl) {
       csvStream.emit('error', new Error('Failed to load CSV. Missing link from source'))
       return
     }

--- a/packages/model/CsvSource.ts
+++ b/packages/model/CsvSource.ts
@@ -16,7 +16,7 @@ import { blankNode } from '@rdf-esm/data-model'
 import { MediaObjectMixin } from './MediaObject'
 
 export interface CsvSource extends RdfResource {
-  associatedMedia: Schema.MediaObject
+  associatedMedia: Schema.MediaObject | undefined
   name: string
   errorMessages: string[]
   dialect: Csvw.Dialect


### PR DESCRIPTION
Prior to this PR we would export the S3 location to sources as they appeared in the original project. If said project would be imported to same environment, these files would be deleted to "make room" for new project's CSVs

This removes the actual paths to uploaded CSVs so they will not be inadvertently deleted