### PR TITLE
fix: do not crash when missing table identifier template

### DIFF
--- a/.changeset/strange-toys-serve.md
+++ b/.changeset/strange-toys-serve.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/model": patch
+---
+
+Do not crash when table has no identifier template

--- a/packages/model/Table.ts
+++ b/packages/model/Table.ts
@@ -55,11 +55,7 @@ export function TableMixin<Base extends Constructor>(base: Base): Mixin {
     }
 
     get parsedTemplate() {
-      if (!this.identifierTemplate) {
-        throw new Error('Table has no identifier template')
-      }
-
-      return parse(this.identifierTemplate)
+      return parse(this.identifierTemplate ?? '')
     }
   }
 


### PR DESCRIPTION
Crashing may not be the wrong behavior, but it doesn't belong in the getter of `parsedTemplate`.