### PR TITLE
build(ui): disable hot-reload in lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -25,6 +25,9 @@ services:
     type: node:16
     command: (cd ui; yarn serve --public app.cube-creator.lndo.site --hostname 0.0.0.0 --port 80)
     ssl: true
+    overrides:
+      environment:
+        NO_WEBSOCKET: "true"
   store:
     type: compose
     services:

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -6,10 +6,18 @@ process.env.VUE_APP_VERSION = require('./package.json').version
 
 const publicPath = process.env.PUBLIC_PATH || '/'
 
+const websocketConfig = {}
+if (process.env.NO_WEBSOCKET === 'true') {
+  websocketConfig.webSocketServer = false
+  websocketConfig.hot = false
+  websocketConfig.liveReload = false
+}
+
 module.exports = {
   publicPath,
   devServer: {
     allowedHosts: 'all',
+    ...websocketConfig,
     client: {
       progress: false,
     },


### PR DESCRIPTION
As of #1095 the web app running in lands container failed trying to access the insecure `ws://` websockets (cause by upgrade to webpack 5?).

I did not find a way to switch to `wss://` so this disables the sockets completely (and thus live reload)