### PR TITLE
feat(cli): --no-status-update flag

### DIFF
--- a/.changeset/real-poets-play.md
+++ b/.changeset/real-poets-play.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Optional flag to skip updating job resource

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -42,6 +42,7 @@ async function main() {
     .option('-v, --variable <name=value>', 'Pipeline variables', parseVariables, new Map())
     .option('--debug', 'Print diagnostic information to standard output')
     .option('--auth-param <name=value>', 'Additional variables to pass to the token endpoint', parseVariables, new Map())
+    .option('--no-status-update', 'Does not update job status')
     .action(capture('Transform', ({ job }) => ({ job }), transform))
 
   program
@@ -53,6 +54,7 @@ async function main() {
     .option('-v, --variable <name=value>', 'Pipeline variables', parseVariables, new Map())
     .option('--debug', 'Print diagnostic information to standard output')
     .option('--no-upload', 'When used together with --to filesystem, will prevent writing to store')
+    .option('--no-status-update', 'Does not update job status')
     .option('--auth-param <name=value>', 'Additional variables to pass to the token endpoint', parseVariables, new Map())
     .action(capture('Publish', ({ job }) => ({ job }), publish))
 
@@ -64,6 +66,7 @@ async function main() {
     .option('-v, --variable <name=value>', 'Pipeline variables', parseVariables, new Map())
     .option('--debug', 'Print diagnostic information to standard output')
     .option('--enable-buffer-monitor', 'enable histogram of buffer usage')
+    .option('--no-status-update', 'Does not update job status')
     .option('--auth-param <name=value>', 'Additional variables to pass to the token endpoint', parseVariables, new Map())
     .action(capture('Unlist', ({ job }) => ({ job }), unlist))
 
@@ -80,6 +83,7 @@ async function main() {
     .option('--execution-url <executionUrl>', 'Link to job execution')
     .option('-v, --variable <name=value>', 'Pipeline variables', parseVariables, new Map())
     .option('--debug', 'Print diagnostic information to standard output')
+    .option('--no-status-update', 'Does not update job status')
     .option('--auth-param <name=value>', 'Additional variables to pass to the token endpoint', parseVariables, new Map())
     .action(capture('Import', ({ job }) => ({ job }), importCube))
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "mkdir -p output; touch .env",
-    "transform": "dotenv -e ./.env -e ./.test.env -e ../.local.env -- sh -c 'ts-node index.ts transform --job \"$TRANSFORM_JOB\" --debug --to filesystem'",
-    "publish": "dotenv -e ./.env -e ./.test.env -e ../.local.env -- sh -c 'ts-node index.ts publish --job \"$PUBLISH_JOB\" --debug --to filesystem --no-upload --variable targetFile=./output/cube.nq'",
-    "expire-timedout": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts timeout-jobs'",
+    "transform": "dotenv -e ./.env -e ./.test.env -e ../.local.env -- sh -c 'ts-node index.ts transform --job \"$TRANSFORM_JOB\" --debug --to filesystem --no-status-update'",
+    "publish": "dotenv -e ./.env -e ./.test.env -e ../.local.env -- sh -c 'ts-node index.ts publish --job \"$PUBLISH_JOB\" --debug --to filesystem --no-upload --no-status-update --variable targetFile=./output/cube.nq'",
+    "expire-timedout": "dotenv -e ./.env -e ./.test.env -- sh -c 'ts-node index.ts timeout-jobs --no-status-update'",
     "build": "tsc"
   },
   "dependencies": {


### PR DESCRIPTION
Small improvement for running jobs from remote environments locally.

By skipping the job status update we will be able to run a job without confusing and potentially misleading changes of the jobs listed in the application