### PR TITLE
perf: reorder query patterns

### DIFF
--- a/cli/lib/loadCube.ts
+++ b/cli/lib/loadCube.ts
@@ -24,8 +24,8 @@ export async function loadCube(this: Pipeline.Context, { jobUri, endpoint, user,
   const project = await loadProject(jobUri, this)
 
   const patterns = sparql`
-    ?s ?p ?o .
     ?cube a ${cube.Cube} ; !${cube.observationConstraint}* ?s .
+    ?s ?p ?o .
 
     filter (?p != ${csvw.describes})`
 


### PR DESCRIPTION
I found Fuseki having issues with this query. By running the path pattern first we greatly improve performance (to put mildly, because suddenly the query stopped working on my box)

Might also be beneficial on Stardog