### PR TITLE
Remove SENTRY_URL

### DIFF
--- a/.github/workflows/docker-api.yaml
+++ b/.github/workflows/docker-api.yaml
@@ -59,6 +59,5 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: zazuko
           SENTRY_PROJECT: cube-creator-api
-          SENTRY_URL: https://sentry.zazuko.com/
         with:
           version_prefix: cube-creator-api@

--- a/.github/workflows/docker-app.yaml
+++ b/.github/workflows/docker-app.yaml
@@ -60,6 +60,5 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: zazuko
           SENTRY_PROJECT: cube-creator-app
-          SENTRY_URL: https://sentry.zazuko.com/
         with:
           version_prefix: cube-creator-app@

--- a/.github/workflows/docker-cli.yaml
+++ b/.github/workflows/docker-cli.yaml
@@ -59,6 +59,5 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: zazuko
           SENTRY_PROJECT: cube-creator-cli
-          SENTRY_URL: https://sentry.zazuko.com/
         with:
           version_prefix: cube-creator-cli@


### PR DESCRIPTION
Since we are migrating to the SaaS version of Sentry, someone needs to take care of updating the `SENTRY_AUTH_TOKEN` secret.

This pull request is removing the `SENTRY_URL` configuration, so that it points to the Sentry SaaS version.