### PR TITLE
refactor: reduce hydra-box queries

### DIFF
--- a/.changeset/six-jobs-shout.md
+++ b/.changeset/six-jobs-shout.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Performance: Optimize queries loading resources


### PR DESCRIPTION
This greatly reduces the queries which discover potential links with hydra operations.

Since we've added activity log for resource changes, these have been constantly growing because every resource is linked to its log entries by `as:object` predicate. This PR simply excludes that link from being considered by hydra.