### PR TITLE
feat: show hints when mapping shared dimension terms

### DIFF
--- a/.changeset/moody-mayflies-hug.md
+++ b/.changeset/moody-mayflies-hug.md
@@ -1,0 +1,7 @@
+---
+"@cube-creator/core-api": patch
+"@cube-creator/shared-dimensions-api": patch
+"@cube-creator/ui": patch
+---
+
+Display shared dimension name when mapping terms (closes #1112)

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -509,6 +509,7 @@ ${shape('dimension/shared-mapping')} {
       ${sh.defaultValue} ${placeholderEntity} ;
       ${sh.minCount} 1 ;
       ${sh.maxCount} 1 ;
+      ${sh1.itemHelptextPath} ( ${schema.inDefinedTermSet} ${schema.name} ) ;
       ${hydra.search} [
         ${sh.path} [
           ${sh.inversePath} ${prov.hadDictionaryMember} ;

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "resolutions": {
     "jsonld": "~1",
-    "@types/eslint": "^8"
+    "@types/eslint": "^8",
+    "clownface": "zazuko/clownface#filter-return-value"
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -41,7 +41,7 @@
     "alcaeus": "^2.1",
     "buffer": "^6.0.3",
     "bulma-quickview": "^2.0.0",
-    "clownface": "^1.2.0",
+    "clownface": "^1.5.0",
     "clownface-shacl-path": "^1.0.1",
     "cookie-storage": "^6.1.0",
     "core-js": "^3.6.5",
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.4.10",
-    "@types/clownface": "^1.0.3",
+    "@types/clownface": "^1.2.7",
     "@types/debounce": "^1.2.0",
     "@types/markdown-it": "^12.2.3",
     "@types/rdf-ext": "^1.3.11",

--- a/ui/src/forms/editors/AutoCompleteEditor.vue
+++ b/ui/src/forms/editors/AutoCompleteEditor.vue
@@ -26,6 +26,8 @@ import VueSelect from 'vue-select'
 import { debounce } from 'debounce'
 import { findNodes } from 'clownface-shacl-path'
 import { sh1 } from '@cube-creator/core/namespace'
+import only from 'clownface/filter'
+import { displayLanguage } from '@/store/serializers'
 
 interface Option {
   label: string
@@ -90,12 +92,19 @@ export default defineComponent({
       const helptextPath = this.property.pointer.out(sh1.itemHelptextPath)
 
       const options = this.options ?? []
-      return options.map(([pointer, label]) => ({
-        value: pointer.term.value,
-        label,
-        term: pointer.term,
-        helptext: helptextPath.value && findNodes(pointer, helptextPath).values.shift()
-      }))
+      return options.map(([pointer, label]) => {
+        let helptext: string | undefined
+        if (helptextPath.value) {
+          [helptext] = findNodes(pointer, helptextPath).filter(only.taggedLiteral(displayLanguage)).values
+        }
+
+        return {
+          value: pointer.term.value,
+          label,
+          term: pointer.term,
+          helptext,
+        }
+      })
     },
 
     _value (): Option | null {

--- a/ui/src/forms/editors/AutoCompleteEditor.vue
+++ b/ui/src/forms/editors/AutoCompleteEditor.vue
@@ -9,7 +9,12 @@
     @search="onSearch"
     @search:focus="__load"
     :clear-search-on-blur="clearOnBlur"
-  />
+  >
+    <template #option="option">
+      {{ option.label }}
+      <cite v-if="option.helptext"><br>({{ option.helptext }})</cite>
+    </template>
+  </vue-select>
 </template>
 
 <script lang="ts">
@@ -19,6 +24,8 @@ import { Term, NamedNode } from 'rdf-js'
 import { GraphPointer } from 'clownface'
 import VueSelect from 'vue-select'
 import { debounce } from 'debounce'
+import { findNodes } from 'clownface-shacl-path'
+import { sh1 } from '@cube-creator/core/namespace'
 
 interface Option {
   label: string
@@ -80,8 +87,15 @@ export default defineComponent({
 
   computed: {
     _options (): Option[] {
+      const helptextPath = this.property.pointer.out(sh1.itemHelptextPath)
+
       const options = this.options ?? []
-      return options.map(([pointer, label]) => ({ value: pointer.term.value, label, term: pointer.term }))
+      return options.map(([pointer, label]) => ({
+        value: pointer.term.value,
+        label,
+        term: pointer.term,
+        helptext: helptextPath.value && findNodes(pointer, helptextPath).values.shift()
+      }))
     },
 
     _value (): Option | null {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5206,10 +5206,9 @@ clownface-shacl-path@^1.0.1, clownface-shacl-path@^1.2.2:
     "@tpluscode/rdf-ns-builders" "^1.0.0"
     "@tpluscode/rdf-string" "^0.2.24"
 
-clownface@^1, clownface@^1.0.0, clownface@^1.1.0, clownface@^1.2.0, clownface@^1.3.0, clownface@^1.4.0, clownface@^1.5.0:
+clownface@^1, clownface@^1.0.0, clownface@^1.1.0, clownface@^1.2.0, clownface@^1.3.0, clownface@^1.4.0, clownface@^1.5.0, clownface@zazuko/clownface#filter-return-value:
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/clownface/-/clownface-1.5.0.tgz#42146717b19d2791569b9c8fca78d8225744a72d"
-  integrity sha512-rQEtU1EIroWVWzmoFq+GvvYT5etCO58bzYeaKBfaJn12ItwormbKKtbKFdD7e3NqRczhZhBKWmvCaWVoZBd+Xg==
+  resolved "https://codeload.github.com/zazuko/clownface/tar.gz/f98c8aef8fbb1b3e67913eb6694bef01f84a72b2"
   dependencies:
     "@rdfjs/data-model" "^1.1.0"
     "@rdfjs/namespace" "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,10 +2582,10 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
   integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
 
-"@types/clownface@*", "@types/clownface@^1", "@types/clownface@^1.0.3", "@types/clownface@^1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@types/clownface/-/clownface-1.2.6.tgz#506d88d7b5be1387b131fc19c83d1c5f899d3fdb"
-  integrity sha512-AAHs2y+BOjnUV8ffyo0be1JMYqfn2Li/pboBNVTF+Y8S69faw/+JTKATPFho6lgCMP3ZV3BMBWOoCyZ8C8TJaA==
+"@types/clownface@*", "@types/clownface@^1", "@types/clownface@^1.0.3", "@types/clownface@^1.2.6", "@types/clownface@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@types/clownface/-/clownface-1.2.7.tgz#6a745e557dec23ecd06fc95856142b8d4f19fa5a"
+  integrity sha512-+j2e0ZLVZLzZA389pKeUDDdbelvM5Mez7OPbEcETsVrU/G921YAXt57Lm9OdV30i0F2UYzHmtT2PEj//bEjU6g==
   dependencies:
     rdf-js "^4.0.2"
 
@@ -5206,10 +5206,10 @@ clownface-shacl-path@^1.0.1, clownface-shacl-path@^1.2.2:
     "@tpluscode/rdf-ns-builders" "^1.0.0"
     "@tpluscode/rdf-string" "^0.2.24"
 
-clownface@^1, clownface@^1.0.0, clownface@^1.1.0, clownface@^1.2.0, clownface@^1.3.0, clownface@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/clownface/-/clownface-1.4.0.tgz#fc6018bd50459164c55d0f5916f8614fbdda11f2"
-  integrity sha512-zunn16e/qZYBqJX4N+0Jq3mmNohGveEog1/cTWHmfL+z9rL9CrzlU1MlBnU46a9+0ZiLAefRieSf4/TKGYssFg==
+clownface@^1, clownface@^1.0.0, clownface@^1.1.0, clownface@^1.2.0, clownface@^1.3.0, clownface@^1.4.0, clownface@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/clownface/-/clownface-1.5.0.tgz#42146717b19d2791569b9c8fca78d8225744a72d"
+  integrity sha512-rQEtU1EIroWVWzmoFq+GvvYT5etCO58bzYeaKBfaJn12ItwormbKKtbKFdD7e3NqRczhZhBKWmvCaWVoZBd+Xg==
   dependencies:
     "@rdfjs/data-model" "^1.1.0"
     "@rdfjs/namespace" "^1.0.0"


### PR DESCRIPTION
Adds an option to display hints in autocomplete editor. Here' used to add the shared dimension name next to terms in mapping screen

This is achieved by retrieving the necessary data from the endpoint which populates the dropdown and annotating the SHACL Property

```turtle
[]
  a sh:PropettyShape ;
  sh1:itemHelptextPath ( schema:inDefinedTermSet schema:name ) ;
.
```

The UI uses `sh1:itemHelptextPath` to find the labels to display as a second line in the dropdown

TODO:

* [ ] Select help text in the correct language (requires https://github.com/zazuko/clownface/pull/63)