### PR TITLE
feat: add dimension order property

### DIFF
--- a/.changeset/heavy-walls-scream.md
+++ b/.changeset/heavy-walls-scream.md
@@ -4,4 +4,4 @@
 "@cube-creator/ui": patch
 ---
 
-Add `sh:order` property on dimensions to manually define their ordering
+Add `sh:order` property on dimensions to manually define their ordering (closes #987)

--- a/.changeset/heavy-walls-scream.md
+++ b/.changeset/heavy-walls-scream.md
@@ -1,0 +1,7 @@
+---
+"@cube-creator/core-api": patch
+"@cube-creator/model": patch
+"@cube-creator/ui": patch
+---
+
+Add `sh:order` property on dimensions to manually define their ordering

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -179,12 +179,6 @@ ${shape('dimension/metadata')} {
       ${sh.maxCount} 1 ;
       ${sh.order} 40 ;
     ] , [
-      ${sh.path} ${schema.about} ;
-      ${sh.nodeKind} ${sh.IRI} ;
-      ${sh.minCount} 1 ;
-      ${sh.maxCount} 1 ;
-      ${dash.hidden} true ;
-    ] , [
       ${sh.name} "Relation to another dimension" ;
       ${sh.path} ${meta.dimensionRelation} ;
       ${sh.nodeKind} ${sh.BlankNode} ;
@@ -215,6 +209,21 @@ ${shape('dimension/metadata')} {
           ${sh.order} 20 ;
         ] ;
       ] ;
+    ] ,
+    [
+      ${sh.name} "Order" ;
+      ${sh.description} "Numerical value defining the display order of this dimension compared to other dimensions." ;
+      ${sh.path} ${sh.order} ;
+      ${sh.datatype} ${xsd.integer} ;
+      ${sh.minCount} 0 ;
+      ${sh.maxCount} 1 ;
+      ${sh.order} 60 ;
+    ] , [
+      ${sh.path} ${schema.about} ;
+      ${sh.nodeKind} ${sh.IRI} ;
+      ${sh.minCount} 1 ;
+      ${sh.maxCount} 1 ;
+      ${dash.hidden} true ;
     ] ,
     ${validateDataKindShape}
   .

--- a/packages/model/DimensionMetadata.ts
+++ b/packages/model/DimensionMetadata.ts
@@ -2,7 +2,7 @@ import * as Rdfs from '@rdfine/rdfs'
 import { Constructor, namespace, property, RdfResource } from '@tpluscode/rdfine'
 import { Mixin } from '@tpluscode/rdfine/lib/ResourceFactory'
 import { Literal, NamedNode, Term } from 'rdf-js'
-import { qudt, schema } from '@tpluscode/rdf-ns-builders'
+import { qudt, schema, sh } from '@tpluscode/rdf-ns-builders'
 import * as Thing from '@rdfine/schema/lib/Thing'
 import { cc, cube, meta } from '@cube-creator/core/namespace'
 import { initializer } from './lib/initializer'
@@ -17,6 +17,7 @@ export interface DimensionMetadata extends RdfResource {
   mappings?: NamedNode
   isKeyDimension: boolean
   isMeasureDimension: boolean
+  order?: number
 }
 
 export interface DimensionMetadataCollection extends RdfResource {
@@ -43,6 +44,9 @@ function DimensionMetadataMixin<Base extends Constructor>(base: Base): Mixin {
 
     @property({ path: cc.dimensionMapping })
     mappings?: NamedNode
+
+    @property.literal({ path: sh.order, type: Number })
+    order?: number
 
     get isMeasureDimension(): boolean {
       return this.types.has(cube.MeasureDimension)

--- a/ui/src/store/modules/project.ts
+++ b/ui/src/store/modules/project.ts
@@ -84,7 +84,16 @@ const getters: GetterTree<ProjectState, RootState> = {
   },
 
   dimensions (state) {
-    return state.dimensionMetadataCollection?.hasPart || []
+    const dimensions = state.dimensionMetadataCollection?.hasPart || []
+
+    // Sort dimensions with the following priority:
+    //   sh:order / measure dimension / key dimension / property (alphabetically)
+    return dimensions.sort((dim1, dim2) => (
+      ((dim1.order ?? Infinity) - (dim2.order ?? Infinity))) ||
+      ((dim1.isMeasureDimension ? 1 : Infinity) - (dim2.isMeasureDimension ? 1 : Infinity)) ||
+      ((dim1.isKeyDimension ? 1 : Infinity) - (dim2.isKeyDimension ? 1 : Infinity)) ||
+      dim1.about.value.localeCompare(dim2.about.value)
+    )
   },
 
   findSource (_state, getters) {

--- a/ui/src/store/serializers.ts
+++ b/ui/src/store/serializers.ts
@@ -170,6 +170,7 @@ export function serializeDimensionMetadata (dimension: DimensionMetadata): Dimen
       : undefined,
     isKeyDimension: dimension.isKeyDimension,
     isMeasureDimension: dimension.isMeasureDimension,
+    order: dimension.order,
   })
 }
 


### PR DESCRIPTION
- Add a `sh:order` property on dimension metadata (manually input in the form for now)
- Sort dimensions by
  1. Order
  2. Measure dimension
  3. Key dimension
  4. Alphabetically (property)

Part of #700, but only with the simplest UI possible: a field to enter the order value.