### PR TITLE
fix: leftover shapes in shared dimension DB and very slow queries

### DIFF
--- a/.changeset/bright-bikes-talk.md
+++ b/.changeset/bright-bikes-talk.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+The shared dimension API would query the store ineffectively, ultimately preventing the server from starting

--- a/apis/shared-dimensions/lib/domain/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension.ts
@@ -13,7 +13,7 @@ import { CONSTRUCT, sparql } from '@tpluscode/sparql-builder'
 import { streamClient } from '../sparql'
 import { StreamClient } from 'sparql-http-client/StreamClient'
 import TermMap from '@rdfjs/term-map'
-import { resourceQueryPatterns } from '../resource'
+import { getPatternsFromShape, resourceShapePatterns } from '../resource'
 
 export { importDimension } from './shared-dimension/import'
 
@@ -168,13 +168,19 @@ export async function getExportedDimension({ resource, store, client = streamCli
 
   const dimensionAndTerms = sparql`?term ${schema.inDefinedTermSet}* ${dimension.term} .`
 
-  const quads = await CONSTRUCT`
-    ?term ?rootProp ?rootObject .
-    ?child ?childProp ?childObject .
-  `
+  const dataset = await $rdf.dataset().import(await CONSTRUCT`?s ?p ?o`
+    .FROM(store.graph)
+    .WHERE`${resourceShapePatterns(dimensionAndTerms, true)}`
+    .execute(client.query))
+  const shapes = clownface({ dataset })
+    .has(sh.targetNode)
+    .filter(shape => !shape.in(sh.node).terms.length) // exclude nested shapes
+  const patterns = getPatternsFromShape(shapes)
+
+  const quads = await CONSTRUCT`${patterns}`
     .FROM(store.graph)
     .WHERE`
-      ${resourceQueryPatterns(dimensionAndTerms, false)}
+      ${patterns}
     `.execute(client.query)
 
   const baseUriPattern = new RegExp(`^${env.MANAGED_DIMENSIONS_BASE}`)

--- a/apis/shared-dimensions/lib/loader.ts
+++ b/apis/shared-dimensions/lib/loader.ts
@@ -8,7 +8,7 @@ import { ParsingClient } from 'sparql-http-client/ParsingClient'
 import { StreamClient } from 'sparql-http-client/StreamClient'
 import once from 'once'
 import { PassThrough } from 'stream'
-import { getQuery } from './store'
+import { resourceQuery } from './store'
 
 interface LoaderOptions {
   graph: NamedNode
@@ -37,7 +37,10 @@ export default class Loader implements HydraBox.ResourceLoader {
       return $rdf.quad(term, rdf.type, type)
     }))
 
-    const fullDataset = () => getQuery(term, this.options.graph).execute(this.options.stream.query)
+    const fullDataset = async () => {
+      const query = await resourceQuery(term, this.options.graph, this.options.sparql)
+      return query.execute(this.options.stream.query)
+    }
 
     return [{
       term,

--- a/apis/shared-dimensions/lib/resource.ts
+++ b/apis/shared-dimensions/lib/resource.ts
@@ -5,35 +5,94 @@ import clownface, { AnyPointer, GraphPointer } from 'clownface'
 import { nanoid } from 'nanoid'
 import TermSet from '@rdfjs/term-set'
 import $rdf from 'rdf-ext'
+import { CONSTRUCT, DELETE, SELECT, WITH } from '@tpluscode/sparql-builder'
+import ParsingClient from 'sparql-http-client/ParsingClient'
 
-export function resourceQueryPatterns(resourceOrPattern: NamedNode | SparqlTemplateResult, strict: boolean) {
-  let rootPropPatterns = sparql`?term ?rootProp ?rootObject .`
-  if (!strict) {
-    rootPropPatterns = sparql`OPTIONAL { ${rootPropPatterns} }`
-  }
-
+export function resourceShapePatterns(resourceOrPattern: NamedNode | SparqlTemplateResult, all = false) {
   const termPattern = 'termType' in resourceOrPattern
     ? sparql`BIND( ${resourceOrPattern} as ?term )`
     : resourceOrPattern
 
-  return sparql`
-    ${termPattern}
+  let selectRoot = SELECT`?rootShape`
+    .WHERE`
+      ${termPattern}
+      ?rootShape ${sh.targetNode} ?term .
+      MINUS {
+        # Exclude shapes which are children of property shapes
+        ?propertyShape ${sh.node} ?rootShape .
+      }
+    `
 
-    ?rootShape ${sh.targetNode} ?term .
-    MINUS {
-      # Exclude shapes which are children of property shapes
-      ?propertyShape ${sh.node} ?rootShape .
+  if (!all) {
+    selectRoot = selectRoot.LIMIT(1)
+  }
+
+  return sparql`
+    {
+      ${selectRoot}
     }
 
-    OPTIONAL { ?rootShape ${sh.property}/${sh.path} ?rootProp . }
-    ${rootPropPatterns}
+    ?rootShape (!${sh.targetNode})* ?s .
+    ?s ?p ?o .
+  `
+}
 
-    OPTIONAL {
-      ?rootShape (${sh.property}/${sh.node})+ ?childPropShape .
-      ?childPropShape ${sh.targetNode} ?child .
-      ?childPropShape ${sh.property}/${sh.path} ?childProp .
-      ?child ?childProp ?childObject .
-    }`
+function variableSequence() {
+  let N = 1
+  return () => {
+    return $rdf.variable(`value${N++}`)
+  }
+}
+
+export function getPatternsFromShape(shapes: AnyPointer, nextVariable = variableSequence()): SparqlTemplateResult[] {
+  return shapes.toArray().flatMap(shape => {
+    const node = shape.out(sh.targetNode).term
+    if (!node) {
+      return []
+    }
+
+    const property = shape.out(sh.property)
+    const childShapes = property.out(sh.node).toArray()
+
+    const ownPatterns = property.out(sh.path).map(path => {
+      return sparql`${node} ${path.term} ${nextVariable()} .`
+    })
+    const childPatterns = childShapes.flatMap(child => getPatternsFromShape(child, nextVariable))
+
+    return [
+      ...ownPatterns,
+      ...childPatterns,
+    ]
+  })
+}
+
+async function getShape(id: NamedNode, graph: NamedNode, client: ParsingClient) {
+  const dataset = $rdf.dataset(await CONSTRUCT`?s ?p ?o`
+    .FROM(graph)
+    .WHERE`${resourceShapePatterns(id)}`
+    .execute(client.query))
+  return clownface({ dataset }).has(sh.targetNode, id)
+}
+
+export async function deleteQuery(id: NamedNode, graph: NamedNode, client: ParsingClient) {
+  const shape = await getShape(id, graph, client)
+  const patterns = getPatternsFromShape(shape)
+
+  return WITH(graph, DELETE`${patterns}`.WHERE`${patterns}`)
+}
+
+export async function resourceQuery(id: NamedNode, graph: NamedNode, client: ParsingClient) {
+  const shape = await getShape(id, graph, client)
+
+  const patterns = getPatternsFromShape(shape)
+
+  return CONSTRUCT`${patterns}`
+    .FROM(graph)
+    .WHERE`${patterns}`
+}
+
+export function deleteShapesQuery(id: NamedNode, graph: NamedNode) {
+  return WITH(graph, DELETE`?s ?p ?o`.WHERE`${resourceShapePatterns(id, true)}`)
 }
 
 function isResource(arg: Term): arg is NamedNode | BlankNode {


### PR DESCRIPTION
Every resource in shared dimensions API is stored alongside a shape which describe its properties. See [the example data](https://github.com/zazuko/cube-creator/blob/8b6a59ab0c1713ccb0338beb8e78881b9048e442/fuseki/shared-dimensions.trig#L77-L102)

Until now to retrieve a resource from that API we ran a single query which used property paths to query those shapes and build patterns to get the precise triples. This same implementation was used to delete and update resources, and export a dimension

This proved quite ineffective on Stardog. I assume that SPARQL property paths are to blame. 

This PR changes the implementation so that any needed shape(s) are retrieved first with a fast `CONSTRUCT` and the SHACL properties are recessed in memory to avoid deep SPARQL Paths in `OPTIONAL` clauses. This looks somewhat like

1 Get shape for a resource 

```SPARQL
PREFIX sh: <http://www.w3.org/ns/shacl#> 

CONSTRUCT { ?s ?p ?o }  
FROM <https://lindas.admin.ch/cube/dimension> WHERE {     
  {     
    SELECT ?rootShape  WHERE {     
      BIND( <https://ld.admin.ch/cube/dimension/technologies/shacl> as ?term )    
      ?rootShape sh:targetNode ?term .  
      MINUS {      
        # Exclude shapes which are children of property shapes    
        ?propertyShape sh:node ?rootShape .
      }     
    }  
    LIMIT 1  
  }    
  ?rootShape (!sh:targetNode)* ?s .   
  ?s ?p ?o .  
} 
```

2 Get its exact data

```SPARQL
CONSTRUCT { 
  <https://ld.admin.ch/cube/dimension/technologies/shacl> schema:name ?value1 .
  <https://ld.admin.ch/cube/dimension/technologies/shacl> rdf:type ?value2 .
  # etc
}
FROM <https://lindas.admin.ch/cube/dimension> 
WHERE { 
  <https://ld.admin.ch/cube/dimension/technologies/shacl> schema:name ?value1 .
  <https://ld.admin.ch/cube/dimension/technologies/shacl> rdf:type ?value2 .
  # etc
} 
```