### PR TITLE
fix: missing join on project's mapping resource

### DIFF
--- a/.changeset/cool-radios-tie.md
+++ b/.changeset/cool-radios-tie.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+In some cases a column was wrongly marked as key or measure dimension in the Cube Designer view (fixes #1097)

--- a/apis/core/lib/domain/queries/dimension-metadata.ts
+++ b/apis/core/lib/domain/queries/dimension-metadata.ts
@@ -83,6 +83,7 @@ export async function getDimensionTypes(metadata: GraphPointer, store: ResourceS
 
       graph ?observationTable {
         ?observationTable a ${cc.ObservationTable} ;
+                          ${cc.csvMapping} ?csvMapping ;
                           ${cc.columnMapping} ?column .
       }
 


### PR DESCRIPTION
The missing pattern joining the table to its mapping resource would produce an unwanted cross-product of columns from multiple projects.

In the case of #1097, there exists a `jahr` column in another project which is a key dimension, thus it was wrongly determined as such when setting the default value in the form