### PR TITLE
fix: make all fields optional in CSV dialect form

### DIFF
--- a/.changeset/tender-crabs-call.md
+++ b/.changeset/tender-crabs-call.md
@@ -1,0 +1,6 @@
+---
+"@cube-creator/core-api": patch
+"@cube-creator/ui": patch
+---
+
+Make CSV delimiter and quote char optional (fixes #968)

--- a/apis/core/bootstrap/shapes/csv-source.ts
+++ b/apis/core/bootstrap/shapes/csv-source.ts
@@ -103,7 +103,6 @@ ${shapeUpdateId} {
       ${sh.name} "Delimiter" ;
       ${sh.path} ${csvw.delimiter} ;
       ${sh.datatype} ${xsd.string} ;
-      ${sh.minCount} 1 ;
       ${sh.maxCount} 1 ;
       ${sh.minLength} 1 ;
       ${sh.order} 10 ;
@@ -112,7 +111,6 @@ ${shapeUpdateId} {
       ${sh.name} "Quote char" ;
       ${sh.path} ${csvw.quoteChar} ;
       ${sh.datatype} ${xsd.string} ;
-      ${sh.minCount} 1 ;
       ${sh.maxCount} 1 ;
       ${sh.minLength} 1 ;
       ${sh.order} 20 ;

--- a/apis/core/lib/domain/csv-source/upload.ts
+++ b/apis/core/lib/domain/csv-source/upload.ts
@@ -52,8 +52,8 @@ export async function createCSVSource({
       const sampleCol = sampleValues(header, rows)
 
       csvSource.setDialect({
-        quoteChar: dialect.quote,
-        delimiter: dialect.delimiter,
+        quoteChar: dialect.quote || undefined,
+        delimiter: dialect.delimiter || undefined,
         header: true,
         headerRowCount: header.length,
       })

--- a/e2e-tests/csv-source/get-csv.hydra
+++ b/e2e-tests/csv-source/get-csv.hydra
@@ -48,8 +48,8 @@ With Class cc:CubeProject {
                     prefix cc: <https://cube-creator.zazuko.com/vocab#>
 
                     <> cc:sourceKind cc:MediaLocal ;
-                       schema:name "test1.csv" ;
-                       schema:identifier "test-data/upload-test-cube/test1.csv" ;
+                       schema:name "test.csv" ;
+                       schema:identifier "test-data/get-test-cube/test.csv" ;
                     ```
                 } => { }
             }

--- a/e2e-tests/csv-source/update.hydra
+++ b/e2e-tests/csv-source/update.hydra
@@ -51,25 +51,5 @@ With Class cc:CSVSource {
         } => {
             Expect Status 400
         }
-
-        Invoke {
-            Content-Type "text/turtle"
-
-            ```
-            base <https://cube-creator.lndo.site/>
-            prefix schema: <http://schema.org/>
-            prefix csvw: <http://www.w3.org/ns/csvw#>
-            PREFIX cc: <https://cube-creator.zazuko.com/vocab#>
-
-            <cube-project/ubd/csv-source/ubd>
-                a cc:CSVSource ;
-                schema:name "Should be because incomplete dialect" ;
-                csvw:dialect [
-                    csvw:delimiter "-" ;
-                ] .
-            ```
-        } => {
-            Expect Status 400
-        }
     }
 }

--- a/e2e-tests/csv-source/upload.hydra
+++ b/e2e-tests/csv-source/upload.hydra
@@ -56,7 +56,6 @@ With Class cc:CubeProject {
                     Expect Type <https://cube-creator.zazuko.com/vocab#CSVSource>
                     Expect Property <http://schema.org/associatedMedia>
                     Expect Property csvw:dialect {
-                        Expect Property csvw:quoteChar
                         Expect Property csvw:delimiter
                         Expect Property csvw:header
                         Expect Property csvw:headerRowCount

--- a/minio/cube-creator/test-data/get-test-cube/test.csv
+++ b/minio/cube-creator/test-data/get-test-cube/test.csv
@@ -1,0 +1,5 @@
+A,B,C
+1,'2,4',test
+1,2,test
+1,2,test1
+1,2,test2


### PR DESCRIPTION
The upload used to store "empty string" as delimiter and quote char when
they could not be determined from the file. Store `undefined` instead
and make these 2 fields optional.