### PR TITLE
fix(publish): remove cube resource with a trailing slash

### DIFF
--- a/.changeset/kind-humans-yell.md
+++ b/.changeset/kind-humans-yell.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Some cubes were published with a second resource, wrongly ending with a `/`

--- a/cli/lib/cube.ts
+++ b/cli/lib/cube.ts
@@ -98,7 +98,7 @@ export async function injectRevision(this: Pick<Context, 'variables' | 'logger'>
 
   function rebase<T extends Term>(term: T, rev = revision): T {
     if (term.termType === 'NamedNode' && term.value.startsWith(cubeNamespace)) {
-      return $rdf.namedNode(term.value.replace(new RegExp(`^${cubeNamespace}/?`), `${cubeNamespace}/${rev}/`)) as any
+      return $rdf.namedNode(term.value.replace(new RegExp(`^${cubeNamespace}(/?.*)$`), `${cubeNamespace}/${rev}$1`)) as any
     }
 
     return term


### PR DESCRIPTION
Turns we have a bogus cube with ending slash for every cube we publish such as inn the local environment one would find

```diff
https://environment.ld.admin.ch/foen/ubd/28/3
-https://environment.ld.admin.ch/foen/ubd/28/3/
```

@l00mi do we want to clean them all up in live environments?