### PR TITLE
chore: use our own Fuseki image

### DIFF
--- a/.github/workflows/setup-env/action.yml
+++ b/.github/workflows/setup-env/action.yml
@@ -9,6 +9,10 @@ runs:
         cache: "yarn"
     - run: yarn install --ci
       shell: bash
+    - name: Set up Docker
+      uses: docker-practice/actions-setup-docker@1.0.8
+      with:
+        docker_version: 20.10.12
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Install lando

--- a/.github/workflows/setup-env/action.yml
+++ b/.github/workflows/setup-env/action.yml
@@ -21,3 +21,5 @@ runs:
     - name: Start site
       run: sh e2e-tests/start-lando.sh
       shell: bash
+      env:
+        DOCKER_BUILDKIT: "1"

--- a/.github/workflows/setup-env/action.yml
+++ b/.github/workflows/setup-env/action.yml
@@ -6,13 +6,11 @@ runs:
     - uses: actions/setup-node@v2.4.0
       with:
         node-version: 16
-        cache: 'yarn'
+        cache: "yarn"
     - run: yarn install --ci
       shell: bash
-    - name: setup-docker
-      uses: docker-practice/actions-setup-docker@1.0.4
-      with:
-        docker_version: 20.10.3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
     - name: Install lando
       run: sh e2e-tests/install-lando.sh
       shell: bash

--- a/.lando.yml
+++ b/.lando.yml
@@ -31,7 +31,7 @@ services:
   store:
     type: compose
     services:
-      image: ghcr.io/zazuko/fuseki-geosparql:v2.0.1
+      image: ghcr.io/zazuko/fuseki-geosparql:v2.0.2
       command: /opt/fuseki/entrypoint.sh
       environment:
         ADMIN_PASSWORD: password

--- a/.lando.yml
+++ b/.lando.yml
@@ -10,7 +10,7 @@ services:
     overrides:
       image: node:14
       ports:
-        - '45671:45671'
+        - "45671:45671"
       environment:
         TS_NODE_TRANSPILE_ONLY: "true"
         TS_NODE_PROJECT: apis/core/tsconfig.json
@@ -31,17 +31,14 @@ services:
   store:
     type: compose
     services:
-      image: blankdots/jena-fuseki:fuseki3.13.1
-      command: /docker-entrypoint.sh /jena-fuseki/start-fuseki.sh
+      image: ghcr.io/zazuko/fuseki-geosparql:v2.0.1
+      command: /opt/fuseki/entrypoint.sh
       environment:
         ADMIN_PASSWORD: password
-        ENABLE_DATA_WRITE: "true"
-        ENABLE_UPDATE: "true"
-        ENABLE_UPLOAD: "true"
       volumes:
-        - ./fuseki/config.ttl:/data/fuseki/config/config.ttl
+        - ./fuseki/config.ttl:/fuseki/config.ttl
       healthcheck:
-        test: wget --no-verbose --tries=1 --spider http://localhost:3030 || exit 1
+        test: wget --no-verbose --tries=1 --spider http://localhost:3030/$$/ping || exit 1
         interval: 5s
         timeout: 3s
         retries: 3
@@ -75,7 +72,7 @@ services:
         TS_NODE_TRANSPILE_ONLY: "true"
         NODE_TLS_REJECT_UNAUTHORIZED: 0
     moreHttpPorts:
-          - 45681
+      - 45681
   collector:
     type: compose
     scanner: false

--- a/.lando.yml
+++ b/.lando.yml
@@ -37,11 +37,6 @@ services:
         ADMIN_PASSWORD: password
       volumes:
         - ./fuseki/config.ttl:/fuseki/config.ttl
-      healthcheck:
-        test: wget --no-verbose --tries=1 --spider http://localhost:3030/$$/ping || exit 1
-        interval: 5s
-        timeout: 3s
-        retries: 3
   trifid:
     type: compose
     app_mount: false

--- a/.lando.yml
+++ b/.lando.yml
@@ -37,6 +37,11 @@ services:
         ADMIN_PASSWORD: password
       volumes:
         - ./fuseki/config.ttl:/fuseki/config.ttl
+      healthcheck:
+        test: wget --no-verbose --tries=1 --spider http://localhost:3030/ || exit 1
+        interval: 5s
+        timeout: 3s
+        retries: 10
   trifid:
     type: compose
     app_mount: false

--- a/.lando.yml
+++ b/.lando.yml
@@ -38,7 +38,7 @@ services:
       volumes:
         - ./fuseki/config.ttl:/fuseki/config.ttl
       healthcheck:
-        test: wget --no-verbose --tries=1 --spider http://localhost:3030/ || exit 1
+        test: wget --no-verbose --tries=1 --spider http://localhost:3030/$$/ping || exit 1
         interval: 5s
         timeout: 3s
         retries: 10

--- a/fuseki/config.ttl
+++ b/fuseki/config.ttl
@@ -7,49 +7,52 @@
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 
 [] rdf:type fuseki:Server ;
