### PR TITLE
fix: nested errors not displaying

### DIFF
--- a/.changeset/calm-boxes-sort.md
+++ b/.changeset/calm-boxes-sort.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Fix nested errors display

--- a/ui/src/components/HydraOperationErrorResult.vue
+++ b/ui/src/components/HydraOperationErrorResult.vue
@@ -4,7 +4,7 @@
     <span v-if="usefullMessages.length === 1">
       {{ usefullMessages[0] }}
     </span>
-    <ul v-else>
+    <ul v-else class="mb-2">
       <li v-for="(message, messageIndex) in usefullMessages" :key="messageIndex">
         {{ message }}
       </li>
@@ -26,7 +26,10 @@ import type { Shape } from '@rdfine/shacl'
 import $rdf from '@rdf-esm/data-model'
 import { sh } from '@tpluscode/rdf-ns-builders'
 
-@Component
+@Component({
+  // Define `name` to allow recursive call
+  name: 'hydra-operation-error-result',
+})
 export default class HydraOperationErrorResult extends Vue {
   @Prop({ default: null }) result!: any
   @Prop({ default: null }) shape!: Shape | null


### PR DESCRIPTION
Nested errors would not display because of the way recursive components
work in Vue. For some reason, this was not happening locally when
developping. I guess compilation stripes away component name.