### PR TITLE
fix: weird behavior in identifier template input

### DIFF
--- a/.changeset/poor-llamas-allow.md
+++ b/.changeset/poor-llamas-allow.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Fix identifier template input creating broken templates (closes #991)

--- a/ui/src/forms/editors/IdentifierTemplateEditor.vue
+++ b/ui/src/forms/editors/IdentifierTemplateEditor.vue
@@ -11,7 +11,6 @@
       :custom-formatter="formatProposition"
       placeholder="e.g. MyTable/{column_id}"
       :disabled="!source"
-      keep-first
     />
   </b-field>
 </template>
@@ -82,7 +81,10 @@ export default class extends Vue {
   }
 
   onSelect (value: string, event: Event): void {
-    event.preventDefault()
+    if (event) {
+      event.preventDefault()
+    }
+
     const inputElement = this.getInputElement()
     inputElement && inputElement.focus()
   }


### PR DESCRIPTION
The `keep-first` option would somehow find an option when no options are
actually valid, which resulted in a weird behavior when editing the
identifier.