### PR TITLE
fix: correct type to find hierarchies

### DIFF
--- a/.changeset/tall-pots-drop.md
+++ b/.changeset/tall-pots-drop.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+List of hierarchies would show instances used in individual cubes

--- a/apis/shared-dimensions/lib/domain/hierarchies.ts
+++ b/apis/shared-dimensions/lib/domain/hierarchies.ts
@@ -1,12 +1,12 @@
 import { CONSTRUCT } from '@tpluscode/sparql-builder'
-import { meta } from '@cube-creator/core/namespace'
+import { md } from '@cube-creator/core/namespace'
 
 export function getHierarchies() {
   return CONSTRUCT`
     ?h ?p ?o .
   `
     .WHERE`
-      ?h a ${meta.Hierarchy} .
+      ?h a ${md.Hierarchy} .
       ?h ?p ?o .
     `
 }

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -106,7 +106,8 @@ type SharedDimensionsTerms =
   'createAs' |
   'dynamicPropertyType' |
   'hierarchies' |
-  'Hierarchies'
+  'Hierarchies' |
+  'Hierarchy'
 
 type MetaTerms =
   'SharedDimension' |


### PR DESCRIPTION
A simple mistake which caused hierarchies from inside cubes to show up in the main listing. Instead of `meta:Hierarchy` we should use `md:Hierarchy` which is a more specific type used by the API itself

Similar to how we have `md:SharedDimension` as an API specific (informal) subclass of `schema:DefinedTermSet`