### PR TITLE
Replace Buefy with Oruga

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,6 @@
     "@uppy/vue": "^0.4.5",
     "@zazuko/rdf-vocabularies": "^2021.3.17",
     "alcaeus": "^2.1",
-    "buefy": "^0.9.5",
     "buffer": "^6.0.3",
     "bulma-quickview": "^2.0.0",
     "clownface": "^1.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,8 @@
     "@hydrofoil/shaperone-core": "^0.8.2",
     "@hydrofoil/shaperone-hydra": "^0.3.1",
     "@hydrofoil/shaperone-wc": "^0.6.3",
+    "@oruga-ui/oruga": "^0.5.4",
+    "@oruga-ui/theme-bulma": "^0.2.2",
     "@rdf-esm/data-model": "^0.5.3",
     "@rdf-esm/dataset": "^0.5.1",
     "@rdfine/schema": "^0.6.3",

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -40,13 +40,14 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
+import BLoading from '@/components/BLoading.vue'
 import NavBar from '@/components/NavBar.vue'
 import { APIErrorAuthorization } from './api/errors'
 import { Message } from './store/modules/app'
 import * as storeNs from './store/namespace'
 
 @Component({
-  components: { NavBar },
+  components: { BLoading, NavBar },
 })
 export default class App extends Vue {
   @storeNs.app.State('loading') isLoading!: boolean

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -10,14 +10,13 @@
       <o-notification
         v-for="(message, index) in messages"
         :key="index"
-        :type="message.type"
-        :class="'is-' + message.type"
+        :variant="message.variant"
         has-icon
         closable
         aria-close-label="Dismiss"
         @close="dismissMessage(message)"
-        :auto-close="message.type !== 'danger'"
-        :duration="7000"
+        :auto-close="message.variant !== 'danger'"
+        :duration="5000"
       >
         <h3 class="has-text-weight-bold">
           {{ message.title }}

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -7,19 +7,25 @@
     </div>
 
     <div class="messages">
-      <b-message
+      <o-notification
         v-for="(message, index) in messages"
         :key="index"
-        :title="message.title || ' '"
         :type="message.type"
+        :class="'is-' + message.type"
         has-icon
+        closable
         aria-close-label="Dismiss"
         @close="dismissMessage(message)"
-        :auto-close="message.type !== 'is-danger'"
+        :auto-close="message.type !== 'danger'"
         :duration="7000"
       >
-        {{ message.message }}
-      </b-message>
+        <h3 class="has-text-weight-bold">
+          {{ message.title }}
+        </h3>
+        <p>
+          {{ message.message }}
+        </p>
+      </o-notification>
     </div>
 
     <b-loading :active="isLoading" :is-full-page="true" />

--- a/ui/src/components/BLoading.vue
+++ b/ui/src/components/BLoading.vue
@@ -1,0 +1,25 @@
+<template>
+  <transition :name="animation">
+    <div
+      class="loading-overlay is-active"
+      :class="{ 'is-full-page': isFullPage }"
+      v-show="active"
+    >
+      <div class="loading-background" />
+      <slot>
+        <div class="loading-icon" />
+      </slot>
+    </div>
+  </transition>
+</template>
+
+<script lang="ts">
+import { Prop, Component, Vue } from 'vue-property-decorator'
+
+@Component
+export default class BLoading extends Vue {
+  @Prop({ default: false }) active!: boolean
+  @Prop({ default: true }) isFullPage!: boolean
+  @Prop({ default: 'fade' }) animation!: string
+}
+</script>

--- a/ui/src/components/BMessage.vue
+++ b/ui/src/components/BMessage.vue
@@ -1,0 +1,26 @@
+<template>
+  <article class="message" :class="[type, size]">
+    <header v-if="$slots.header || title" class="message-header">
+      <div v-if="$slots.header">
+        <slot name="header" />
+      </div>
+      <p v-else-if="title">
+        {{ title }}
+      </p>
+    </header>
+    <section class="message-body" v-if="$slots.default">
+      <slot />
+    </section>
+  </article>
+</template>
+
+<script lang="ts">
+import { Prop, Component, Vue } from 'vue-property-decorator'
+
+@Component
+export default class BMessage extends Vue {
+  @Prop() type?: string
+  @Prop() size?: string
+  @Prop() title?: string
+}
+</script>

--- a/ui/src/components/ButtonLoading.vue
+++ b/ui/src/components/ButtonLoading.vue
@@ -1,0 +1,44 @@
+<template>
+  <o-button
+    :native-type="nativeType"
+    :variant="variant"
+    :size="size"
+    :icon-left="icon"
+    :icon-class="iconClass"
+    :disabled="disabled || loading"
+    v-on="$listeners"
+  >
+    <slot />
+  </o-button>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import BLoading from './BLoading.vue'
+
+@Component({
+  components: { BLoading },
+})
+export default class ButtonLoading extends Vue {
+  @Prop() nativeType?: string
+  @Prop() variant?: string
+  @Prop() size?: string
+  @Prop() iconLeft?: string
+  @Prop() disabled?: boolean
+  @Prop() loading?: boolean
+
+  get icon () {
+    if (this.loading) {
+      return 'spinner'
+    } else {
+      return this.iconLeft
+    }
+  }
+
+  get iconClass () {
+    return this.loading
+      ? 'animate-spin'
+      : ''
+  }
+}
+</script>

--- a/ui/src/components/CsvSourceMapping.vue
+++ b/ui/src/components/CsvSourceMapping.vue
@@ -84,7 +84,7 @@
             </span>
           </o-checkbox>
           <div>
-            <b-tooltip
+            <o-tooltip
               v-for="{table, columnMapping} in getColumnMappings(column)"
               :key="columnMapping.id.value"
               class="source-column-mapping"

--- a/ui/src/components/CsvSourceMapping.vue
+++ b/ui/src/components/CsvSourceMapping.vue
@@ -7,16 +7,16 @@
             {{ source.name }}
           </h4>
           <div class="is-flex gap-1">
-            <b-button
+            <o-button
               v-if="tableCollection.actions.create"
               :disabled="selectedColumns.length === 0"
               tag="router-link"
               :to="{ name: 'TableCreate', query: createTableQueryParams }"
-              size="is-small"
+              size="small"
               icon-left="plus"
             >
               Create table from selected columns
-            </b-button>
+            </o-button>
             <b-dropdown position="is-bottom-left" class="has-text-weight-normal">
               <button class="button is-text is-small" slot="trigger">
                 <b-icon icon="ellipsis-h" />

--- a/ui/src/components/CsvSourceMapping.vue
+++ b/ui/src/components/CsvSourceMapping.vue
@@ -73,12 +73,16 @@
           @mouseenter="highlightArrows(column)"
           @mouseleave="unhighlightArrows(column)"
         >
-          <b-checkbox :value="selectedColumnsMap[column.clientPath]" @input="selectedColumnsMap[column.clientPath] = $event" class="source-column-name">
+          <o-checkbox
+            :value="selectedColumnsMap[column.clientPath]"
+            @input="selectedColumnsMap[column.clientPath] = $event"
+            class="source-column-name"
+          >
             {{ column.name }}
             <span class="has-text-grey" v-if="column.samples.length > 0">
               &nbsp;({{ column.samples.slice(0, 3).join(", ") }})
             </span>
-          </b-checkbox>
+          </o-checkbox>
           <div>
             <b-tooltip
               v-for="{table, columnMapping} in getColumnMappings(column)"

--- a/ui/src/components/CsvSourceMapping.vue
+++ b/ui/src/components/CsvSourceMapping.vue
@@ -44,7 +44,7 @@
             </b-dropdown>
           </div>
         </div>
-        <b-message v-if="source.errorMessages.length" type="is-danger" class="content">
+        <b-message v-if="source.errorMessages.length" type="is-danger" class="content mb-0">
           <p>An error occurred while parsing the CSV file:</p>
           <pre v-for="error in source.errorMessages" :key="error">{{ error }}</pre>
           <div class="content" v-if="source.actions.delete || source.actions.edit">
@@ -124,6 +124,7 @@
 import { Prop, Component, Vue, Watch } from 'vue-property-decorator'
 import { CsvSource, Table, TableCollection, CsvColumn, ColumnMapping } from '@cube-creator/model'
 import { isLiteralColumnMapping } from '@cube-creator/model/ColumnMapping'
+import BMessage from './BMessage.vue'
 import MapperTable from './MapperTable.vue'
 import HydraOperationButton from './HydraOperationButton.vue'
 import { api } from '@/api'
@@ -131,6 +132,7 @@ import * as storeNs from '../store/namespace'
 
 @Component({
   components: {
+    BMessage,
     MapperTable,
     HydraOperationButton,
   },

--- a/ui/src/components/CsvSourceMapping.vue
+++ b/ui/src/components/CsvSourceMapping.vue
@@ -133,6 +133,7 @@ import MapperTable from './MapperTable.vue'
 import HydraOperationButton from './HydraOperationButton.vue'
 import { api } from '@/api'
 import * as storeNs from '../store/namespace'
+import { confirmDialog } from '@/use-dialog'
 
 @Component({
   components: {
@@ -189,12 +190,10 @@ export default class CsvSourceMapping extends Vue {
   }
 
   async deleteSource (source: CsvSource): Promise<void> {
-    this.$buefy.dialog.confirm({
+    confirmDialog(this, {
       title: source.actions.delete?.title,
       message: 'Are you sure you want to delete this CSV source?',
       confirmText: 'Delete',
-      type: 'is-danger',
-      hasIcon: true,
       onConfirm: () => {
         this.$store.dispatch('api/invokeDeleteOperation', {
           operation: source.actions.delete,

--- a/ui/src/components/CsvSourceMapping.vue
+++ b/ui/src/components/CsvSourceMapping.vue
@@ -17,31 +17,31 @@
             >
               Create table from selected columns
             </o-button>
-            <b-dropdown position="is-bottom-left" class="has-text-weight-normal">
+            <o-dropdown position="bottom-left" class="has-text-weight-normal" aria-role="list">
               <button class="button is-text is-small" slot="trigger">
-                <b-icon icon="ellipsis-h" />
+                <o-icon icon="ellipsis-h" />
               </button>
-              <b-dropdown-item v-if="source.actions.edit" has-link>
-                <router-link :to="{ name: 'SourceEdit', params: { sourceId: source.clientPath } }">
-                  <b-icon icon="pencil-alt" />
+              <o-dropdown-item tag="div" item-class="p" clickable v-if="source.actions.edit">
+                <router-link class="dropdown-item" :to="{ name: 'SourceEdit', params: { sourceId: source.clientPath } }">
+                  <o-icon icon="pencil-alt" />
                   {{ source.actions.edit.title }}
                 </router-link>
-              </b-dropdown-item>
-              <b-dropdown-item v-if="source.actions.replace" has-link>
-                <router-link :to="{ name: 'SourceReplaceCSV', params: { sourceId: source.clientPath } }">
-                  <b-icon icon="upload" />
+              </o-dropdown-item>
+              <o-dropdown-item tag="div" item-class="p" v-if="source.actions.replace">
+                <router-link class="dropdown-item" :to="{ name: 'SourceReplaceCSV', params: { sourceId: source.clientPath } }">
+                  <o-icon icon="upload" />
                   {{ source.actions.replace.title }}
                 </router-link>
-              </b-dropdown-item>
-              <b-dropdown-item v-if="source.actions.download" @click="downloadSource(source)">
-                <b-icon icon="download" />
+              </o-dropdown-item>
+              <o-dropdown-item v-if="source.actions.download" @click="downloadSource(source)">
+                <o-icon icon="download" />
                 {{ source.actions.download.title }}
-              </b-dropdown-item>
-              <b-dropdown-item v-if="source.actions.delete" @click="deleteSource(source)">
-                <b-icon icon="trash" />
+              </o-dropdown-item>
+              <o-dropdown-item v-if="source.actions.delete" @click="deleteSource(source)">
+                <o-icon icon="trash" />
                 {{ source.actions.delete.title }}
-              </b-dropdown-item>
-            </b-dropdown>
+              </o-dropdown-item>
+            </o-dropdown>
           </div>
         </div>
         <b-message v-if="source.errorMessages.length" type="is-danger" class="content mb-0">

--- a/ui/src/components/CsvUploadForm.vue
+++ b/ui/src/components/CsvUploadForm.vue
@@ -9,9 +9,9 @@
     </o-tab-item>
     <o-tab-item label="URL" value="MediaURL">
       <form @submit.prevent="submitUrl">
-        <b-field label="URL">
+        <o-field label="URL">
           <b-input v-model="fileUrl" type="url" required />
-        </b-field>
+        </o-field>
         <o-button native-type="submit" variant="primary" :loading="isLoading">
           Upload
         </o-button>

--- a/ui/src/components/CsvUploadForm.vue
+++ b/ui/src/components/CsvUploadForm.vue
@@ -12,9 +12,9 @@
         <b-field label="URL">
           <b-input v-model="fileUrl" type="url" required />
         </b-field>
-        <b-button native-type="submit" type="is-primary" :loading="isLoading">
+        <o-button native-type="submit" variant="primary" :loading="isLoading">
           Upload
-        </b-button>
+        </o-button>
       </form>
     </b-tab-item>
   </b-tabs>

--- a/ui/src/components/CsvUploadForm.vue
+++ b/ui/src/components/CsvUploadForm.vue
@@ -1,13 +1,13 @@
 <template>
-  <b-tabs type="is-boxed" v-model="sourceKind">
-    <b-tab-item label="Upload" value="MediaLocal">
+  <o-tabs type="boxed" v-model="sourceKind">
+    <o-tab-item label="Upload" value="MediaLocal">
       <file-upload
         :file-meta="fileMeta"
         :after-upload="submitLocal"
         @done="close"
       />
-    </b-tab-item>
-    <b-tab-item label="URL" value="MediaURL">
+    </o-tab-item>
+    <o-tab-item label="URL" value="MediaURL">
       <form @submit.prevent="submitUrl">
         <b-field label="URL">
           <b-input v-model="fileUrl" type="url" required />
@@ -16,8 +16,8 @@
           Upload
         </o-button>
       </form>
-    </b-tab-item>
-  </b-tabs>
+    </o-tab-item>
+  </o-tabs>
 </template>
 
 <script lang="ts">

--- a/ui/src/components/CsvUploadForm.vue
+++ b/ui/src/components/CsvUploadForm.vue
@@ -10,7 +10,7 @@
     <o-tab-item label="URL" value="MediaURL">
       <form @submit.prevent="submitUrl">
         <o-field label="URL">
-          <b-input v-model="fileUrl" type="url" required />
+          <o-input v-model="fileUrl" type="url" required />
         </o-field>
         <o-button native-type="submit" variant="primary" :loading="isLoading">
           Upload

--- a/ui/src/components/CsvUploadForm.vue
+++ b/ui/src/components/CsvUploadForm.vue
@@ -12,9 +12,9 @@
         <o-field label="URL">
           <o-input v-model="fileUrl" type="url" required />
         </o-field>
-        <o-button native-type="submit" variant="primary" :loading="isLoading">
+        <button-loading native-type="submit" variant="primary" :loading="isLoading">
           Upload
-        </o-button>
+        </button-loading>
       </form>
     </o-tab-item>
   </o-tabs>
@@ -27,10 +27,11 @@ import { schema } from '@tpluscode/rdf-ns-builders'
 import clownface from 'clownface'
 
 import { cc } from '@cube-creator/core/namespace'
-import FileUpload, { UploadedFile } from '@/components/FileUpload.vue'
+import ButtonLoading from './ButtonLoading.vue'
+import FileUpload, { UploadedFile } from './FileUpload.vue'
 
 @Component({
-  components: { FileUpload },
+  components: { ButtonLoading, FileUpload },
 })
 export default class CsvUploadForm extends Vue {
   @Prop({ default: undefined }) fileMeta!: Record<string, unknown>

--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -16,11 +16,11 @@
                 </div>
               </div>
               <div class="level-right">
-                <b-select :value="selectedLanguage" @input="$emit('selectLanguage', $event)" class="level-item" title="Language">
+                <o-select :value="selectedLanguage" @input="$emit('selectLanguage', $event)" class="level-item" title="Language">
                   <option v-for="language in languages" :key="language" :value="language">
                     {{ language }}
                   </option>
-                </b-select>
+                </o-select>
               </div>
             </div>
           </th>
@@ -115,11 +115,11 @@
               </div>
               <div class="is-flex gap-2">
                 <o-tooltip label="Page size">
-                  <b-select v-model="pageSize" title="Page size">
+                  <o-select v-model="pageSize" title="Page size">
                     <option v-for="pageSizeOption in pageSizes" :key="pageSizeOption" :native-value="pageSizeOption">
                       {{ pageSizeOption }}
                     </option>
-                  </b-select>
+                  </o-select>
                 </o-tooltip>
                 <o-tooltip label="Refresh data">
                   <o-button icon-left="sync" @click="refreshData" />

--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -101,7 +101,7 @@
                   />
                 </o-tooltip>
                 <span class="ml-4">Page</span>
-                <b-input
+                <o-input
                   v-model.number="page"
                   type="number"
                   min="1"

--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -87,14 +87,14 @@
             <div class="is-flex is-justify-content-space-between gap-4">
               <div class="is-flex is-align-items-center gap-1">
                 <b-tooltip label="Previous page">
-                  <b-button
+                  <o-button
                     icon-left="chevron-left"
                     @click="page = page - 1"
                     :disabled="!hasPreviousPage"
                   />
                 </b-tooltip>
                 <b-tooltip label="Next page">
-                  <b-button
+                  <o-button
                     icon-left="chevron-right"
                     @click="page = page + 1"
                     :disabled="!hasNextPage"
@@ -122,7 +122,7 @@
                   </b-select>
                 </b-tooltip>
                 <b-tooltip label="Refresh data">
-                  <b-button icon-left="sync" @click="refreshData" />
+                  <o-button icon-left="sync" @click="refreshData" />
                 </b-tooltip>
               </div>
             </div>

--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -145,6 +145,7 @@ import type { Cube, Dataset, DimensionMetadata, DimensionMetadataCollection } fr
 import { supportedLanguages } from '@cube-creator/core/languages'
 import { api } from '@/api'
 import Remote, { RemoteData } from '@/remote'
+import BMessage from './BMessage.vue'
 import HydraOperationButton from './HydraOperationButton.vue'
 import TermWithLanguage from './TermWithLanguage.vue'
 import LoadingBlock from './LoadingBlock.vue'
@@ -155,6 +156,7 @@ const debounceRefreshDelay = 500
 
 @Component({
   components: {
+    BMessage,
     CubePreviewDimension,
     CubePreviewValue,
     HydraOperationButton,

--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -86,20 +86,20 @@
           <td :colspan="tableWidth" class="has-background-light">
             <div class="is-flex is-justify-content-space-between gap-4">
               <div class="is-flex is-align-items-center gap-1">
-                <b-tooltip label="Previous page">
+                <o-tooltip label="Previous page">
                   <o-button
                     icon-left="chevron-left"
                     @click="page = page - 1"
                     :disabled="!hasPreviousPage"
                   />
-                </b-tooltip>
-                <b-tooltip label="Next page">
+                </o-tooltip>
+                <o-tooltip label="Next page">
                   <o-button
                     icon-left="chevron-right"
                     @click="page = page + 1"
                     :disabled="!hasNextPage"
                   />
-                </b-tooltip>
+                </o-tooltip>
                 <span class="ml-4">Page</span>
                 <b-input
                   v-model.number="page"
@@ -114,16 +114,16 @@
                 </span>
               </div>
               <div class="is-flex gap-2">
-                <b-tooltip label="Page size">
+                <o-tooltip label="Page size">
                   <b-select v-model="pageSize" title="Page size">
                     <option v-for="pageSizeOption in pageSizes" :key="pageSizeOption" :native-value="pageSizeOption">
                       {{ pageSizeOption }}
                     </option>
                   </b-select>
-                </b-tooltip>
-                <b-tooltip label="Refresh data">
+                </o-tooltip>
+                <o-tooltip label="Refresh data">
                   <o-button icon-left="sync" @click="refreshData" />
-                </b-tooltip>
+                </o-tooltip>
               </div>
             </div>
           </td>

--- a/ui/src/components/CubePreview.vue
+++ b/ui/src/components/CubePreview.vue
@@ -44,7 +44,7 @@
           <td :colspan="tableWidth" class="p-0">
             <div class="message is-warning">
               <p class="message-body px-2 py-1 is-flex">
-                <b-icon icon="exclamation-triangle" class="mr-1" />
+                <o-icon icon="exclamation-triangle" class="mr-1" />
                 <span>{{ error.description }}</span>
               </p>
             </div>

--- a/ui/src/components/CubePreviewDimension.vue
+++ b/ui/src/components/CubePreviewDimension.vue
@@ -27,7 +27,7 @@
       <scale-of-measure-icon :scale-of-measure="dimension.scaleOfMeasure" />
       <data-kind-icon :data-kind="dimension.dataKind" />
       <o-tooltip v-show="description" :label="description">
-        <b-icon icon="comment-alt" pack="far" type="is-primary" />
+        <o-icon icon="comment-alt" pack="far" variant="primary" />
       </o-tooltip>
     </div>
   </div>

--- a/ui/src/components/CubePreviewDimension.vue
+++ b/ui/src/components/CubePreviewDimension.vue
@@ -11,7 +11,7 @@
         :to="{ name: 'DimensionEdit', params: { dimensionId: dimension.clientPath } }"
       />
       <div v-if="dimension.mappings">
-        <b-tooltip :label="linkToSharedDimensionLabel">
+        <o-tooltip :label="linkToSharedDimensionLabel">
           <o-button
             tag="router-link"
             :to="{ name: 'DimensionMapping', params: { dimensionId: dimension.clientPath } }"
@@ -20,15 +20,15 @@
             variant="text"
             :class="{ 'has-text-primary': dimension.sharedDimensions.length > 0 }"
           />
-        </b-tooltip>
+        </o-tooltip>
       </div>
     </div>
     <div class="icons">
       <scale-of-measure-icon :scale-of-measure="dimension.scaleOfMeasure" />
       <data-kind-icon :data-kind="dimension.dataKind" />
-      <b-tooltip v-show="description" :label="description">
+      <o-tooltip v-show="description" :label="description">
         <b-icon icon="comment-alt" pack="far" type="is-primary" />
-      </b-tooltip>
+      </o-tooltip>
     </div>
   </div>
 </template>

--- a/ui/src/components/CubePreviewDimension.vue
+++ b/ui/src/components/CubePreviewDimension.vue
@@ -12,12 +12,12 @@
       />
       <div v-if="dimension.mappings">
         <b-tooltip :label="linkToSharedDimensionLabel">
-          <b-button
+          <o-button
             tag="router-link"
             :to="{ name: 'DimensionMapping', params: { dimensionId: dimension.clientPath } }"
             icon-left="link"
-            size="is-small"
-            type="is-text"
+            size="small"
+            variant="text"
             :class="{ 'has-text-primary': dimension.sharedDimensions.length > 0 }"
           />
         </b-tooltip>

--- a/ui/src/components/CubeProjectsItem.vue
+++ b/ui/src/components/CubeProjectsItem.vue
@@ -27,7 +27,7 @@
         </o-tooltip>
       </div>
     </div>
-    <b-collapse animation="slide" v-model="detailsShown">
+    <o-collapse animation="slide" :open.sync="detailsShown">
       <table v-if="details" class="table is-fullwidth has-background-light">
         <tr v-for="part in details.parts" :key="part.id.value" class="is-size-7">
           <th class="w-1/3">
@@ -43,7 +43,7 @@
         </tr>
       </table>
       <loading-block v-else />
-    </b-collapse>
+    </o-collapse>
   </div>
 </template>
 

--- a/ui/src/components/CubeProjectsItem.vue
+++ b/ui/src/components/CubeProjectsItem.vue
@@ -22,9 +22,9 @@
             {{ project.creator.name }}
           </p>
         </div>
-        <b-tooltip class="is-block" label="More details">
+        <o-tooltip class="is-block" label="More details">
           <o-button icon-left="info-circle" variant="white" size="small" @click="toggleDetails" />
-        </b-tooltip>
+        </o-tooltip>
       </div>
     </div>
     <b-collapse animation="slide" v-model="detailsShown">

--- a/ui/src/components/CubeProjectsItem.vue
+++ b/ui/src/components/CubeProjectsItem.vue
@@ -23,7 +23,7 @@
           </p>
         </div>
         <b-tooltip class="is-block" label="More details">
-          <b-button icon-left="info-circle" type="is-white" size="is-small" @click="toggleDetails" />
+          <o-button icon-left="info-circle" variant="white" size="small" @click="toggleDetails" />
         </b-tooltip>
       </div>
     </div>

--- a/ui/src/components/DataKindIcon.vue
+++ b/ui/src/components/DataKindIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <o-tooltip v-if="dataKind" :label="label" class="tag is-rounded is-primary">
-    <b-icon :icon="icon" />
+    <o-icon :icon="icon" />
   </o-tooltip>
 </template>
 

--- a/ui/src/components/DataKindIcon.vue
+++ b/ui/src/components/DataKindIcon.vue
@@ -1,7 +1,7 @@
 <template>
-  <b-tooltip v-if="dataKind" :label="label" class="tag is-rounded is-primary">
+  <o-tooltip v-if="dataKind" :label="label" class="tag is-rounded is-primary">
     <b-icon :icon="icon" />
-  </b-tooltip>
+  </o-tooltip>
 </template>
 
 <script lang="ts">

--- a/ui/src/components/DialogConfirm.vue
+++ b/ui/src/components/DialogConfirm.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">
+        {{ title }}
+      </p>
+      <button class="delete" aria-label="close" @click="onCancel" />
+    </header>
+    <section class="modal-card-body">
+      <div :class="{ media: hasIcon }">
+        <div class="media-left">
+          <o-icon
+            v-if="icon"
+            :icon="icon"
+            :variant="variant"
+            size="large"
+            both
+            aria-hidden
+          />
+        </div>
+        <div class="media-content">
+          {{ message }}
+        </div>
+      </div>
+    </section>
+    <footer class="modal-card-foot">
+      <o-button @click="onCancel">
+        Cancel
+      </o-button>
+      <o-button :variant="variant" @click="onConfirm">
+        {{ confirmText }}
+      </o-button>
+    </footer>
+  </div>
+</template>
+
+<script lang="ts">
+import type { ColorsModifiers } from '@oruga-ui/oruga/types/helpers'
+import { Prop, Component, Vue } from 'vue-property-decorator'
+
+@Component
+export default class DialogConfirm extends Vue {
+  @Prop({ default: 'Are you sure?' }) title!: string
+  @Prop({ required: true }) message!: string
+  @Prop({ default: 'Confirm' }) confirmText!: string
+  @Prop({ default: 'danger' }) variant!: ColorsModifiers
+  @Prop({ default: true }) hasIcon!: boolean
+
+  onConfirm (): void {
+    this.$emit('confirm')
+    this.$emit('close')
+  }
+
+  onCancel (): void {
+    this.$emit('cancel')
+    this.$emit('close')
+  }
+
+  get icon () {
+    if (!this.hasIcon) {
+      return null
+    }
+
+    switch (this.variant) {
+      case 'info':
+        return 'information'
+      case 'success':
+        return 'check-circle'
+      case 'warning':
+        return 'alert'
+      case 'danger':
+        return 'alert-circle'
+      default:
+        return null
+    }
+  }
+}
+</script>

--- a/ui/src/components/DownloadButton.vue
+++ b/ui/src/components/DownloadButton.vue
@@ -1,7 +1,14 @@
 <template>
-  <o-button :size="size" :variant="variant" icon-left="download" @click="download" :loading="loading" v-if="this.resource">
+  <button-loading
+    v-if="resource"
+    :size="size"
+    :variant="variant"
+    icon-left="download"
+    @click="download"
+    :loading="loading"
+  >
     {{ title }}
-  </o-button>
+  </button-loading>
 </template>
 
 <script lang="ts">
@@ -10,8 +17,11 @@ import { prepareHeaders } from '@/api'
 import { parse } from '@tinyhttp/content-disposition'
 import store from '@/store'
 import { Resource } from 'alcaeus'
+import ButtonLoading from './ButtonLoading.vue'
 
-@Component
+@Component({
+  components: { ButtonLoading },
+})
 export default class DownloadButton extends Vue {
   @Prop({ required: true }) resource: Resource | undefined
   @Prop({ default: 'default' }) variant!: string

--- a/ui/src/components/DownloadButton.vue
+++ b/ui/src/components/DownloadButton.vue
@@ -1,7 +1,7 @@
 <template>
-  <b-button :size="size" :type="type" icon-left="download" @click="download" :loading="loading" v-if="this.resource">
+  <o-button :size="size" :variant="variant" icon-left="download" @click="download" :loading="loading" v-if="this.resource">
     {{ title }}
-  </b-button>
+  </o-button>
 </template>
 
 <script lang="ts">
@@ -14,8 +14,8 @@ import { Resource } from 'alcaeus'
 @Component
 export default class DownloadButton extends Vue {
   @Prop({ required: true }) resource: Resource | undefined
-  @Prop({ default: 'is-default' }) type!: string
-  @Prop({ default: 'is-normal' }) size!: string
+  @Prop({ default: 'default' }) variant!: string
+  @Prop({ default: 'normal' }) size!: string
 
   loading = false
 

--- a/ui/src/components/FormSubmitCancel.vue
+++ b/ui/src/components/FormSubmitCancel.vue
@@ -3,14 +3,14 @@
     <hr>
     <b-field class="buttons" :addons="false">
       <div class="control">
-        <b-button native-type="submit" class="button" :type="submitButtonType" :disabled="disabled" :loading="isSubmitting">
+        <o-button native-type="submit" class="button" :variant="submitButtonVariant" :disabled="disabled" :loading="isSubmitting">
           {{ _submitLabel }}
-        </b-button>
+        </o-button>
       </div>
       <div class="control" v-if="showCancel">
-        <b-button @click="$emit('cancel')">
+        <o-button @click="$emit('cancel')">
           Cancel
-        </b-button>
+        </o-button>
       </div>
     </b-field>
   </b-field>
@@ -25,7 +25,7 @@ export default class FormSubmitCancel extends Vue {
   @Prop() disabled?: boolean
   @Prop() isSubmitting?: boolean
   @Prop({ default: true }) showCancel?: boolean
-  @Prop({ default: 'is-primary' }) submitButtonType?: string
+  @Prop({ default: 'primary' }) submitButtonVariant?: string
 
   get _submitLabel (): string {
     return this.submitLabel || 'Save'

--- a/ui/src/components/FormSubmitCancel.vue
+++ b/ui/src/components/FormSubmitCancel.vue
@@ -3,9 +3,14 @@
     <hr>
     <o-field class="buttons" :addons="false">
       <div class="control">
-        <o-button native-type="submit" class="button" :variant="submitButtonVariant" :disabled="disabled" :loading="isSubmitting">
+        <button-loading
+          native-type="submit"
+          :variant="submitButtonVariant"
+          :disabled="disabled"
+          :loading="isSubmitting"
+        >
           {{ _submitLabel }}
-        </o-button>
+        </button-loading>
       </div>
       <div class="control" v-if="showCancel">
         <o-button @click="$emit('cancel')">
@@ -18,8 +23,11 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator'
+import ButtonLoading from './ButtonLoading.vue'
 
-@Component
+@Component({
+  components: { ButtonLoading },
+})
 export default class FormSubmitCancel extends Vue {
   @Prop() submitLabel?: string
   @Prop() disabled?: boolean

--- a/ui/src/components/FormSubmitCancel.vue
+++ b/ui/src/components/FormSubmitCancel.vue
@@ -1,7 +1,7 @@
 <template>
-  <b-field :addons="false">
+  <o-field :addons="false">
     <hr>
-    <b-field class="buttons" :addons="false">
+    <o-field class="buttons" :addons="false">
       <div class="control">
         <o-button native-type="submit" class="button" :variant="submitButtonVariant" :disabled="disabled" :loading="isSubmitting">
           {{ _submitLabel }}
@@ -12,8 +12,8 @@
           Cancel
         </o-button>
       </div>
-    </b-field>
-  </b-field>
+    </o-field>
+  </o-field>
 </template>
 
 <script lang="ts">

--- a/ui/src/components/HydraOperationButton.vue
+++ b/ui/src/components/HydraOperationButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-tooltip v-if="operation" :label="operation.title">
+  <o-tooltip v-if="operation" :label="operation.title">
     <o-button
       :tag="tag"
       :to="to"
@@ -11,7 +11,7 @@
     >
       <slot />
     </o-button>
-  </b-tooltip>
+  </o-tooltip>
 </template>
 
 <script lang="ts">

--- a/ui/src/components/HydraOperationButton.vue
+++ b/ui/src/components/HydraOperationButton.vue
@@ -1,16 +1,16 @@
 <template>
   <b-tooltip v-if="operation" :label="operation.title">
-    <b-button
+    <o-button
       :tag="tag"
       :to="to"
       @click="$emit('click')"
-      :type="type"
+      :variant="variant"
       :size="size"
       :icon-left="iconName"
       :disabled="disabled"
     >
       <slot />
-    </b-button>
+    </o-button>
   </b-tooltip>
 </template>
 
@@ -23,8 +23,8 @@ import { Location } from 'vue-router'
 export default class HydraOperationButton extends Vue {
   @Prop({ default: null }) operation!: RuntimeOperation | null
   @Prop({ default: null }) to!: Location | null
-  @Prop({ default: 'is-text' }) type!: string
-  @Prop({ default: 'is-small' }) size!: string
+  @Prop({ default: 'text' }) variant!: string
+  @Prop({ default: 'small' }) size!: string
   @Prop({ default: null }) icon!: string | null
   @Prop({ default: false }) disabled!: boolean
 

--- a/ui/src/components/HydraOperationError.vue
+++ b/ui/src/components/HydraOperationError.vue
@@ -18,10 +18,11 @@
 import { Vue, Component, Prop } from 'vue-property-decorator'
 import type { Shape } from '@rdfine/shacl'
 import { ErrorDetails } from '@/api/errors'
+import BMessage from './BMessage.vue'
 import HydraOperationErrorResult from './HydraOperationErrorResult.vue'
 
 @Component({
-  components: { HydraOperationErrorResult },
+  components: { BMessage, HydraOperationErrorResult },
 })
 export default class extends Vue {
   @Prop({ default: null }) error!: ErrorDetails | null

--- a/ui/src/components/HydraOperationForm.vue
+++ b/ui/src/components/HydraOperationForm.vue
@@ -10,7 +10,7 @@
       :submit-label="_submitLabel"
       :is-submitting="isSubmitting"
       :show-cancel="showCancel"
-      :submit-button-type="submitButtonType"
+      :submit-button-variant="submitButtonVariant"
       :disabled="!shape"
       @cancel="$emit('cancel')"
     />
@@ -39,7 +39,7 @@ export default class HydraOperationForm extends Vue {
   @Prop({ default: false }) isSubmitting!: boolean
   @Prop() showCancel?: boolean
   @Prop() submitLabel?: string
-  @Prop() submitButtonType?: string
+  @Prop() submitButtonVariant?: string
 
   __clone: GraphPointer | null = null
 

--- a/ui/src/components/HydraOperationFormWithRaw.vue
+++ b/ui/src/components/HydraOperationFormWithRaw.vue
@@ -13,9 +13,9 @@
       @cancel="$emit('cancel', $event)"
     />
     <div class="mt-4 has-text-right">
-      <b-button @click="toggleMode" icon-left="chevron-left">
+      <o-button @click="toggleMode" icon-left="chevron-left">
         Back to form (basic)
-      </b-button>
+      </o-button>
     </div>
   </div>
   <div v-else>
@@ -32,9 +32,9 @@
       @cancel="$emit('cancel', $event)"
     />
     <div class="mt-4 has-text-right">
-      <b-button icon-right="exclamation-triangle" @click="toggleMode" type="is-text">
+      <o-button icon-right="exclamation-triangle" @click="toggleMode" variant="text">
         Edit raw RDF (advanced)
-      </b-button>
+      </o-button>
     </div>
   </div>
 </template>

--- a/ui/src/components/HydraRawRdfForm.vue
+++ b/ui/src/components/HydraRawRdfForm.vue
@@ -32,6 +32,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator'
 import { RuntimeOperation } from 'alcaeus'
 import $rdf from 'rdf-ext'
 import clownface, { GraphPointer } from 'clownface'
+import BMessage from './BMessage.vue'
 import FormSubmitCancel from './FormSubmitCancel.vue'
 import HydraOperationError from './HydraOperationError.vue'
 import { ErrorDetails } from '@/api/errors'
@@ -44,7 +45,7 @@ interface ParseError {
 }
 
 @Component({
-  components: { FormSubmitCancel, HydraOperationError, LoadingBlock },
+  components: { BMessage, FormSubmitCancel, HydraOperationError, LoadingBlock },
 })
 export default class HydraRawRdfForm extends Vue {
   @Prop({ required: true }) operation!: RuntimeOperation

--- a/ui/src/components/JobForm.vue
+++ b/ui/src/components/JobForm.vue
@@ -11,7 +11,7 @@
       :is-submitting="isSubmitting"
       @submit="onSubmit"
       :show-cancel="false"
-      :submit-button-type="submitButtonType"
+      :submit-button-variant="submitButtonVariant"
     />
   </div>
 </template>
@@ -33,7 +33,7 @@ import { NamedNode } from 'rdf-js'
 })
 export default class JobForm extends Vue {
   @Prop() operation!: RuntimeOperation
-  @Prop() submitButtonType?: string
+  @Prop() submitButtonVariant?: string
   @Prop({ default: false }) confirm!: boolean
   @Prop({ default: 'Are you sure?' }) confirmationMessage!: string
 

--- a/ui/src/components/JobForm.vue
+++ b/ui/src/components/JobForm.vue
@@ -28,6 +28,7 @@ import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import { rdf, sh } from '@tpluscode/rdf-ns-builders'
 import { NamedNode } from 'rdf-js'
 import { displayToast } from '@/use-toast'
+import { confirmDialog } from '@/use-dialog'
 
 @Component({
   components: { HydraOperationForm },
@@ -89,12 +90,10 @@ export default class JobForm extends Vue {
 
   async askConfirmation (): Promise<boolean> {
     return new Promise((resolve) => {
-      this.$buefy.dialog.confirm({
+      confirmDialog(this, {
         title: this.operation.title,
         message: this.confirmationMessage,
         confirmText: 'Confirm',
-        type: 'is-danger',
-        hasIcon: true,
         onConfirm () {
           resolve(true)
         },

--- a/ui/src/components/JobForm.vue
+++ b/ui/src/components/JobForm.vue
@@ -27,6 +27,7 @@ import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import { rdf, sh } from '@tpluscode/rdf-ns-builders'
 import { NamedNode } from 'rdf-js'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { HydraOperationForm },
@@ -69,9 +70,9 @@ export default class JobForm extends Vue {
         resource,
       })
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: `${job.name} was started`,
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$store.dispatch('project/fetchJobCollection')

--- a/ui/src/components/JobItem.vue
+++ b/ui/src/components/JobItem.vue
@@ -8,7 +8,7 @@
       </div>
       <slot />
     </div>
-    <b-icon icon="chevron-right" />
+    <o-icon icon="chevron-right" />
   </router-link>
 </template>
 

--- a/ui/src/components/JobStatus.vue
+++ b/ui/src/components/JobStatus.vue
@@ -1,9 +1,9 @@
 <template>
   <span v-if="showLabel" class="tag is-light" :class="typeClass">
-    <b-icon :icon="icon" :class="iconColorClass" />
+    <o-icon :icon="icon" :class="iconColorClass" />
     <span>{{ label }}</span>
   </span>
-  <b-icon v-else :icon="icon" :class="iconColorClass" />
+  <o-icon v-else :icon="icon" :class="iconColorClass" />
 </template>
 
 <script lang="ts">

--- a/ui/src/components/LoadingBlock.vue
+++ b/ui/src/components/LoadingBlock.vue
@@ -1,8 +1,18 @@
 <template>
   <div class="loading-block section">
-    <b-loading active :is-full-page="false" />
+    <b-loading :active="true" :is-full-page="false" />
   </div>
 </template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import BLoading from './BLoading.vue'
+
+@Component({
+  components: { BLoading },
+})
+export default class LoadingBlock extends Vue {}
+</script>
 
 <style scoped>
 .loading-block {

--- a/ui/src/components/MapperTable.vue
+++ b/ui/src/components/MapperTable.vue
@@ -57,12 +57,12 @@
           <span v-if="columnMapping.datatype" class="has-text-grey"> (<property-display :term="columnMapping.datatype" />)</span>
           <span v-if="columnMapping.language" class="has-text-grey"> (language: {{ columnMapping.language.value }})</span>
         </span>
-        <b-tooltip v-if="columnMapping.isKeyDimension" label="Key dimension">
+        <o-tooltip v-if="columnMapping.isKeyDimension" label="Key dimension">
           <b-icon icon="key" type="is-grey" />
-        </b-tooltip>
-        <b-tooltip v-if="columnMapping.isMeasureDimension" label="Measure dimension">
+        </o-tooltip>
+        <o-tooltip v-if="columnMapping.isMeasureDimension" label="Measure dimension">
           <b-icon icon="chart-bar" type="is-primary" />
-        </b-tooltip>
+        </o-tooltip>
       </div>
       <div class="is-flex">
         <hydra-operation-button
@@ -76,7 +76,7 @@
       </div>
     </div>
     <div class="panel-block">
-      <b-tooltip v-if="table.actions.createLiteralColumnMapping || table.actions.createReferenceColumnMapping" label="Map column">
+      <o-tooltip v-if="table.actions.createLiteralColumnMapping || table.actions.createReferenceColumnMapping" label="Map column">
         <o-button
           tag="router-link"
           :to="{ name: 'ColumnMappingCreate', params: { tableId: table.clientPath } }"
@@ -85,7 +85,7 @@
           icon-left="plus"
           data-testid="create-column-mapping"
         />
-      </b-tooltip>
+      </o-tooltip>
     </div>
   </div>
 </template>

--- a/ui/src/components/MapperTable.vue
+++ b/ui/src/components/MapperTable.vue
@@ -95,12 +95,13 @@ import { Prop, Component, Vue } from 'vue-property-decorator'
 import { Term } from 'rdf-js'
 import { ResourceIdentifier } from '@tpluscode/rdfine'
 import { ColumnMapping, Table } from '@cube-creator/model'
+import BMessage from './BMessage.vue'
 import HydraOperationButton from './HydraOperationButton.vue'
 import PropertyDisplay from './PropertyDisplay.vue'
 import * as storeNs from '../store/namespace'
 
 @Component({
-  components: { HydraOperationButton, PropertyDisplay },
+  components: { BMessage, HydraOperationButton, PropertyDisplay },
 })
 export default class MapperTable extends Vue {
   @Prop() readonly table!: Table

--- a/ui/src/components/MapperTable.vue
+++ b/ui/src/components/MapperTable.vue
@@ -49,9 +49,9 @@
       @mouseleave="$emit('unhighlight-arrows', [columnMapping.id.value])"
     >
       <div class="is-flex gap-2">
-        <b-tag v-if="columnMapping.referencedTable" rounded :style="{ 'background-color': getTableColor(columnMapping.referencedTable.id) }">
+        <span v-if="columnMapping.referencedTable" class="tag is-rounded" :style="{ 'background-color': getTableColor(columnMapping.referencedTable.id) }">
           <property-display :term="columnMapping.targetProperty" />
-        </b-tag>
+        </span>
         <span v-else>
           <property-display :term="columnMapping.targetProperty" />
           <span v-if="columnMapping.datatype" class="has-text-grey"> (<property-display :term="columnMapping.datatype" />)</span>

--- a/ui/src/components/MapperTable.vue
+++ b/ui/src/components/MapperTable.vue
@@ -99,6 +99,7 @@ import BMessage from './BMessage.vue'
 import HydraOperationButton from './HydraOperationButton.vue'
 import PropertyDisplay from './PropertyDisplay.vue'
 import * as storeNs from '../store/namespace'
+import { confirmDialog } from '../use-dialog'
 
 @Component({
   components: { BMessage, HydraOperationButton, PropertyDisplay },
@@ -136,12 +137,10 @@ export default class MapperTable extends Vue {
   }
 
   deleteTable (table: Table): void {
-    this.$buefy.dialog.confirm({
+    confirmDialog(this, {
       title: table.actions.delete?.title,
       message: 'Are you sure you want to delete this table?',
       confirmText: 'Delete',
-      type: 'is-danger',
-      hasIcon: true,
       onConfirm: () => {
         this.$store.dispatch('api/invokeDeleteOperation', {
           operation: table.actions.delete,
@@ -153,12 +152,10 @@ export default class MapperTable extends Vue {
   }
 
   deleteColumnMapping (columnMapping: ColumnMapping): void {
-    this.$buefy.dialog.confirm({
+    confirmDialog(this, {
       title: columnMapping.actions.delete?.title,
       message: 'Are you sure you want to delete this column mapping?',
       confirmText: 'Delete',
-      type: 'is-danger',
-      hasIcon: true,
       onConfirm: () => {
         this.$store.dispatch('api/invokeDeleteOperation', {
           operation: columnMapping.actions.delete,

--- a/ui/src/components/MapperTable.vue
+++ b/ui/src/components/MapperTable.vue
@@ -77,11 +77,11 @@
     </div>
     <div class="panel-block">
       <b-tooltip v-if="table.actions.createLiteralColumnMapping || table.actions.createReferenceColumnMapping" label="Map column">
-        <b-button
+        <o-button
           tag="router-link"
           :to="{ name: 'ColumnMappingCreate', params: { tableId: table.clientPath } }"
-          type="is-text"
-          size="is-small"
+          variant="text"
+          size="small"
           icon-left="plus"
           data-testid="create-column-mapping"
         />

--- a/ui/src/components/MapperTable.vue
+++ b/ui/src/components/MapperTable.vue
@@ -18,16 +18,16 @@
               @click="deleteTable(table)"
               data-testid="delete-table"
             />
-            <b-dropdown position="is-bottom-left">
+            <o-dropdown position="bottom-left" class="has-text-weight-normal">
               <button class="button is-text is-small" slot="trigger">
                 <b-icon icon="ellipsis-h" />
               </button>
-              <b-dropdown-item v-if="table.csvw" has-link>
-                <router-link :to="{ name: 'TableCsvw', params: { tableId: table.clientPath } }">
+              <o-dropdown-item tag="div" item-class="p" v-if="table.csvw" has-link>
+                <router-link class="dropdown-item" :to="{ name: 'TableCsvw', params: { tableId: table.clientPath } }">
                   View generated CSVW
                 </router-link>
-              </b-dropdown-item>
-            </b-dropdown>
+              </o-dropdown-item>
+            </o-dropdown>
           </div>
         </div>
       </div>

--- a/ui/src/components/MapperTable.vue
+++ b/ui/src/components/MapperTable.vue
@@ -20,7 +20,7 @@
             />
             <o-dropdown position="bottom-left" class="has-text-weight-normal">
               <button class="button is-text is-small" slot="trigger">
-                <b-icon icon="ellipsis-h" />
+                <o-icon icon="ellipsis-h" />
               </button>
               <o-dropdown-item tag="div" item-class="p" v-if="table.csvw" has-link>
                 <router-link class="dropdown-item" :to="{ name: 'TableCsvw', params: { tableId: table.clientPath } }">
@@ -58,10 +58,10 @@
           <span v-if="columnMapping.language" class="has-text-grey"> (language: {{ columnMapping.language.value }})</span>
         </span>
         <o-tooltip v-if="columnMapping.isKeyDimension" label="Key dimension">
-          <b-icon icon="key" type="is-grey" />
+          <o-icon icon="key" variant="grey" />
         </o-tooltip>
         <o-tooltip v-if="columnMapping.isMeasureDimension" label="Measure dimension">
-          <b-icon icon="chart-bar" type="is-primary" />
+          <o-icon icon="chart-bar" variant="primary" />
         </o-tooltip>
       </div>
       <div class="is-flex">

--- a/ui/src/components/NavBar.vue
+++ b/ui/src/components/NavBar.vue
@@ -1,32 +1,40 @@
 <template>
-  <b-navbar type="is-light" shadow>
-    <template slot="brand">
-      <b-navbar-item tag="router-link" :to="{ name: 'Home' }">
+  <nav class="navbar is-light has-shadow">
+    <div class="navbar-brand">
+      <router-link class="navbar-item" :to="{ name: 'Home' }">
         Cube Creator
-      </b-navbar-item>
-    </template>
-    <template slot="start">
-      <b-navbar-item tag="router-link" :to="{ name: 'CubeProjects' }">
-        Cube Projects
-      </b-navbar-item>
-      <b-navbar-item tag="router-link" :to="{ name: 'SharedDimensions' }">
-        Shared Dimensions
-      </b-navbar-item>
-    </template>
-    <template slot="end">
-      <b-navbar-item
-        href="https://github.com/zazuko/cube-creator/wiki"
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-      >
-        <b-icon icon="question-circle" />
-        <span>Help</span>
-      </b-navbar-item>
-      <b-navbar-item>
-        <sign-out-button />
-      </b-navbar-item>
-    </template>
-  </b-navbar>
+      </router-link>
+      <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" @click="isOpen = !isOpen">
+        <span aria-hidden="true" />
+        <span aria-hidden="true" />
+        <span aria-hidden="true" />
+      </a>
+    </div>
+    <div class="navbar-menu" :class="{ 'is-active': isOpen }">
+      <div class="navbar-start">
+        <router-link class="navbar-item" :to="{ name: 'CubeProjects' }">
+          Cube Projects
+        </router-link>
+        <router-link class="navbar-item" :to="{ name: 'SharedDimensions' }">
+          Shared Dimensions
+        </router-link>
+      </div>
+      <div class="navbar-end">
+        <a
+          class="navbar-item"
+          href="https://github.com/zazuko/cube-creator/wiki"
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+        >
+          <o-icon icon="question-circle" />
+          <span class="ml-1">Help</span>
+        </a>
+        <div class="navbar-item">
+          <sign-out-button />
+        </div>
+      </div>
+    </div>
+  </nav>
 </template>
 
 <script>
@@ -36,6 +44,12 @@ import SignOutButton from './auth/SignOutButton.vue'
 export default Vue.extend({
   name: 'NavBar',
   components: { SignOutButton },
+
+  data () {
+    return {
+      isOpen: false,
+    }
+  }
 })
 </script>
 

--- a/ui/src/components/PropertyDisplay.vue
+++ b/ui/src/components/PropertyDisplay.vue
@@ -1,7 +1,7 @@
 <template>
-  <b-tooltip :label="expanded">
+  <o-tooltip :label="expanded">
     {{ shrunk }}
-  </b-tooltip>
+  </o-tooltip>
 </template>
 
 <script lang="ts">

--- a/ui/src/components/RadioButton.vue
+++ b/ui/src/components/RadioButton.vue
@@ -1,0 +1,38 @@
+<template>
+  <o-radio
+    :value="value"
+    :native-value="nativeValue"
+    :size="size"
+    @input="$emit('input', $event)"
+    class="button radio-button"
+    :class="{ 'is-primary': isSelected }"
+  >
+    <slot />
+  </o-radio>
+</template>
+
+<script lang="ts">
+import { Prop, Component, Vue } from 'vue-property-decorator'
+
+@Component
+export default class RadioButton extends Vue {
+  @Prop() value!: string
+  @Prop() nativeValue!: string
+  @Prop() size?: string
+
+  get isSelected () {
+    return this.value === this.nativeValue
+  }
+}
+</script>
+
+<style>
+.b-radio.radio-button .check,
+.b-radio.radio-button input[type=radio] {
+  display: none;
+}
+
+.b-radio.radio-button > .control-label {
+  padding-left: 0;
+}
+</style>

--- a/ui/src/components/RadioButton.vue
+++ b/ui/src/components/RadioButton.vue
@@ -33,6 +33,6 @@ export default class RadioButton extends Vue {
 }
 
 .b-radio.radio-button > .control-label {
-  padding-left: 0;
+  padding-left: 0 !important;
 }
 </style>

--- a/ui/src/components/ReferenceColumnMappingForm.vue
+++ b/ui/src/components/ReferenceColumnMappingForm.vue
@@ -1,18 +1,18 @@
 <template>
   <form @submit.prevent="onSubmit">
-    <b-field label="Link to table">
+    <o-field label="Link to table">
       <b-select v-model="data.referencedTable" placeholder="Select a table">
         <option v-for="table in tables" :key="table.clientPath" :value="table">
           {{ table.name }}
         </option>
       </b-select>
-    </b-field>
+    </o-field>
 
-    <b-field label="Using the property">
+    <o-field label="Using the property">
       <property-input :value="data.targetProperty" :update="(value) => data.targetProperty = value" />
-    </b-field>
+    </o-field>
 
-    <b-field v-if="data.referencedTable" label="Identifier mapping" :addons="false">
+    <o-field v-if="data.referencedTable" label="Identifier mapping" :addons="false">
       <div v-if="data.identifierMapping">
         <p v-if="data.identifierMapping">
           The identifier <code>{{ data.referencedTable.identifierTemplate }}</code> will take
@@ -34,16 +34,16 @@
         </table>
       </div>
       <loading-block v-else />
-    </b-field>
+    </o-field>
 
-    <b-field label="Dimension type">
+    <o-field label="Dimension type">
       <radio-buttons
         class="has-addons"
         :options="dimensionTypes"
         :value="data.dimensionType"
         :update="(value) => data.dimensionType = value"
       />
-    </b-field>
+    </o-field>
 
     <hydra-operation-error :error="error" class="mt-4" />
 

--- a/ui/src/components/ReferenceColumnMappingForm.vue
+++ b/ui/src/components/ReferenceColumnMappingForm.vue
@@ -1,11 +1,11 @@
 <template>
   <form @submit.prevent="onSubmit">
     <o-field label="Link to table">
-      <b-select v-model="data.referencedTable" placeholder="Select a table">
+      <o-select v-model="data.referencedTable" placeholder="Select a table">
         <option v-for="table in tables" :key="table.clientPath" :value="table">
           {{ table.name }}
         </option>
-      </b-select>
+      </o-select>
     </o-field>
 
     <o-field label="Using the property">
@@ -22,11 +22,11 @@
           <tbody>
             <tr v-for="mapping in data.identifierMapping" :key="mapping.referencedColumn.id.value">
               <td>
-                <b-select v-model="mapping.sourceColumnId">
+                <o-select v-model="mapping.sourceColumnId">
                   <option v-for="column in source.columns" :key="column.clientPath" :value="column.id.value">
                     {{ column.name }}
                   </option>
-                </b-select>
+                </o-select>
               </td>
               <td>for <code>{{ '{' + getColumn(data.referencedTable.id, mapping.referencedColumn.id).name + '}' }}</code></td>
             </tr>

--- a/ui/src/components/ScaleOfMeasureIcon.vue
+++ b/ui/src/components/ScaleOfMeasureIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <o-tooltip v-if="scaleOfMeasure" :label="label" class="tag is-rounded is-primary">
-    <b-icon :icon="icon" />
+    <o-icon :icon="icon" />
   </o-tooltip>
 </template>
 

--- a/ui/src/components/ScaleOfMeasureIcon.vue
+++ b/ui/src/components/ScaleOfMeasureIcon.vue
@@ -1,7 +1,7 @@
 <template>
-  <b-tooltip v-if="scaleOfMeasure" :label="label" class="tag is-rounded is-primary">
+  <o-tooltip v-if="scaleOfMeasure" :label="label" class="tag is-rounded is-primary">
     <b-icon :icon="icon" />
-  </b-tooltip>
+  </o-tooltip>
 </template>
 
 <script lang="ts">

--- a/ui/src/components/SharedDimensionTags.vue
+++ b/ui/src/components/SharedDimensionTags.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="is-flex gap-1">
-    <b-tag v-if="dimension.validThrough <= new Date()" type="is-warning is-light">
+    <span v-if="dimension.validThrough <= new Date()" class="tag is-warning is-light">
       deprecated
-    </b-tag>
-    <b-tag v-if="!dimension.actions.replace" type="is-light">
+    </span>
+    <span v-if="!dimension.actions.replace" class="tag is-light">
       read-only
-    </b-tag>
+    </span>
   </div>
 </template>
 

--- a/ui/src/components/SharedDimensionTermLink.vue
+++ b/ui/src/components/SharedDimensionTermLink.vue
@@ -1,9 +1,9 @@
 <template>
-  <b-tooltip :label="uri">
+  <o-tooltip :label="uri">
     <a :href="uri" target="_blank" rel="noopener noreferer" class="button is-small is-text">
       <b-icon icon="external-link-alt" />
     </a>
-  </b-tooltip>
+  </o-tooltip>
 </template>
 
 <script lang="ts">

--- a/ui/src/components/SharedDimensionTermLink.vue
+++ b/ui/src/components/SharedDimensionTermLink.vue
@@ -1,7 +1,7 @@
 <template>
   <o-tooltip :label="uri">
     <a :href="uri" target="_blank" rel="noopener noreferer" class="button is-small is-text">
-      <b-icon icon="external-link-alt" />
+      <o-icon icon="external-link-alt" />
     </a>
   </o-tooltip>
 </template>

--- a/ui/src/components/TermDisplay.vue
+++ b/ui/src/components/TermDisplay.vue
@@ -1,7 +1,7 @@
 <template>
-  <b-tooltip :label="displayFull" :active="displayShort !== displayFull">
+  <o-tooltip :label="displayFull" :active="displayShort !== displayFull">
     {{ displayShort }}<span v-if="showLanguage && term.language" class="has-text-grey-light">@{{ term.language }}</span>
-  </b-tooltip>
+  </o-tooltip>
 </template>
 
 <script lang="ts">

--- a/ui/src/components/auth/SignOutButton.vue
+++ b/ui/src/components/auth/SignOutButton.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="user">
-    <b-button @click="signOut" icon-right="power-off" title="Sign out">
+    <o-button @click="signOut" icon-right="power-off" title="Sign out">
       {{ user.name }}
-    </b-button>
+    </o-button>
   </div>
 </template>
 

--- a/ui/src/forms/FormObject.vue
+++ b/ui/src/forms/FormObject.vue
@@ -3,7 +3,7 @@
     <render-wc-template :template-result="renderEditor()" class="form-object-editor" />
     <div v-if="property.canRemove">
       <b-tooltip label="Remove value">
-        <b-button icon-left="minus" @click.prevent="actions.remove" type="is-text" />
+        <o-button icon-left="minus" @click.prevent="actions.remove" variant="text" />
       </b-tooltip>
     </div>
   </div>

--- a/ui/src/forms/FormObject.vue
+++ b/ui/src/forms/FormObject.vue
@@ -2,9 +2,9 @@
   <div v-if="isReady" class="form-object">
     <render-wc-template :template-result="renderEditor()" class="form-object-editor" />
     <div v-if="property.canRemove">
-      <b-tooltip label="Remove value">
+      <o-tooltip label="Remove value">
         <o-button icon-left="minus" @click.prevent="actions.remove" variant="text" />
-      </b-tooltip>
+      </o-tooltip>
     </div>
   </div>
   <loading-block v-else class="is-size-7 py-5" />

--- a/ui/src/forms/FormProperty.vue
+++ b/ui/src/forms/FormProperty.vue
@@ -3,12 +3,12 @@
     <span class="label">
       {{ property.name }}
     </span>
-    <b-field v-if="property.shape.description">
+    <o-field v-if="property.shape.description">
       <vue-markdown class="help" :anchor-attributes="linkAttrs" :source="property.shape.description" />
-    </b-field>
-    <b-field v-if="property.selectedEditor">
+    </o-field>
+    <o-field v-if="property.selectedEditor">
       <render-wc-template :template-result="renderMultiEditor()" />
-    </b-field>
+    </o-field>
     <div v-else v-for="object in property.objects" :key="object.key">
       <render-wc-template :template-result="renderObject({ object })" />
     </div>

--- a/ui/src/forms/FormProperty.vue
+++ b/ui/src/forms/FormProperty.vue
@@ -14,7 +14,7 @@
     </div>
     <div v-if="!property.selectedEditor && property.canAdd">
       <b-tooltip label="Add value">
-        <b-button icon-left="plus" @click.prevent="actions.addObject" type="is-text" />
+        <o-button icon-left="plus" @click.prevent="actions.addObject" variant="text" />
       </b-tooltip>
     </div>
   </label>

--- a/ui/src/forms/FormProperty.vue
+++ b/ui/src/forms/FormProperty.vue
@@ -13,9 +13,9 @@
       <render-wc-template :template-result="renderObject({ object })" />
     </div>
     <div v-if="!property.selectedEditor && property.canAdd">
-      <b-tooltip label="Add value">
+      <o-tooltip label="Add value">
         <o-button icon-left="plus" @click.prevent="actions.addObject" variant="text" />
-      </b-tooltip>
+      </o-tooltip>
     </div>
   </label>
 </template>

--- a/ui/src/forms/editors/CheckboxEditor.vue
+++ b/ui/src/forms/editors/CheckboxEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-checkbox :value="value" @input="emit" />
+  <o-checkbox :value="value" @input="emit" />
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/CheckboxListEditor.vue
+++ b/ui/src/forms/editors/CheckboxListEditor.vue
@@ -1,6 +1,6 @@
 <template>
-  <b-field>
-    <b-checkbox-button
+  <b-field :addons="false">
+    <o-checkbox
       v-for="[term, label] in choices"
       :key="term.value"
       :native-value="term.value"
@@ -8,7 +8,7 @@
       @input="emit"
     >
       <span>{{ label }}</span>
-    </b-checkbox-button>
+    </o-checkbox>
   </b-field>
 </template>
 

--- a/ui/src/forms/editors/CheckboxListEditor.vue
+++ b/ui/src/forms/editors/CheckboxListEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-field :addons="false">
+  <o-field :addons="false">
     <o-checkbox
       v-for="[term, label] in choices"
       :key="term.value"
@@ -9,7 +9,7 @@
     >
       <span>{{ label }}</span>
     </o-checkbox>
-  </b-field>
+  </o-field>
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/DatePickerEditor.vue
+++ b/ui/src/forms/editors/DatePickerEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-datepicker :value="dateValue" @input="onUpdate" icon="calendar-alt" />
+  <o-datepicker :value="dateValue" @input="onUpdate" icon="calendar-alt" />
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/DateTimePickerEditor.vue
+++ b/ui/src/forms/editors/DateTimePickerEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-datetimepicker :value="dateValue" @input="onUpdate" icon="calendar-alt" />
+  <o-datetimepicker :value="dateValue" @input="onUpdate" icon="calendar-alt" />
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/DictionaryTableEditor.vue
+++ b/ui/src/forms/editors/DictionaryTableEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <b-field>
+    <o-field>
       <b-radio-button
         v-for="filter in filters"
         :key="filter"
@@ -9,7 +9,7 @@
       >
         {{ filter }}
       </b-radio-button>
-    </b-field>
+    </o-field>
     <table class="terms-table">
       <tbody>
         <tr v-for="o in displayedObjects" :key="o.key" class="term-row">

--- a/ui/src/forms/editors/DictionaryTableEditor.vue
+++ b/ui/src/forms/editors/DictionaryTableEditor.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
     <o-field>
-      <b-radio-button
+      <radio-button
         v-for="filter in filters"
         :key="filter"
         :native-value="filter"
         v-model="selectedFilter"
       >
         {{ filter }}
-      </b-radio-button>
+      </radio-button>
     </o-field>
     <table class="terms-table">
       <tbody>
@@ -45,10 +45,11 @@ import { prov, sh } from '@tpluscode/rdf-ns-builders'
 import { Term } from 'rdf-js'
 import { PropertyShape } from '@rdfine/shacl'
 import { PropertyRenderer } from '@hydrofoil/shaperone-core/renderer'
+import RadioButton from '@/components/RadioButton.vue'
 import RenderWcTemplate from '../RenderWcTemplate.vue'
 
 @Component({
-  components: { RenderWcTemplate },
+  components: { RadioButton, RenderWcTemplate },
 })
 export default class extends Vue {
   @Prop() objects!: PropertyObjectState[]

--- a/ui/src/forms/editors/DictionaryTableEditor.vue
+++ b/ui/src/forms/editors/DictionaryTableEditor.vue
@@ -20,9 +20,9 @@
             />
           </td>
           <td class="term-remove-col">
-            <b-tooltip label="Remove value">
+            <o-tooltip label="Remove value">
               <o-button icon-left="minus" @click.prevent="renderer.actions.removeObject(o.object)" variant="white" />
-            </b-tooltip>
+            </o-tooltip>
           </td>
         </tr>
         <tr v-if="displayedObjects.length === 0">
@@ -32,9 +32,9 @@
         </tr>
       </tbody>
     </table>
-    <b-tooltip label="Add value">
+    <o-tooltip label="Add value">
       <o-button icon-left="plus" @click.prevent="renderer.actions.addObject" variant="white" />
-    </b-tooltip>
+    </o-tooltip>
   </div>
 </template>
 

--- a/ui/src/forms/editors/DictionaryTableEditor.vue
+++ b/ui/src/forms/editors/DictionaryTableEditor.vue
@@ -21,7 +21,7 @@
           </td>
           <td class="term-remove-col">
             <b-tooltip label="Remove value">
-              <b-button icon-left="minus" @click.prevent="renderer.actions.removeObject(o.object)" type="is-white" />
+              <o-button icon-left="minus" @click.prevent="renderer.actions.removeObject(o.object)" variant="white" />
             </b-tooltip>
           </td>
         </tr>
@@ -33,7 +33,7 @@
       </tbody>
     </table>
     <b-tooltip label="Add value">
-      <b-button icon-left="plus" @click.prevent="renderer.actions.addObject" type="is-white" />
+      <o-button icon-left="plus" @click.prevent="renderer.actions.addObject" variant="white" />
     </b-tooltip>
   </div>
 </template>

--- a/ui/src/forms/editors/FileUploadEditor.vue
+++ b/ui/src/forms/editors/FileUploadEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-field class="file is-primary" :class="{'has-name': !!file}">
+  <o-field class="file is-primary" :class="{'has-name': !!file}">
     <b-upload v-model="file" class="file-label" @input="onFileSelected">
       <span class="file-cta">
         <o-icon class="file-icon" icon="upload" />
@@ -9,7 +9,7 @@
         {{ file.name }}
       </span>
     </b-upload>
-  </b-field>
+  </o-field>
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/FileUploadEditor.vue
+++ b/ui/src/forms/editors/FileUploadEditor.vue
@@ -2,7 +2,7 @@
   <b-field class="file is-primary" :class="{'has-name': !!file}">
     <b-upload v-model="file" class="file-label" @input="onFileSelected">
       <span class="file-cta">
-        <b-icon class="file-icon" icon="upload" />
+        <o-icon class="file-icon" icon="upload" />
         <span class="file-label">Select file</span>
       </span>
       <span class="file-name" v-if="file">

--- a/ui/src/forms/editors/FileUploadEditor.vue
+++ b/ui/src/forms/editors/FileUploadEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <o-field class="file is-primary" :class="{'has-name': !!file}">
-    <b-upload v-model="file" class="file-label" @input="onFileSelected">
+    <o-upload v-model="file" class="file-label" @input="onFileSelected">
       <span class="file-cta">
         <o-icon class="file-icon" icon="upload" />
         <span class="file-label">Select file</span>
@@ -8,7 +8,7 @@
       <span class="file-name" v-if="file">
         {{ file.name }}
       </span>
-    </b-upload>
+    </o-upload>
   </o-field>
 </template>
 

--- a/ui/src/forms/editors/IdentifierTemplateEditor.vue
+++ b/ui/src/forms/editors/IdentifierTemplateEditor.vue
@@ -1,5 +1,8 @@
 <template>
-  <b-field :message="wasValidated ? invalidMessage : ''" :type="{ 'is-danger': wasValidated && invalidMessage }">
+  <o-field
+    :message="wasValidated ? invalidMessage : ''"
+    :variant="wasValidated && invalidMessage ? 'danger' : ''"
+  >
     <b-autocomplete
       ref="autocomplete"
       :value="value"
@@ -12,7 +15,7 @@
       placeholder="e.g. MyTable/{column_id}"
       :disabled="!source"
     />
-  </b-field>
+  </o-field>
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/IdentifierTemplateEditor.vue
+++ b/ui/src/forms/editors/IdentifierTemplateEditor.vue
@@ -3,7 +3,7 @@
     :message="wasValidated ? invalidMessage : ''"
     :variant="wasValidated && invalidMessage ? 'danger' : ''"
   >
-    <b-autocomplete
+    <o-autocomplete
       ref="autocomplete"
       :value="value"
       @input="update"

--- a/ui/src/forms/editors/PropertyInput.vue
+++ b/ui/src/forms/editors/PropertyInput.vue
@@ -1,6 +1,6 @@
 <template>
   <o-field :message="fullURI">
-    <b-autocomplete
+    <o-autocomplete
       :value="textValue"
       @input="onUpdate"
       :data="suggestions"

--- a/ui/src/forms/editors/PropertyInput.vue
+++ b/ui/src/forms/editors/PropertyInput.vue
@@ -1,11 +1,11 @@
 <template>
-  <b-field :message="fullURI">
+  <o-field :message="fullURI">
     <b-autocomplete
       :value="textValue"
       @input="onUpdate"
       :data="suggestions"
     />
-  </b-field>
+  </o-field>
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/RadioButtons.vue
+++ b/ui/src/forms/editors/RadioButtons.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-field :message="message">
+  <o-field :message="message">
     <b-radio-button
       v-for="option in choices"
       :key="option.value"
@@ -9,7 +9,7 @@
     >
       {{ label(option) }}
     </b-radio-button>
-  </b-field>
+  </o-field>
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/RadioButtons.vue
+++ b/ui/src/forms/editors/RadioButtons.vue
@@ -1,6 +1,6 @@
 <template>
   <o-field :message="message">
-    <b-radio-button
+    <radio-button
       v-for="option in choices"
       :key="option.value"
       :value="_value"
@@ -8,7 +8,7 @@
       @input="emit"
     >
       {{ label(option) }}
-    </b-radio-button>
+    </radio-button>
   </o-field>
 </template>
 
@@ -17,8 +17,11 @@ import { Prop, Component, Vue } from 'vue-property-decorator'
 import { GraphPointer, MultiPointer } from 'clownface'
 import { Term } from 'rdf-js'
 import { rdfs } from '@tpluscode/rdf-ns-builders'
+import RadioButton from '@/components/RadioButton.vue'
 
-@Component
+@Component({
+  components: { RadioButton },
+})
 export default class extends Vue {
   @Prop() options?: MultiPointer
   @Prop() value?: GraphPointer

--- a/ui/src/forms/editors/SelectEditor.vue
+++ b/ui/src/forms/editors/SelectEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-select class="select-editor" placeholder="Select" @input="onInput" :value="valueStr">
+  <o-select class="select-editor" placeholder="Select" @input="onInput" :value="valueStr">
     <option
       v-for="[option, label] in options"
       :value="option.term.value"
@@ -7,7 +7,7 @@
     >
       {{ label }}
     </option>
-  </b-select>
+  </o-select>
 </template>
 
 <style scoped>

--- a/ui/src/forms/editors/TagsWithLanguageEditor.vue
+++ b/ui/src/forms/editors/TagsWithLanguageEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <b-field v-for="([language, objects], languageIndex) in tags" :key="languageIndex" :addons="false" class="is-flex">
+    <o-field v-for="([language, objects], languageIndex) in tags" :key="languageIndex" :addons="false" class="is-flex">
       <b-taginput
         :value="objects"
         field="value"
@@ -13,7 +13,7 @@
           {{ languageOption }}
         </option>
       </b-select>
-    </b-field>
+    </o-field>
     <o-tooltip label="Add value">
       <o-button icon-left="plus" @click="addLanguage" variant="white" />
     </o-tooltip>

--- a/ui/src/forms/editors/TagsWithLanguageEditor.vue
+++ b/ui/src/forms/editors/TagsWithLanguageEditor.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <o-field v-for="([language, objects], languageIndex) in tags" :key="languageIndex" :addons="false" class="is-flex">
-      <b-taginput
+      <o-inputitems
         :value="objects"
         field="value"
         @add="addTag(languageIndex, language, $event)"

--- a/ui/src/forms/editors/TagsWithLanguageEditor.vue
+++ b/ui/src/forms/editors/TagsWithLanguageEditor.vue
@@ -15,7 +15,7 @@
       </b-select>
     </b-field>
     <b-tooltip label="Add value">
-      <b-button icon-left="plus" @click="addLanguage" type="is-white" />
+      <o-button icon-left="plus" @click="addLanguage" variant="white" />
     </b-tooltip>
   </div>
 </template>

--- a/ui/src/forms/editors/TagsWithLanguageEditor.vue
+++ b/ui/src/forms/editors/TagsWithLanguageEditor.vue
@@ -8,11 +8,11 @@
         @remove="removeTag(languageIndex, $event)"
         class="is-flex-grow-1"
       />
-      <b-select :value="language" @input="updateLanguage(languageIndex, $event)">
+      <o-select :value="language" @input="updateLanguage(languageIndex, $event)">
         <option v-for="languageOption in languages" :key="languageOption">
           {{ languageOption }}
         </option>
-      </b-select>
+      </o-select>
     </o-field>
     <o-tooltip label="Add value">
       <o-button icon-left="plus" @click="addLanguage" variant="white" />

--- a/ui/src/forms/editors/TagsWithLanguageEditor.vue
+++ b/ui/src/forms/editors/TagsWithLanguageEditor.vue
@@ -14,9 +14,9 @@
         </option>
       </b-select>
     </b-field>
-    <b-tooltip label="Add value">
+    <o-tooltip label="Add value">
       <o-button icon-left="plus" @click="addLanguage" variant="white" />
-    </b-tooltip>
+    </o-tooltip>
   </div>
 </template>
 

--- a/ui/src/forms/editors/TextFieldEditor.vue
+++ b/ui/src/forms/editors/TextFieldEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-input :value="value" @input="update" />
+  <o-input :value="value" @input="update" />
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/TextFieldWithLangEditor.vue
+++ b/ui/src/forms/editors/TextFieldWithLangEditor.vue
@@ -1,11 +1,11 @@
 <template>
   <o-field>
     <o-input :value="valueText" @input="updateValue" class="text-input" :type="inputType" />
-    <b-select :value="valueLanguage" @input="updateLanguage">
+    <o-select :value="valueLanguage" @input="updateLanguage">
       <option v-for="language in languages" :key="language">
         {{ language }}
       </option>
-    </b-select>
+    </o-select>
   </o-field>
 </template>
 

--- a/ui/src/forms/editors/TextFieldWithLangEditor.vue
+++ b/ui/src/forms/editors/TextFieldWithLangEditor.vue
@@ -1,12 +1,12 @@
 <template>
-  <b-field>
+  <o-field>
     <b-input :value="valueText" @input="updateValue" class="text-input" :type="inputType" />
     <b-select :value="valueLanguage" @input="updateLanguage">
       <option v-for="language in languages" :key="language">
         {{ language }}
       </option>
     </b-select>
-  </b-field>
+  </o-field>
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/TextFieldWithLangEditor.vue
+++ b/ui/src/forms/editors/TextFieldWithLangEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <o-field>
-    <b-input :value="valueText" @input="updateValue" class="text-input" :type="inputType" />
+    <o-input :value="valueText" @input="updateValue" class="text-input" :type="inputType" />
     <b-select :value="valueLanguage" @input="updateLanguage">
       <option v-for="language in languages" :key="language">
         {{ language }}

--- a/ui/src/forms/editors/URIInput.vue
+++ b/ui/src/forms/editors/URIInput.vue
@@ -1,6 +1,6 @@
 <template>
   <o-field :message="message">
-    <b-input :value="textValue" @blur="onUpdate" />
+    <o-input :value="textValue" @blur="onUpdate" />
   </o-field>
 </template>
 

--- a/ui/src/forms/editors/URIInput.vue
+++ b/ui/src/forms/editors/URIInput.vue
@@ -1,7 +1,7 @@
 <template>
-  <b-field :message="message">
+  <o-field :message="message">
     <b-input :value="textValue" @blur="onUpdate" />
-  </b-field>
+  </o-field>
 </template>
 
 <script lang="ts">

--- a/ui/src/forms/editors/index.ts
+++ b/ui/src/forms/editors/index.ts
@@ -51,25 +51,25 @@ export const textAreaWithLang: Lazy<SingleEditorComponent> = {
 export const instanceSelect: Lazy<InstancesSelectEditor> = {
   ...instancesSelectCore,
   async lazyRender () {
-    await import('./SelectEditor.vue').then(createCustomElement('b-select'))
+    await import('./SelectEditor.vue').then(createCustomElement('select-editor'))
 
-    return ({ property, value }, { update }) => html`<b-select .property="${property.shape}"
+    return ({ property, value }, { update }) => html`<select-editor .property="${property.shape}"
                           .update="${update}"
                           .options="${value.componentState.instances}"
-                          .value="${value.object?.term}"></b-select>`
+                          .value="${value.object?.term}"></select-editor>`
   }
 }
 
 export const enumSelect: Lazy<EnumSelectEditor> = {
   ...enumSelectCore,
   async lazyRender () {
-    await import('./SelectEditor.vue').then(createCustomElement('b-select'))
+    await import('./SelectEditor.vue').then(createCustomElement('select-editor'))
 
     return ({ property, value }, { update }) =>
-      html`<b-select .property="${property.shape}"
+      html`<select-editor .property="${property.shape}"
                           .update="${update}"
                           .options="${value.componentState.choices}"
-                          .value="${value.object?.term}"></b-select>`
+                          .value="${value.object?.term}"></select-editor>`
   }
 }
 

--- a/ui/src/forms/editors/index.ts
+++ b/ui/src/forms/editors/index.ts
@@ -15,9 +15,9 @@ import { Literal } from 'rdf-js'
 export const textField: Lazy<SingleEditorComponent> = {
   editor: dash.TextFieldEditor,
   async lazyRender () {
-    await import('./TextFieldEditor.vue').then(createCustomElement('b-textbox'))
+    await import('./TextFieldEditor.vue').then(createCustomElement('textfield-editor'))
 
-    return ({ value }, { update }) => html`<b-textbox .value="${value.object?.value || ''}" .update="${update}"></b-textbox>`
+    return ({ value }, { update }) => html`<textfield-editor .value="${value.object?.value || ''}" .update="${update}"></textfield-editor>`
   }
 }
 

--- a/ui/src/forms/editors/index.ts
+++ b/ui/src/forms/editors/index.ts
@@ -159,12 +159,12 @@ export const autoComplete: Lazy<InstancesSelectEditor> = {
 export const radioButtons: Lazy<SingleEditorComponent> = {
   editor: ns.editor.RadioButtons,
   async lazyRender () {
-    await import('./RadioButtons.vue').then(createCustomElement('b-radio'))
+    await import('./RadioButtons.vue').then(createCustomElement('radio-buttons'))
 
     return ({ property, value }, { update }) => {
       const items = property.shape.pointer.node(property.shape.in)
 
-      return html`<b-radio .options="${items}" .value="${value.object}" .update="${update}"></b-radio>`
+      return html`<radio-buttons .options="${items}" .value="${value.object}" .update="${update}"></radio-buttons>`
     }
   }
 }

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -27,7 +27,23 @@ Vue.use(Oruga, {
   iconComponent: 'FontAwesomeIcon',
   dropdown: {
     ...bulmaConfig.dropdown,
-    itemClass: (s: string, { props }: any) => props.itemClass || 'dropdown-item',
+    itemClass: (_: string, { props }: any) => props.itemClass || 'dropdown-item',
+  },
+  tooltip: {
+    ...bulmaConfig.tooltip,
+    rootClass: (_: string, { props }: any) => {
+      const classes = ['b-tooltip']
+
+      if (props.variant) {
+        classes.push(`is-${props.variant}`)
+      } else {
+        classes.push('is-light')
+      }
+
+      if (props.position) classes.push(`is-${props.position}`)
+
+      return classes.join(' ')
+    },
   },
 })
 

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -2,6 +2,8 @@ import Vue from 'vue'
 import * as Sentry from '@sentry/vue'
 import { Integrations } from '@sentry/tracing'
 import Buefy from 'buefy'
+import Oruga from '@oruga-ui/oruga'
+import { bulmaConfig } from '@oruga-ui/theme-bulma'
 import App from './App.vue'
 import router from './router'
 
@@ -18,6 +20,12 @@ import('./forms')
 iconsLibrary.add(fas)
 iconsLibrary.add(far)
 Vue.component('FontAwesomeIcon', FontAwesomeIcon)
+
+Vue.use(Oruga, {
+  ...bulmaConfig,
+  iconPack: 'fas',
+  iconComponent: 'FontAwesomeIcon',
+})
 
 Vue.use(Buefy, {
   defaultIconPack: 'fas',

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue'
 import * as Sentry from '@sentry/vue'
 import { Integrations } from '@sentry/tracing'
-import Buefy from 'buefy'
 import Oruga from '@oruga-ui/oruga'
 import { bulmaConfig } from '@oruga-ui/theme-bulma'
 import App from './App.vue'
@@ -45,13 +44,6 @@ Vue.use(Oruga, {
       return classes.join(' ')
     },
   },
-})
-
-Vue.use(Buefy, {
-  defaultIconPack: 'fas',
-  defaultIconComponent: 'FontAwesomeIcon',
-  defaultTooltipType: 'is-light',
-  defaultTooltipDelay: 200,
 })
 
 Sentry.init({

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -25,6 +25,10 @@ Vue.use(Oruga, {
   ...bulmaConfig,
   iconPack: 'fas',
   iconComponent: 'FontAwesomeIcon',
+  dropdown: {
+    ...bulmaConfig.dropdown,
+    itemClass: (s: string, { props }: any) => props.itemClass || 'dropdown-item',
+  },
 })
 
 Vue.use(Buefy, {

--- a/ui/src/store/modules/api.ts
+++ b/ui/src/store/modules/api.ts
@@ -52,7 +52,7 @@ const actions: ActionTree<APIState, RootState> = {
       context.commit('app/pushMessage', {
         title: 'An error occurred',
         message: `${e}`,
-        type: 'danger',
+        variant: 'danger',
       }, { root: true })
 
       throw e

--- a/ui/src/store/modules/api.ts
+++ b/ui/src/store/modules/api.ts
@@ -52,7 +52,7 @@ const actions: ActionTree<APIState, RootState> = {
       context.commit('app/pushMessage', {
         title: 'An error occurred',
         message: `${e}`,
-        type: 'is-danger',
+        type: 'danger',
       }, { root: true })
 
       throw e

--- a/ui/src/store/modules/api.ts
+++ b/ui/src/store/modules/api.ts
@@ -4,7 +4,6 @@ import { api } from '@/api'
 import { RootState } from '../types'
 import { GraphPointer } from 'clownface'
 import RdfResourceImpl, { ResourceIdentifier } from '@tpluscode/rdfine'
-import { ToastProgrammatic as Toast } from 'buefy'
 import { dcat } from '@tpluscode/rdf-ns-builders'
 
 export interface APIState {
@@ -40,16 +39,16 @@ const actions: ActionTree<APIState, RootState> = {
     try {
       await api.invokeDeleteOperation(operation)
 
-      Toast.open({
+      context.dispatch('app/showMessage', {
         message: successMessage,
-        type: 'is-success',
-      })
+        variant: 'success',
+      }, { root: true })
 
       if (callbackAction) {
         context.dispatch(callbackAction, callbackParams, { root: true })
       }
     } catch (e) {
-      context.commit('app/pushMessage', {
+      context.dispatch('app/showMessage', {
         title: 'An error occurred',
         message: `${e}`,
         variant: 'danger',

--- a/ui/src/store/modules/app.ts
+++ b/ui/src/store/modules/app.ts
@@ -5,7 +5,7 @@ import { RootState } from '../types'
 export interface Message {
   title: string
   message: string
-  type: 'is-info' | 'is-success' | 'is-danger'
+  type: 'info' | 'success' | 'danger'
 }
 
 export interface AppState {

--- a/ui/src/store/modules/app.ts
+++ b/ui/src/store/modules/app.ts
@@ -1,11 +1,12 @@
 import { ActionTree, MutationTree, GetterTree } from 'vuex'
+import { ColorsModifiers } from '@oruga-ui/oruga/types/helpers'
 import { loadCommonProperties } from '@/rdf-properties'
 import { RootState } from '../types'
 
 export interface Message {
-  title: string
+  title?: string
   message: string
-  type: 'info' | 'success' | 'danger'
+  variant: ColorsModifiers
 }
 
 export interface AppState {

--- a/ui/src/styles/_loading.scss
+++ b/ui/src/styles/_loading.scss
@@ -1,0 +1,47 @@
+// Copied over from Buefy when transitionning to Oruga
+
+$loading-background-legacy: #7f7f7f !default;
+$loading-background: rgba(255,255,255,0.5) !default;
+$loading-icon-size: 3em !default;
+$loading-full-page-icon-size: 5em !default;
+
+.loading-overlay {
+    @include overlay;
+    align-items: center;
+    display: none;
+    justify-content: center;
+    overflow: hidden;
+    z-index: 29;
+    &.is-active {
+        display: flex
+    }
+    &.is-full-page {
+        position: fixed;
+        z-index: 999;
+        .loading-icon {
+            &:after {
+                top: calc(50% - #{$loading-full-page-icon-size * 0.5});
+                left: calc(50% - #{$loading-full-page-icon-size * 0.5});
+                width: $loading-full-page-icon-size;
+                height: $loading-full-page-icon-size;
+            }
+        }
+    }
+    .loading-background {
+        @include overlay;
+        background:$loading-background-legacy;
+        background:$loading-background;
+    }
+    .loading-icon {
+        position: relative;
+        &:after {
+            @include loader;
+            position: absolute;
+            top: calc(50% - #{$loading-icon-size * 0.5});
+            left: calc(50% - #{$loading-icon-size * 0.5});
+            width: $loading-icon-size;
+            height: $loading-icon-size;
+            border-width: 0.25em;
+        }
+    }
+}

--- a/ui/src/styles/bulma.scss
+++ b/ui/src/styles/bulma.scss
@@ -16,6 +16,7 @@ $panel-radius: 0;
 // Import Bulma and Buefy styles
 @import "~bulma";
 @import "~buefy/src/scss/buefy";
+@import "./loading";
 
 .panel-block,
 .panel-heading,

--- a/ui/src/styles/bulma.scss
+++ b/ui/src/styles/bulma.scss
@@ -41,3 +41,5 @@ $panel-radius: 0;
     border-color: $tabs-toggle-link-active-border-color;
     color: $tabs-toggle-link-active-color;
 }
+
+@import '~@oruga-ui/theme-bulma/dist/scss/bulma';

--- a/ui/src/styles/bulma.scss
+++ b/ui/src/styles/bulma.scss
@@ -13,9 +13,8 @@ $panel-shadow: none;
 $panel-heading-size: 1rem;
 $panel-radius: 0;
 
-// Import Bulma and Buefy styles
 @import "~bulma";
-@import "~buefy/src/scss/buefy";
+@import '~@oruga-ui/theme-bulma/dist/scss/bulma';
 @import "./loading";
 
 .panel-block,
@@ -46,5 +45,3 @@ $panel-radius: 0;
     border-color: $tabs-toggle-link-active-border-color;
     color: $tabs-toggle-link-active-color;
 }
-
-@import '~@oruga-ui/theme-bulma/dist/scss/bulma';

--- a/ui/src/styles/bulma.scss
+++ b/ui/src/styles/bulma.scss
@@ -45,3 +45,9 @@ $panel-radius: 0;
     border-color: $tabs-toggle-link-active-border-color;
     color: $tabs-toggle-link-active-color;
 }
+
+// Fix an issue in Oruga where the input doesn't have the proper `file-input`
+// class and there is no way to inject it in the configuration.
+.file > .file-label > input[type=file] {
+    @extend .file-input;
+}

--- a/ui/src/styles/bulma.scss
+++ b/ui/src/styles/bulma.scss
@@ -37,6 +37,10 @@ $panel-radius: 0;
     flex-grow: 1;
 }
 
+.panel-block input[type=checkbox] {
+    margin-right: 0;
+}
+
 .tabs.is-highlighted li.is-active a {
     background-color: $tabs-toggle-link-active-background-color;
     border-color: $tabs-toggle-link-active-border-color;

--- a/ui/src/styles/utilities.scss
+++ b/ui/src/styles/utilities.scss
@@ -57,3 +57,13 @@
 .w-20 {
     width: 5rem;
 }
+
+@keyframes spin {
+    to {
+        transform: rotate(1turn);
+    }
+}
+
+.animate-spin {
+    animation: spin 1s linear infinite;
+}

--- a/ui/src/use-dialog.ts
+++ b/ui/src/use-dialog.ts
@@ -1,0 +1,44 @@
+import DialogConfirm from './components/DialogConfirm.vue'
+import type { ColorsModifiers } from '@oruga-ui/oruga/types/helpers'
+
+interface ConfirmOptions {
+  title?: string
+  message: string
+  confirmText?: string
+  variant?: ColorsModifiers
+  hasIcon?: boolean
+  onConfirm?: () => void
+  onCancel?: () => void
+}
+
+export function confirmDialog (parent: any, options: ConfirmOptions) {
+  const defaultOptions = {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onConfirm: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onCancel: () => {},
+  }
+
+  const finalOptions = {
+    ...defaultOptions,
+    ...options,
+  }
+
+  parent.$oruga.modal.open({
+    parent,
+    component: DialogConfirm,
+    props: {
+      title: finalOptions.title,
+      message: finalOptions.message,
+      confirmText: finalOptions.confirmText,
+      hasIcon: finalOptions.hasIcon,
+      variant: finalOptions.variant,
+    },
+    events: {
+      cancel: finalOptions.onCancel,
+      confirm: finalOptions.onConfirm,
+    },
+    trapFocus: true,
+    onCancel: finalOptions.onCancel,
+  })
+}

--- a/ui/src/use-toast.ts
+++ b/ui/src/use-toast.ts
@@ -1,0 +1,10 @@
+import { Message } from './store/modules/app'
+
+export function displayToast (component: any, message: Message) {
+  component.$oruga.notification.open({
+    rootClass: 'toast-notification',
+    position: 'top',
+    duration: 2000,
+    ...message,
+  })
+}

--- a/ui/src/views/CSVMapping.vue
+++ b/ui/src/views/CSVMapping.vue
@@ -15,7 +15,7 @@
       </div>
       <div class="column is-1">
         <p class="has-text-centered">
-          <b-icon icon="arrow-right" size="is-small" />
+          <o-icon icon="arrow-right" size="small" />
         </p>
       </div>
       <div class="column is-5">

--- a/ui/src/views/CSVReplace.vue
+++ b/ui/src/views/CSVReplace.vue
@@ -40,6 +40,7 @@ import CsvUploadForm from '@/components/CsvUploadForm.vue'
 import SidePane from '@/components/SidePane.vue'
 import BMessage from '@/components/BMessage.vue'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { BMessage, CsvUploadForm, SidePane },
@@ -83,9 +84,9 @@ export default class CSVReplaceView extends Vue {
     try {
       await api.invokeSaveOperation(operation, resource)
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'CSV file was successfully replaced',
-        type: 'is-success',
+        variant: 'success',
       })
 
       await this.close()

--- a/ui/src/views/CSVReplace.vue
+++ b/ui/src/views/CSVReplace.vue
@@ -38,10 +38,11 @@ import { CsvMapping, CsvSource } from '@cube-creator/model'
 import { api } from '@/api'
 import CsvUploadForm from '@/components/CsvUploadForm.vue'
 import SidePane from '@/components/SidePane.vue'
+import BMessage from '@/components/BMessage.vue'
 import * as storeNs from '../store/namespace'
 
 @Component({
-  components: { CsvUploadForm, SidePane },
+  components: { BMessage, CsvUploadForm, SidePane },
 })
 export default class CSVReplaceView extends Vue {
   @storeNs.project.State('csvMapping') mapping!: CsvMapping

--- a/ui/src/views/CSVReplace.vue
+++ b/ui/src/views/CSVReplace.vue
@@ -4,11 +4,11 @@
       {{ error }}
     </b-message>
 
-    <b-field>
+    <o-field>
       <p>
         You can upload a new CSV file to replace <em>{{ source.name }}</em>.
       </p>
-    </b-field>
+    </o-field>
 
     <b-message type="is-info">
       <ul class="list-disc list-inside">

--- a/ui/src/views/CSVUpload.vue
+++ b/ui/src/views/CSVUpload.vue
@@ -22,13 +22,14 @@ import { Component, Vue } from 'vue-property-decorator'
 import { CsvMapping } from '@cube-creator/model'
 
 import { api } from '@/api'
+import BMessage from '@/components/BMessage.vue'
 import CsvUploadForm from '@/components/CsvUploadForm.vue'
 import FormSubmitCancel from '@/components/FormSubmitCancel.vue'
 import SidePane from '@/components/SidePane.vue'
 import * as storeNs from '../store/namespace'
 
 @Component({
-  components: { CsvUploadForm, SidePane, FormSubmitCancel },
+  components: { BMessage, CsvUploadForm, SidePane, FormSubmitCancel },
 })
 export default class CSVUploadView extends Vue {
   @storeNs.project.State('csvMapping') mapping!: CsvMapping

--- a/ui/src/views/CSVUpload.vue
+++ b/ui/src/views/CSVUpload.vue
@@ -27,6 +27,7 @@ import CsvUploadForm from '@/components/CsvUploadForm.vue'
 import FormSubmitCancel from '@/components/FormSubmitCancel.vue'
 import SidePane from '@/components/SidePane.vue'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { BMessage, CsvUploadForm, SidePane, FormSubmitCancel },
@@ -63,9 +64,9 @@ export default class CSVUploadView extends Vue {
     try {
       await Promise.all(uploads)
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'CSV files were successfully uploaded',
-        type: 'is-success',
+        variant: 'success',
       })
 
       await this.close()

--- a/ui/src/views/ColumnMappingCreate.vue
+++ b/ui/src/views/ColumnMappingCreate.vue
@@ -47,6 +47,7 @@ import ReferenceColumnMappingForm from '@/components/ReferenceColumnMappingForm.
 import LiteralColumnMappingForm from '@/components/LiteralColumnMappingForm.vue'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 type ColumnMappingType = 'literal' | 'reference'
 
@@ -97,9 +98,9 @@ export default class CubeProjectEditView extends Vue {
 
       this.$store.commit('project/storeNewColumnMapping', { table: this.table, columnMapping })
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Column mapping was successfully created',
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'CSVMapping' })

--- a/ui/src/views/ColumnMappingCreate.vue
+++ b/ui/src/views/ColumnMappingCreate.vue
@@ -1,13 +1,13 @@
 <template>
   <side-pane :title="operation.title" @close="onCancel">
-    <b-field label="Column mapping type">
+    <o-field label="Column mapping type">
       <b-radio-button v-model="columnMappingType" native-value="literal">
         Literal value
       </b-radio-button>
       <b-radio-button v-model="columnMappingType" native-value="reference">
         Link to another table
       </b-radio-button>
-    </b-field>
+    </o-field>
 
     <literal-column-mapping-form
       v-if="columnMappingType === 'literal'"

--- a/ui/src/views/ColumnMappingCreate.vue
+++ b/ui/src/views/ColumnMappingCreate.vue
@@ -1,12 +1,12 @@
 <template>
   <side-pane :title="operation.title" @close="onCancel">
     <o-field label="Column mapping type">
-      <b-radio-button v-model="columnMappingType" native-value="literal">
+      <radio-button v-model="columnMappingType" native-value="literal">
         Literal value
-      </b-radio-button>
-      <b-radio-button v-model="columnMappingType" native-value="reference">
+      </radio-button>
+      <radio-button v-model="columnMappingType" native-value="reference">
         Link to another table
-      </b-radio-button>
+      </radio-button>
     </o-field>
 
     <literal-column-mapping-form
@@ -41,6 +41,7 @@ import { RuntimeOperation } from 'alcaeus'
 import { GraphPointer } from 'clownface'
 import { Term } from 'rdf-js'
 import { CsvSource, Table } from '@cube-creator/model'
+import RadioButton from '@/components/RadioButton.vue'
 import SidePane from '@/components/SidePane.vue'
 import ReferenceColumnMappingForm from '@/components/ReferenceColumnMappingForm.vue'
 import LiteralColumnMappingForm from '@/components/LiteralColumnMappingForm.vue'
@@ -50,7 +51,7 @@ import * as storeNs from '../store/namespace'
 type ColumnMappingType = 'literal' | 'reference'
 
 @Component({
-  components: { SidePane, LiteralColumnMappingForm, ReferenceColumnMappingForm },
+  components: { RadioButton, SidePane, LiteralColumnMappingForm, ReferenceColumnMappingForm },
 })
 export default class CubeProjectEditView extends Vue {
   @storeNs.project.Getter('findTable') findTable!: (id: string) => Table

--- a/ui/src/views/ColumnMappingEdit.vue
+++ b/ui/src/views/ColumnMappingEdit.vue
@@ -39,6 +39,7 @@ import ReferenceColumnMappingForm from '@/components/ReferenceColumnMappingForm.
 import LiteralColumnMappingForm from '@/components/LiteralColumnMappingForm.vue'
 import { Term } from 'rdf-js'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, LiteralColumnMappingForm, ReferenceColumnMappingForm },
@@ -89,9 +90,9 @@ export default class CubeProjectEditView extends Vue {
 
       this.$store.commit('project/storeUpdatedColumnMapping', { table: this.table, columnMapping })
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Column mapping was successfully updated',
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'CSVMapping' })

--- a/ui/src/views/CubeMetadataEdit.vue
+++ b/ui/src/views/CubeMetadataEdit.vue
@@ -27,6 +27,7 @@ import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import { cc, cube } from '@cube-creator/core/namespace'
 import { conciseBoundedDescription } from '@/graph'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationFormWithRaw },
@@ -75,9 +76,9 @@ export default class CubeMetadataEdit extends Vue {
 
       this.$store.dispatch('project/fetchCubeMetadata')
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Cube metadata was saved',
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'CubeDesigner' })

--- a/ui/src/views/CubeProject.vue
+++ b/ui/src/views/CubeProject.vue
@@ -4,14 +4,14 @@
       <ul>
         <router-link :to="{ name: 'CubeProjectEdit' }" v-slot="{ href, isActive, navigate }" custom>
           <li :class="{ 'is-active': isActive }">
-            <b-tooltip label="Project settings">
+            <o-tooltip label="Project settings">
               <a :href="href" @click="navigate">
                 <h2 class="project-title has-text-weight-bold truncate">
                   {{ project.title }}
                 </h2>
                 <b-icon icon="cog" class="ml-1" />
               </a>
-            </b-tooltip>
+            </o-tooltip>
           </li>
         </router-link>
         <router-link v-if="hasCSVMapping" :to="{ name: 'CSVMapping' }" v-slot="{ href, isActive, navigate }" custom>

--- a/ui/src/views/CubeProject.vue
+++ b/ui/src/views/CubeProject.vue
@@ -9,7 +9,7 @@
                 <h2 class="project-title has-text-weight-bold truncate">
                   {{ project.title }}
                 </h2>
-                <b-icon icon="cog" class="ml-1" />
+                <o-icon icon="cog" class="ml-1" />
               </a>
             </o-tooltip>
           </li>

--- a/ui/src/views/CubeProjectCreate.vue
+++ b/ui/src/views/CubeProjectCreate.vue
@@ -25,6 +25,7 @@ import SidePane from '@/components/SidePane.vue'
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
 import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationForm },
@@ -59,9 +60,9 @@ export default class extends Vue {
         resource,
       })
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: `Project ${project.title} successfully created`,
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'CubeProject', params: { id: project.clientPath } })

--- a/ui/src/views/CubeProjectEdit.vue
+++ b/ui/src/views/CubeProjectEdit.vue
@@ -31,9 +31,9 @@
         Delete all data related to this project. This operation is not revertible!
       </p>
       <b-field v-if="project.actions.delete">
-        <b-button icon-left="trash" type="is-danger" @click="deleteProject">
+        <o-button icon-left="trash" variant="danger" @click="deleteProject">
           {{ project.actions.delete.title }}
-        </b-button>
+        </o-button>
       </b-field>
     </div>
   </div>

--- a/ui/src/views/CubeProjectEdit.vue
+++ b/ui/src/views/CubeProjectEdit.vue
@@ -19,9 +19,9 @@
       <h3 class="title is-5">
         Export project
       </h3>
-      <b-field>
+      <o-field>
         <download-button :resource="project.export" />
-      </b-field>
+      </o-field>
     </div>
     <div class="box container-narrow" v-if="project.actions.delete">
       <h3 class="title is-5">
@@ -30,11 +30,11 @@
       <p class="block">
         Delete all data related to this project. This operation is not revertible!
       </p>
-      <b-field v-if="project.actions.delete">
+      <o-field v-if="project.actions.delete">
         <o-button icon-left="trash" variant="danger" @click="deleteProject">
           {{ project.actions.delete.title }}
         </o-button>
-      </b-field>
+      </o-field>
     </div>
   </div>
 </template>

--- a/ui/src/views/CubeProjectEdit.vue
+++ b/ui/src/views/CubeProjectEdit.vue
@@ -50,6 +50,7 @@ import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import * as storeNs from '../store/namespace'
 import { displayToast } from '@/use-toast'
+import { confirmDialog } from '@/use-dialog'
 
 @Component({
   components: { HydraOperationForm, DownloadButton },
@@ -102,12 +103,10 @@ export default class CubeProjectEditView extends Vue {
   }
 
   async deleteProject (): Promise<void> {
-    this.$buefy.dialog.confirm({
+    confirmDialog(this, {
       title: this.project.actions.delete?.title,
       message: 'Are you sure you want to delete this project? This action is not revertible.',
       confirmText: 'Delete',
-      type: 'is-danger',
-      hasIcon: true,
       onConfirm: async () => {
         await this.$store.dispatch('api/invokeDeleteOperation', {
           operation: this.project.actions.delete,

--- a/ui/src/views/CubeProjectEdit.vue
+++ b/ui/src/views/CubeProjectEdit.vue
@@ -49,6 +49,7 @@ import { Shape } from '@rdfine/shacl'
 import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { HydraOperationForm, DownloadButton },
@@ -85,9 +86,9 @@ export default class CubeProjectEditView extends Vue {
 
       this.$store.commit('project/storeProject', project)
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Project settings were saved',
-        type: 'is-success',
+        variant: 'success',
       })
     } catch (e) {
       this.error = e.details ?? { detail: e.toString() }

--- a/ui/src/views/CubeProjects.vue
+++ b/ui/src/views/CubeProjects.vue
@@ -8,8 +8,8 @@
         <hydra-operation-button
           :operation="projectsCollection.actions.create"
           :to="{ name: 'CubeProjectCreate' }"
-          type="is-default"
-          size=""
+          variant="default"
+          size="normal"
         >
           {{ projectsCollection.actions.create.title }}
         </hydra-operation-button>

--- a/ui/src/views/DimensionEdit.vue
+++ b/ui/src/views/DimensionEdit.vue
@@ -32,6 +32,7 @@ import { conciseBoundedDescription } from '@/graph'
 import * as storeNs from '../store/namespace'
 import { rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
 import { meta } from '@cube-creator/core/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationFormWithRaw, TermDisplay },
@@ -108,9 +109,9 @@ export default class extends Vue {
 
       this.$store.dispatch('project/refreshDimensionMetadataCollection')
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Dimension metadata was saved',
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'CubeDesigner' })

--- a/ui/src/views/DimensionEdit.vue
+++ b/ui/src/views/DimensionEdit.vue
@@ -1,8 +1,8 @@
 <template>
   <side-pane :title="title" @close="onCancel">
-    <b-field label="Dimension property">
+    <o-field label="Dimension property">
       <term-display v-if="dimension.about" :term="dimension.about" :base="cubeUri" />
-    </b-field>
+    </o-field>
     <hydra-operation-form-with-raw
       v-if="resource && operation"
       :operation="operation"

--- a/ui/src/views/DimensionMapping.vue
+++ b/ui/src/views/DimensionMapping.vue
@@ -27,6 +27,7 @@ import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import { RdfResource } from '@tpluscode/rdfine/RdfResource'
 import { serializeResource } from '../store/serializers'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationForm, TermDisplay },
@@ -78,9 +79,9 @@ export default class extends Vue {
 
       this.$store.dispatch('project/fetchDimensionMetadataCollection')
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Mapping to shared dimension was saved',
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'CubeDesigner' })

--- a/ui/src/views/Job.vue
+++ b/ui/src/views/Job.vue
@@ -51,7 +51,7 @@
       <pre v-if="job.error && job.error.description" class="has-background-danger-light">
         {{ job.error.description }}
       </pre>
-      <b-message v-if="job.error && job.error.validationReport" type="is-danger" title="Validation error" :closable="false">
+      <b-message v-if="job.error && job.error.validationReport" type="is-danger" title="Validation error">
         <validation-report-display :report="job.error.validationReport" />
       </b-message>
     </div>
@@ -65,6 +65,7 @@ import type { CreativeWork } from '@rdfine/schema'
 import { schema } from '@tpluscode/rdf-ns-builders'
 import { Component, Vue } from 'vue-property-decorator'
 import VueMarkdown from 'vue-markdown/src/VueMarkdown'
+import BMessage from '@/components/BMessage.vue'
 import ExternalTerm from '@/components/ExternalTerm.vue'
 import JobStatus from '../components/JobStatus.vue'
 import LoadingBlock from '../components/LoadingBlock.vue'
@@ -72,7 +73,7 @@ import ValidationReportDisplay from '../components/ValidationReportDisplay.vue'
 import * as storeNs from '../store/namespace'
 
 @Component({
-  components: { ExternalTerm, JobStatus, LoadingBlock, ValidationReportDisplay, VueMarkdown },
+  components: { BMessage, ExternalTerm, JobStatus, LoadingBlock, ValidationReportDisplay, VueMarkdown },
 })
 export default class JobView extends Vue {
   @storeNs.app.State('language') language!: string[]

--- a/ui/src/views/Job.vue
+++ b/ui/src/views/Job.vue
@@ -10,15 +10,15 @@
       </p>
     </header>
     <div class="is-flex gap-1">
-      <b-tag v-if="job.revision">
+      <span v-if="job.revision" class="tag">
         Version {{ job.revision }}
-      </b-tag>
-      <b-tag v-if="job.status">
+      </span>
+      <span v-if="job.status" class="tag">
         <ExternalTerm :resource="job.status" />
-      </b-tag>
-      <b-tag v-if="job.publishedTo">
+      </span>
+      <span v-if="job.publishedTo" class="tag">
         <ExternalTerm :resource="job.publishedTo" />
-      </b-tag>
+      </span>
     </div>
     <div class="is-flex gap-1">
       <a v-if="job.query" :href="job.query" target="_blank" rel="noopener" class="button is-small">

--- a/ui/src/views/Job.vue
+++ b/ui/src/views/Job.vue
@@ -23,7 +23,7 @@
     <div class="is-flex gap-1">
       <a v-if="job.query" :href="job.query" target="_blank" rel="noopener" class="button is-small">
         <span>Open in LINDAS</span>
-        <b-icon icon="chevron-right" />
+        <o-icon icon="chevron-right" />
       </a>
       <a
         v-for="workExample in job.workExamples"
@@ -34,7 +34,7 @@
         class="button is-small"
       >
         <span>{{ workExampleLabel(workExample) }}</span>
-        <b-icon icon="external-link-alt" />
+        <o-icon icon="external-link-alt" />
       </a>
     </div>
     <div>
@@ -45,7 +45,7 @@
         <vue-markdown :source="comment" />
       </b-message>
       <a :disabled="!link" :href="link" target="_blank" rel="noopener noreferer" class="button is-small mb-1">
-        <b-icon icon="book" />
+        <o-icon icon="book" />
         <span>View full log</span>
       </a>
       <pre v-if="job.error && job.error.description" class="has-background-danger-light">

--- a/ui/src/views/Logout.vue
+++ b/ui/src/views/Logout.vue
@@ -15,9 +15,12 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
+import BMessage from '../components/BMessage.vue'
 import * as storeNs from '../store/namespace'
 
-@Component
+@Component({
+  components: { BMessage },
+})
 export default class LogoutView extends Vue {
   @storeNs.auth.Getter('oidcIsAuthenticated') isAuthenticated!: boolean
 

--- a/ui/src/views/MaterializeJobs.vue
+++ b/ui/src/views/MaterializeJobs.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <div class="mb-1">
-      <b-button tag="router-link" :to="{ name: 'Materialize' }" icon-left="arrow-left" size="is-small">
+      <o-button tag="router-link" :to="{ name: 'Materialize' }" icon-left="arrow-left" size="small">
         Back to {{ materializeLabel }}
-      </b-button>
+      </o-button>
     </div>
     <div class="box container-narrow">
       <router-view />

--- a/ui/src/views/Publication.vue
+++ b/ui/src/views/Publication.vue
@@ -14,7 +14,7 @@
           :operation="jobCollection.actions.createUnlist"
           :confirm="true"
           confirmation-message="Are you sure you want to unlist this cube? This operation is not reversible."
-          submit-button-type="is-danger"
+          submit-button-variant="danger"
           class="box"
         />
       </div>

--- a/ui/src/views/Publication.vue
+++ b/ui/src/views/Publication.vue
@@ -29,15 +29,15 @@
       <div v-if="jobs.length > 0" class="panel container-narrow">
         <job-item v-for="job in jobs" :key="job.clientPath" :job="job" detail-view="PublicationJob" class="panel-block">
           <div class="is-flex-grow-1 is-flex gap-1">
-            <b-tag v-if="job.revision">
+            <span v-if="job.revision" class="tag">
               Version {{ job.revision }}
-            </b-tag>
-            <b-tag v-if="job.status">
+            </span>
+            <span v-if="job.status" class="tag">
               <ExternalTerm :resource="job.status" />
-            </b-tag>
-            <b-tag v-if="job.publishedTo">
+            </span>
+            <span v-if="job.publishedTo" class="tag">
               <ExternalTerm :resource="job.publishedTo" />
-            </b-tag>
+            </span>
           </div>
         </job-item>
       </div>

--- a/ui/src/views/PublicationJobs.vue
+++ b/ui/src/views/PublicationJobs.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <div class="mb-1">
-      <b-button tag="router-link" :to="{ name: 'Publication' }" icon-left="arrow-left" size="is-small">
+      <o-button tag="router-link" :to="{ name: 'Publication' }" icon-left="arrow-left" size="small">
         Back to publication
-      </b-button>
+      </o-button>
     </div>
     <div class="box container-narrow">
       <router-view />

--- a/ui/src/views/SharedDimension.vue
+++ b/ui/src/views/SharedDimension.vue
@@ -78,9 +78,9 @@
             <td>
               <div class="is-flex is-justify-content-space-between">
                 <div>
-                  <b-tag v-if="term.validThrough <= new Date()" type="is-warning is-light">
+                  <span v-if="term.validThrough <= new Date()" class="tag is-warning is-light">
                     deprecated
-                  </b-tag>
+                  </span>
                 </div>
                 <div>
                   <shared-dimension-term-link :term="term" />

--- a/ui/src/views/SharedDimension.vue
+++ b/ui/src/views/SharedDimension.vue
@@ -11,7 +11,7 @@
         <div class="is-flex is-align-items-center gap-1">
           <hydra-operation-button :operation="dimension.actions.replace" :to="{ name: 'SharedDimensionEdit' }" />
           <hydra-operation-button :operation="dimension.actions.delete" @click="deleteDimension(dimension)" />
-          <download-button :resource="dimension.export" size="is-small" type="is-white" />
+          <download-button :resource="dimension.export" size="small" variant="white" />
         </div>
       </div>
       <table class="table is-narrow is-bordered is-striped is-fullwidth">
@@ -28,7 +28,7 @@
                 v-if="dimension.actions.create"
                 :operation="dimension.actions.create"
                 :to="{ name: 'SharedDimensionTermCreate' }"
-                type="is-default"
+                variant="default"
               >
                 {{ dimension.actions.create.title }}
               </hydra-operation-button>
@@ -101,14 +101,14 @@
                 <div class="is-flex is-align-items-center gap-1">
                   <span class="pr-1">Page {{ page }}</span>
                   <b-tooltip label="Previous page">
-                    <b-button
+                    <o-button
                       icon-left="chevron-left"
                       @click="prevPage"
                       :disabled="!terms.data || page === 1"
                     />
                   </b-tooltip>
                   <b-tooltip label="Next page">
-                    <b-button
+                    <o-button
                       icon-left="chevron-right"
                       @click="nextPage"
                       :disabled="!terms.data || terms.data.length === 0"

--- a/ui/src/views/SharedDimension.vue
+++ b/ui/src/views/SharedDimension.vue
@@ -100,28 +100,28 @@
               <div class="is-flex gap-4">
                 <div class="is-flex is-align-items-center gap-1">
                   <span class="pr-1">Page {{ page }}</span>
-                  <b-tooltip label="Previous page">
+                  <o-tooltip label="Previous page">
                     <o-button
                       icon-left="chevron-left"
                       @click="prevPage"
                       :disabled="!terms.data || page === 1"
                     />
-                  </b-tooltip>
-                  <b-tooltip label="Next page">
+                  </o-tooltip>
+                  <o-tooltip label="Next page">
                     <o-button
                       icon-left="chevron-right"
                       @click="nextPage"
                       :disabled="!terms.data || terms.data.length === 0"
                     />
-                  </b-tooltip>
+                  </o-tooltip>
                 </div>
-                <b-tooltip label="Page size">
+                <o-tooltip label="Page size">
                   <b-select :value="pageSize" @input="changePageSize" title="Page size">
                     <option v-for="pageSizeOption in pageSizes" :key="pageSizeOption" :native-value="pageSizeOption">
                       {{ pageSizeOption }}
                     </option>
                   </b-select>
-                </b-tooltip>
+                </o-tooltip>
               </div>
             </td>
           </tr>

--- a/ui/src/views/SharedDimension.vue
+++ b/ui/src/views/SharedDimension.vue
@@ -147,6 +147,7 @@ import TermWithLanguage from '@/components/TermWithLanguage.vue'
 import DownloadButton from '@/components/DownloadButton.vue'
 import * as storeNs from '../store/namespace'
 import { SharedDimension, SharedDimensionTerm } from '../store/types'
+import { confirmDialog } from '@/use-dialog'
 
 @Component({
   components: {
@@ -183,12 +184,10 @@ export default class extends Vue {
   }
 
   deleteDimension (dimension: SharedDimension): void {
-    this.$buefy.dialog.confirm({
+    confirmDialog(this, {
       title: dimension.actions.delete?.title,
       message: 'Are you sure you want to delete this shared dimension?',
       confirmText: 'Delete',
-      type: 'is-danger',
-      hasIcon: true,
       onConfirm: async () => {
         await this.$store.dispatch('api/invokeDeleteOperation', {
           operation: dimension.actions.delete,
@@ -200,12 +199,10 @@ export default class extends Vue {
   }
 
   deleteTerm (term: SharedDimensionTerm): void {
-    this.$buefy.dialog.confirm({
+    confirmDialog(this, {
       title: term.actions.delete?.title,
       message: 'Are you sure you want to delete this term?',
       confirmText: 'Delete',
-      type: 'is-danger',
-      hasIcon: true,
       onConfirm: () => {
         this.$store.dispatch('api/invokeDeleteOperation', {
           operation: term.actions.delete,

--- a/ui/src/views/SharedDimension.vue
+++ b/ui/src/views/SharedDimension.vue
@@ -137,6 +137,7 @@
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator'
 import HydraOperationButton from '@/components/HydraOperationButton.vue'
+import BMessage from '@/components/BMessage.vue'
 import LoadingBlock from '@/components/LoadingBlock.vue'
 import PageContent from '@/components/PageContent.vue'
 import SharedDimensionTags from '@/components/SharedDimensionTags.vue'
@@ -149,6 +150,7 @@ import { SharedDimension, SharedDimensionTerm } from '../store/types'
 
 @Component({
   components: {
+    BMessage,
     HydraOperationButton,
     LoadingBlock,
     PageContent,

--- a/ui/src/views/SharedDimension.vue
+++ b/ui/src/views/SharedDimension.vue
@@ -116,11 +116,11 @@
                   </o-tooltip>
                 </div>
                 <o-tooltip label="Page size">
-                  <b-select :value="pageSize" @input="changePageSize" title="Page size">
+                  <o-select :value="pageSize" @input="changePageSize" title="Page size">
                     <option v-for="pageSizeOption in pageSizes" :key="pageSizeOption" :native-value="pageSizeOption">
                       {{ pageSizeOption }}
                     </option>
-                  </b-select>
+                  </o-select>
                 </o-tooltip>
               </div>
             </td>

--- a/ui/src/views/SharedDimensionCreate.vue
+++ b/ui/src/views/SharedDimensionCreate.vue
@@ -25,6 +25,7 @@ import HydraOperationForm from '@/components/HydraOperationForm.vue'
 import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationForm },
@@ -64,9 +65,9 @@ export default class extends Vue {
 
       await this.$store.dispatch('sharedDimensions/fetchCollection')
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: `Shared dimension ${dimension.name} successfully created`,
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'SharedDimension', params: { id: dimension.clientPath } })

--- a/ui/src/views/SharedDimensionEdit.vue
+++ b/ui/src/views/SharedDimensionEdit.vue
@@ -25,6 +25,7 @@ import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import * as storeNs from '../store/namespace'
 import { SharedDimension } from '../store/types'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationFormWithRaw },
@@ -76,9 +77,9 @@ export default class extends Vue {
 
       this.$store.dispatch('sharedDimensions/fetchCollection')
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Shared dimension successfully saved',
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'SharedDimension', params: { id: this.dimension.clientPath } })

--- a/ui/src/views/SharedDimensionTermCreate.vue
+++ b/ui/src/views/SharedDimensionTermCreate.vue
@@ -26,6 +26,7 @@ import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import * as storeNs from '../store/namespace'
 import { SharedDimension } from '../store/types'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationForm },
@@ -68,9 +69,9 @@ export default class extends Vue {
 
       this.$store.dispatch('sharedDimension/addTerm', term)
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Shared dimension term successfully created',
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'SharedDimension', params: { id: this.dimension.clientPath } })

--- a/ui/src/views/SharedDimensionTermEdit.vue
+++ b/ui/src/views/SharedDimensionTermEdit.vue
@@ -1,11 +1,11 @@
 <template>
   <side-pane :title="title" @close="onCancel">
-    <b-field label="URI" v-if="termUri">
+    <o-field label="URI" v-if="termUri">
       <a class="form-input" :href="termUri" target="_blank" rel="noopener noreferer">
         <span>{{ termUri }}</span>
         <o-icon icon="external-link-alt" />
       </a>
-    </b-field>
+    </o-field>
     <hydra-operation-form-with-raw
       v-if="operation"
       :operation="operation"

--- a/ui/src/views/SharedDimensionTermEdit.vue
+++ b/ui/src/views/SharedDimensionTermEdit.vue
@@ -32,6 +32,7 @@ import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import * as storeNs from '../store/namespace'
 import { serializeSharedDimensionTerm } from '../store/serializers'
 import { SharedDimension, SharedDimensionTerm } from '../store/types'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationFormWithRaw },
@@ -92,9 +93,9 @@ export default class extends Vue {
 
       this.$store.dispatch('sharedDimension/updateTerm', term)
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Shared dimension term successfully saved',
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'SharedDimension', params: { id: this.dimension.clientPath } })

--- a/ui/src/views/SharedDimensionTermEdit.vue
+++ b/ui/src/views/SharedDimensionTermEdit.vue
@@ -3,7 +3,7 @@
     <b-field label="URI" v-if="termUri">
       <a class="form-input" :href="termUri" target="_blank" rel="noopener noreferer">
         <span>{{ termUri }}</span>
-        <b-icon icon="external-link-alt" />
+        <o-icon icon="external-link-alt" />
       </a>
     </b-field>
     <hydra-operation-form-with-raw

--- a/ui/src/views/SharedDimensions.vue
+++ b/ui/src/views/SharedDimensions.vue
@@ -8,8 +8,8 @@
         <hydra-operation-button
           :operation="collection.actions.create"
           :to="{ name: 'SharedDimensionCreate' }"
-          type="is-default"
-          size=""
+          variant="default"
+          size="normal"
         >
           {{ collection.actions.create.title }}
         </hydra-operation-button>

--- a/ui/src/views/SourceEdit.vue
+++ b/ui/src/views/SourceEdit.vue
@@ -25,6 +25,7 @@ import HydraOperationForm from '@/components/HydraOperationForm.vue'
 import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationForm },
@@ -69,9 +70,9 @@ export default class CubeProjectEditView extends Vue {
 
       this.$store.dispatch('project/refreshSourcesCollection')
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: 'Settings successfully saved',
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'CSVMapping' })

--- a/ui/src/views/TableCreate.vue
+++ b/ui/src/views/TableCreate.vue
@@ -39,6 +39,7 @@ import { api } from '@/api'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import { SourcesCollection, CsvSource, CsvColumn } from '@cube-creator/model'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationForm },
@@ -134,9 +135,9 @@ export default class TableCreateView extends Vue {
 
       this.$store.commit('project/storeTable', table)
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: `Table ${table.name} was successfully created`,
-        type: 'is-success',
+        variant: 'success',
       })
 
       this.$router.push({ name: 'CSVMapping' })

--- a/ui/src/views/TableCreate.vue
+++ b/ui/src/views/TableCreate.vue
@@ -11,7 +11,7 @@
       @cancel="onCancel"
     />
 
-    <b-field label="Mapped columns" v-if="preselectedColumns.length > 0" class="content" :addons="false">
+    <o-field label="Mapped columns" v-if="preselectedColumns.length > 0" class="content" :addons="false">
       <p class="help">
         The following columns will be mapped with default values.
         They can be edited once the table is created.
@@ -21,7 +21,7 @@
           {{ column.name }}
         </li>
       </ul>
-    </b-field>
+    </o-field>
   </side-pane>
 </template>
 

--- a/ui/src/views/TableCsvw.vue
+++ b/ui/src/views/TableCsvw.vue
@@ -45,6 +45,7 @@ import RadioButton from '@/components/RadioButton.vue'
 import { Table } from '@cube-creator/model'
 import Remote, { RemoteData } from '@/remote'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { BMessage, SidePane, LoadingBlock, RadioButton },
@@ -87,7 +88,10 @@ export default class TableCreateView extends Vue {
     const snippet = this.$refs.snippet as any
     const content = snippet.codeMirror.value
     await navigator.clipboard.writeText(content)
-    this.$buefy.toast.open('Copied 👍')
+    displayToast(this, {
+      message: 'Copied 👍',
+      variant: 'success',
+    })
   }
 
   onCancel (): void {

--- a/ui/src/views/TableCsvw.vue
+++ b/ui/src/views/TableCsvw.vue
@@ -6,7 +6,7 @@
 
     <div v-if="csvw.data">
       <div class="is-flex is-justify-content-space-between">
-        <b-field>
+        <o-field>
           <b-radio-button
             v-for="format in formats"
             :key="format.value"
@@ -16,7 +16,7 @@
           >
             {{ format.label }}
           </b-radio-button>
-        </b-field>
+        </o-field>
         <o-button size="small" icon-left="clipboard" @click="copy">
           Copy
         </o-button>

--- a/ui/src/views/TableCsvw.vue
+++ b/ui/src/views/TableCsvw.vue
@@ -17,9 +17,9 @@
             {{ format.label }}
           </b-radio-button>
         </b-field>
-        <b-button size="is-small" icon-left="clipboard" @click="copy">
+        <o-button size="small" icon-left="clipboard" @click="copy">
           Copy
-        </b-button>
+        </o-button>
       </div>
       <rdf-editor
         :quads.prop="csvw.data"

--- a/ui/src/views/TableCsvw.vue
+++ b/ui/src/views/TableCsvw.vue
@@ -38,6 +38,7 @@
 import '@rdfjs-elements/rdf-editor'
 import { Quad } from 'rdf-js'
 import { Vue, Component } from 'vue-property-decorator'
+import BMessage from '@/components/BMessage.vue'
 import SidePane from '@/components/SidePane.vue'
 import LoadingBlock from '@/components/LoadingBlock.vue'
 import { Table } from '@cube-creator/model'
@@ -45,7 +46,7 @@ import Remote, { RemoteData } from '@/remote'
 import * as storeNs from '../store/namespace'
 
 @Component({
-  components: { SidePane, LoadingBlock },
+  components: { BMessage, SidePane, LoadingBlock },
 })
 export default class TableCreateView extends Vue {
   @storeNs.project.Getter('findTable') findTable!: (id: string) => Table | null

--- a/ui/src/views/TableCsvw.vue
+++ b/ui/src/views/TableCsvw.vue
@@ -7,15 +7,15 @@
     <div v-if="csvw.data">
       <div class="is-flex is-justify-content-space-between">
         <o-field>
-          <b-radio-button
+          <radio-button
             v-for="format in formats"
             :key="format.value"
             :native-value="format.value"
             v-model="selectedFormat"
-            size="is-small"
+            size="small"
           >
             {{ format.label }}
-          </b-radio-button>
+          </radio-button>
         </o-field>
         <o-button size="small" icon-left="clipboard" @click="copy">
           Copy
@@ -41,12 +41,13 @@ import { Vue, Component } from 'vue-property-decorator'
 import BMessage from '@/components/BMessage.vue'
 import SidePane from '@/components/SidePane.vue'
 import LoadingBlock from '@/components/LoadingBlock.vue'
+import RadioButton from '@/components/RadioButton.vue'
 import { Table } from '@cube-creator/model'
 import Remote, { RemoteData } from '@/remote'
 import * as storeNs from '../store/namespace'
 
 @Component({
-  components: { BMessage, SidePane, LoadingBlock },
+  components: { BMessage, SidePane, LoadingBlock, RadioButton },
 })
 export default class TableCreateView extends Vue {
   @storeNs.project.Getter('findTable') findTable!: (id: string) => Table | null

--- a/ui/src/views/TableEdit.vue
+++ b/ui/src/views/TableEdit.vue
@@ -26,6 +26,7 @@ import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import { Table } from '@cube-creator/model'
 import { cc } from '@cube-creator/core/namespace'
 import * as storeNs from '../store/namespace'
+import { displayToast } from '@/use-toast'
 
 @Component({
   components: { SidePane, HydraOperationForm },
@@ -79,9 +80,9 @@ export default class TableCreateView extends Vue {
 
       this.$store.commit('project/storeTable', table)
 
-      this.$buefy.toast.open({
+      displayToast(this, {
         message: `Table ${table.name} was successfully created`,
-        type: 'is-success',
+        variant: 'success',
       })
 
       if (table.identifierTemplate !== identifierTemplate) {

--- a/ui/tests/e2e/specs/project-mapping.spec.ts
+++ b/ui/tests/e2e/specs/project-mapping.spec.ts
@@ -177,6 +177,6 @@ describe('CSV mapping flow', () => {
       .click({ force: true })
 
     cy.contains('Project My project successfully deleted').should('be.visible')
-    cy.contains('My project').should('not.exist')
+    cy.contains('My project', { timeout: 10000 }).should('not.be.visible')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,6 +1709,18 @@
     "@opentelemetry/semantic-conventions" "0.24.0"
     lodash.merge "^4.6.2"
 
+"@oruga-ui/oruga@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@oruga-ui/oruga/-/oruga-0.5.4.tgz#ab9cbeec2e64bf7ab1d8338bc3ee0bb37334f95d"
+  integrity sha512-c41Bjjq9YzWtm2RQ8Q0jG1xqBFwHnG81oDlstnpn/0Td7SpwpSnSHO+/xiBHBRgbAMMXlJowfcEsEvkK1Z4hBw==
+
+"@oruga-ui/theme-bulma@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@oruga-ui/theme-bulma/-/theme-bulma-0.2.2.tgz#d3309beeeefdbe52980933cc113bfc185d6ebbf2"
+  integrity sha512-reMiUyOvSaE7Tg3VrJ6kMhFs7JVNdzQ6UyI511qpqRuCB1b4k6SeAaOs5S2LRInacafOJYaFD7xQCMQV8k8UmA==
+  dependencies:
+    bulma "0.9.3"
+
 "@panva/asn1.js@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@panva/asn1.js/-/asn1.js-1.0.0.tgz#dd55ae7b8129e02049f009408b97c61ccf9032f6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4670,13 +4670,6 @@ browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.3, browserslist@^4
     node-releases "^2.0.2"
     picocolors "^1.0.0"
 
-buefy@^0.9.5:
-  version "0.9.17"
-  resolved "https://registry.yarnpkg.com/buefy/-/buefy-0.9.17.tgz#ac5857a1413f253cbb9beb0d87a48021e5b21c78"
-  integrity sha512-+rERzamvkflMsoE6GDqGdj5vpDUmdm5MnCnwjK2O8pdnwr8Pmab94cO//0Vd8ys539qWoeqsjh+B7vPg/lT/nQ==
-  dependencies:
-    bulma "0.9.3"
-
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"


### PR DESCRIPTION
Replace our UI components library Buefy with [Oruga](https://oruga.io/), a Vue3-compatible alternative. I chose this one because:
1. The author of Buefy is one of the authors of Oruga (the structure of both libraries look very similar)
2. It seems to be the "officially supported" upgrade path to Vue 3
3. It has a Bulma theme

The documentation is slightly less polished and the lib is missing some components, but the transition was ok and I think it has what we need for the future.