### PR TITLE
ci: no need to build images on PR hook

### DIFF
--- a/.github/workflows/docker-api.yaml
+++ b/.github/workflows/docker-api.yaml
@@ -6,7 +6,6 @@ on:
       - "**"
     tags:
       - "cube-creator-api/v*.*.*"
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/docker-app.yaml
+++ b/.github/workflows/docker-app.yaml
@@ -6,7 +6,6 @@ on:
       - "**"
     tags:
       - "cube-creator-app/v*.*.*"
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/docker-cli.yaml
+++ b/.github/workflows/docker-cli.yaml
@@ -6,7 +6,6 @@ on:
       - "**"
     tags:
       - "cube-creator-cli/v*.*.*"
-  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
I figure that we should only run the docker packaging on pull. Running also on PR hooks is a little pointless because the `branch` tags will be the same 