-   fuseki:services (
-                     <#cube-creator>
-                     <#shared-dimensions>
-                     <#px-cube>
-                   ) .
-
-<#cube-creator> rdf:type fuseki:Service ;
-              rdfs:label                        "Cube creator database" ;
-              fuseki:name                       "cube-creator" ;       # http://host:port/read
-              fuseki:serviceQuery               "sparql" ;   # SPARQL query service
-              fuseki:serviceQuery               "query" ;    # SPARQL query service (alt name)
-              fuseki:serviceUpdate              "update" ;   # SPARQL update service
-              fuseki:serviceUpload              "upload" ;   # Non-SPARQL upload service
-              fuseki:serviceReadWriteGraphStore "data" ;     # SPARQL Graph store protocol (read and write)
-              fuseki:dataset                    [rdf:type tdb:DatasetTDB ; tdb:location "DB1" ;] ;
+  fuseki:services (
+    <#cube-creator>
+    <#shared-dimensions>
+    <#px-cube>
+  )
 .
 
+<#cube-creator> rdf:type fuseki:Service ;
+  rdfs:label "Cube creator database" ;
+  fuseki:name "cube-creator" ;                # http://host:port/read
+  fuseki:serviceQuery "sparql" ;              # SPARQL query service
+  fuseki:serviceQuery "query" ;               # SPARQL query service (alt name)
+  fuseki:serviceUpdate "update" ;             # SPARQL update service
+  fuseki:serviceUpload "upload" ;             # Non-SPARQL upload service
+  fuseki:serviceReadWriteGraphStore "data" ;  # SPARQL Graph store protocol (read and write)
+  fuseki:dataset [
+    rdf:type tdb:DatasetTDB ;
+    tdb:location "databases/DB1" ;
+  ] ;
+.
 
 <#shared-dimensions> rdf:type fuseki:Service ;
-                     rdfs:label "Shared dimensions database" ;
-                     fuseki:name "shared-dimensions" ;       # http://host:port/read
-                     fuseki:serviceQuery "sparql" ;   # SPARQL query service
-                     fuseki:serviceQuery "query" ;    # SPARQL query service (alt name)
-                     fuseki:serviceUpdate "update" ;   # SPARQL update service
-                     fuseki:serviceUpload "upload" ;   # Non-SPARQL upload service
-                     fuseki:serviceReadWriteGraphStore "data" ;     # SPARQL Graph store protocol (read and write)
-                     fuseki:dataset [
-                                      rdf:type tdb:DatasetTDB ;
-                                      tdb:location "DB2" ;
-                                      tdb:unionDefaultGraph true ;
-                                     ] ;
+  rdfs:label "Shared dimensions database" ;
+  fuseki:name "shared-dimensions" ;           # http://host:port/read
+  fuseki:serviceQuery "sparql" ;              # SPARQL query service
+  fuseki:serviceQuery "query" ;               # SPARQL query service (alt name)
+  fuseki:serviceUpdate "update" ;             # SPARQL update service
+  fuseki:serviceUpload "upload" ;             # Non-SPARQL upload service
+  fuseki:serviceReadWriteGraphStore "data" ;  # SPARQL Graph store protocol (read and write)
+  fuseki:dataset [
+    rdf:type tdb:DatasetTDB ;
+    tdb:location "databases/DB2" ;
+    tdb:unionDefaultGraph true ;
+  ] ;
 .
 
 <#px-cube> rdf:type fuseki:Service ;
-           rdfs:label "Sample PX cube database" ;
-           fuseki:name "px-cube" ;          # http://host:port/read
-           fuseki:serviceQuery "sparql" ;   # SPARQL query service
-           fuseki:serviceQuery "query" ;    # SPARQL query service (alt name)
-           fuseki:serviceUpdate "update" ;   # SPARQL update service
-           fuseki:serviceUpload "upload" ;   # Non-SPARQL upload service
-           fuseki:serviceReadWriteGraphStore "data" ;     # SPARQL Graph store protocol (read and write)
-           fuseki:dataset [
-                            rdf:type tdb:DatasetTDB ;
-                            tdb:location "DB3" ;
-                           ] ;
+  rdfs:label "Sample PX cube database" ;
+  fuseki:name "px-cube" ;                     # http://host:port/read
+  fuseki:serviceQuery "sparql" ;              # SPARQL query service
+  fuseki:serviceQuery "query" ;               # SPARQL query service (alt name)
+  fuseki:serviceUpdate "update" ;             # SPARQL update service
+  fuseki:serviceUpload "upload" ;             # Non-SPARQL upload service
+  fuseki:serviceReadWriteGraphStore "data" ;  # SPARQL Graph store protocol (read and write)
+  fuseki:dataset [
+    rdf:type tdb:DatasetTDB ;
+    tdb:location "databases/DB3" ;
+  ] ;
 .


### PR DESCRIPTION
I wanted to check if running the application locally using `lando` on a M1 machine was working.
It was mostly the case, the only part that was broken is the store (Fuseki).

I replaced the image with the version we are maintaining ourselves, and it gives the following advantages:
- it's running on the following architectures: `amd64` and `arm64` instead of only `amd64`
- it's using the latest version of Apache Jena
- we can enable OpenTelemetry if we want