### PR TITLE
fix: shacl order

### DIFF
--- a/apis/shared-dimensions/lib/shapes/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/shapes/shared-dimension.ts
@@ -118,6 +118,7 @@ const properties: Initializer<PropertyShape>[] = [{
           name: 'Time precision',
           path: time.unitType,
           maxCount: 1,
+          order: 20,
           nodeKind: sh.IRI,
           [sh1.if.value]: {
             [sh.path.value]: rdf.type,


### PR DESCRIPTION
I figured that the precision should be shown below the "Choose type" field.

Without `order` it would be shown first

I don't suppose we want a changelog entry for this? :)