### PR TITLE
Finally extract common code from forms

### DIFF
--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -1,7 +1,7 @@
 import { Hydra } from 'alcaeus/web'
 import { HydraResponse, RdfResource, RuntimeOperation } from 'alcaeus'
 import { ResponseWrapper } from 'alcaeus/ResponseWrapper'
-import { RdfResourceCore } from '@tpluscode/rdfine/RdfResource'
+import RdfResourceImpl, { RdfResourceCore, ResourceIdentifier } from '@tpluscode/rdfine/RdfResource'
 import { hydra, sh } from '@tpluscode/rdf-ns-builders'
 import { ShapeBundle } from '@rdfine/shacl/bundles'
 import { Shape, ValidationReportMixin, ValidationResultMixin } from '@rdfine/shacl'
@@ -132,7 +132,11 @@ export const api = {
     }
   },
 
-  async invokeSaveOperation<T extends RdfResource = RdfResource> (operation: RuntimeOperation | null, data: RdfResource, headers: HeadersInit = {}): Promise<T> {
+  async invokeSaveOperation<T extends RdfResource = RdfResource> (operation: RuntimeOperation | null, resource: RdfResource | GraphPointer<ResourceIdentifier>, headers: HeadersInit = {}): Promise<T> {
+    const data = 'toJSON' in resource
+      ? resource
+      : RdfResourceImpl.factory.createEntity(resource) as RdfResource
+
     if (!operation) throw new Error('Operation does not exist')
 
     const { body, contentHeaders } = this.prepareOperationBody(data, operation)
@@ -145,12 +149,12 @@ export const api = {
       throw await APIError.fromResponse(response)
     }
 
-    const resource = response.representation?.root
-    if (!resource) {
+    const responseResource = response.representation?.root
+    if (!responseResource) {
       throw new Error('Response does not contain created resource')
     }
 
-    return resource as T
+    return responseResource as T
   },
 
   async invokeDeleteOperation (operation: RuntimeOperation | null): Promise<void> {

--- a/ui/src/components/HydraOperationForm.vue
+++ b/ui/src/components/HydraOperationForm.vue
@@ -68,20 +68,9 @@ export default defineComponent({
   },
   emits: ['submit', 'cancel'],
 
-  data (): { __clone: GraphPointer | null } {
-    return {
-      // eslint-disable-next-line vue/no-reserved-keys
-      __clone: null,
-    }
-  },
-
   computed: {
     clone (): GraphPointer | null {
-      const { __clone, resource } = this
-
-      if (__clone) {
-        return __clone
-      }
+      const { resource } = this
 
       if (!resource) {
         return resource
@@ -106,14 +95,6 @@ export default defineComponent({
 
     _submitLabel (): string {
       return this.submitLabel ?? this.operation.title ?? 'Save'
-    },
-  },
-
-  watch: {
-    resource (newResource: GraphPointer, oldResource: GraphPointer) {
-      if (newResource !== oldResource) {
-        this.__clone = null
-      }
     },
   },
 })

--- a/ui/src/components/HydraOperationFormWithRaw.vue
+++ b/ui/src/components/HydraOperationFormWithRaw.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue'
+import { defineComponent, PropType, ref, toRefs } from 'vue'
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
 import HydraRawRdfForm from '@/components/HydraRawRdfForm.vue'
 import clownface, { GraphPointer } from 'clownface'
@@ -84,10 +84,15 @@ export default defineComponent({
   },
   emits: ['submit', 'cancel'],
 
-  data () {
+  setup (props) {
+    const { resource } = toRefs(props)
+
+    const isRawMode = ref(false)
+    const internalResource = ref(resource)
+
     return {
-      isRawMode: false,
-      internalResource: this.resource,
+      isRawMode,
+      internalResource,
     }
   },
 

--- a/ui/src/store/modules/api.ts
+++ b/ui/src/store/modules/api.ts
@@ -1,9 +1,7 @@
-import { RdfResource, RuntimeOperation } from 'alcaeus'
+import { RdfResource } from 'alcaeus'
 import { ActionTree, MutationTree, GetterTree } from 'vuex'
 import { api } from '@/api'
 import { RootState } from '../types'
-import { GraphPointer } from 'clownface'
-import RdfResourceImpl, { ResourceIdentifier } from '@tpluscode/rdfine'
 import { dcat } from '@tpluscode/rdf-ns-builders'
 
 export interface APIState {
@@ -25,12 +23,6 @@ const actions: ActionTree<APIState, RootState> = {
     const entrypoint = await api.fetchResource('/')
     context.commit('storeEntrypoint', entrypoint)
     return entrypoint
-  },
-
-  async invokeSaveOperation (context, { operation, resource, headers }: {operation: RuntimeOperation; resource: RdfResource | GraphPointer<ResourceIdentifier>; headers?: HeadersInit}) {
-    const data = 'toJSON' in resource ? resource : RdfResourceImpl.factory.createEntity(resource) as RdfResource
-
-    return api.invokeSaveOperation(operation, data, headers)
   },
 
   async invokeDeleteOperation (context, { operation, successMessage, callbackAction, callbackParams = {} }): Promise<void> {

--- a/ui/src/use-hydra-form.ts
+++ b/ui/src/use-hydra-form.ts
@@ -1,0 +1,77 @@
+import type { Shape } from '@rdfine/shacl'
+import * as $rdf from '@rdf-esm/dataset'
+import type { RdfResource, ResourceIdentifier, RuntimeOperation } from 'alcaeus'
+import clownface, { GraphPointer } from 'clownface'
+import { computed, ref, Ref, shallowRef, ShallowRef, watch } from 'vue'
+import { Term } from 'rdf-js'
+
+import { api } from './api'
+import { APIErrorValidation, ErrorDetails } from './api/errors'
+
+const initResource = () => clownface({ dataset: $rdf.dataset() }).namedNode('')
+
+interface HydraFormOptions {
+  beforeSubmit?: () => Promise<boolean> | boolean
+  afterSubmit?: (savedResource: RdfResource) => any
+  fetchShapeParams?: { targetClass?: Term }
+  saveHeaders?: HeadersInit
+}
+
+export function useHydraForm (operation: Ref<RuntimeOperation | null>, options: HydraFormOptions = {}) {
+  const resource: Ref<GraphPointer | null> = ref(initResource())
+  const shape: ShallowRef<Shape | null> = shallowRef(null)
+  const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
+  const isSubmitting = ref(false)
+
+  const loadShape = async () => {
+    resource.value = initResource()
+    shape.value = null
+    error.value = null
+    isSubmitting.value = false
+
+    if (operation.value) {
+      shape.value = await api.fetchOperationShape(operation.value, options.fetchShapeParams)
+    }
+  }
+  watch(operation, loadShape, { immediate: true })
+
+  const title = computed(() => operation.value?.title ?? '...')
+
+  const onSubmit = async (data: GraphPointer<ResourceIdentifier>) => {
+    if (options.beforeSubmit) {
+      const shouldContinue = await options.beforeSubmit()
+      if (!shouldContinue) {
+        return
+      }
+    }
+
+    error.value = null
+    isSubmitting.value = true
+
+    try {
+      const savedResource = await api.invokeSaveOperation<RdfResource>(operation.value, data, options.saveHeaders)
+
+      if (options.afterSubmit) {
+        await options.afterSubmit(savedResource)
+      }
+    } catch (e: any) {
+      error.value = e.details ?? { detail: e.toString() }
+
+      if (!(e instanceof APIErrorValidation)) {
+        console.error(e)
+      }
+    } finally {
+      isSubmitting.value = false
+    }
+  }
+
+  return {
+    operation,
+    resource,
+    shape,
+    error,
+    isSubmitting,
+    title,
+    onSubmit,
+  }
+}

--- a/ui/src/views/ColumnMappingCreate.vue
+++ b/ui/src/views/ColumnMappingCreate.vue
@@ -37,7 +37,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
+import { ResourceIdentifier, RuntimeOperation } from 'alcaeus'
 import { GraphPointer } from 'clownface'
 import { mapGetters } from 'vuex'
 import { CsvSource, Table } from '@cube-creator/model'
@@ -47,6 +47,7 @@ import ReferenceColumnMappingForm from '@/components/ReferenceColumnMappingForm.
 import LiteralColumnMappingForm from '@/components/LiteralColumnMappingForm.vue'
 import { APIErrorValidation, ErrorDetails } from '@/api/errors'
 import { displayToast } from '@/use-toast'
+import { api } from '@/api'
 
 type ColumnMappingType = 'literal' | 'reference'
 
@@ -93,15 +94,12 @@ export default defineComponent({
   },
 
   methods: {
-    async onSubmit (resource: GraphPointer): Promise<void> {
+    async onSubmit (resource: GraphPointer<ResourceIdentifier>): Promise<void> {
       this.error = null
       this.isSubmitting = true
 
       try {
-        const columnMapping = await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
+        const columnMapping = await api.invokeSaveOperation(this.operation, resource)
 
         this.$store.commit('project/storeNewColumnMapping', { table: this.table, columnMapping })
 

--- a/ui/src/views/ColumnMappingEdit.vue
+++ b/ui/src/views/ColumnMappingEdit.vue
@@ -29,7 +29,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
+import { ResourceIdentifier, RuntimeOperation } from 'alcaeus'
 import { ColumnMapping, Table, CsvSource } from '@cube-creator/model'
 import { cc } from '@cube-creator/core/namespace'
 import { GraphPointer } from 'clownface'
@@ -39,6 +39,7 @@ import ReferenceColumnMappingForm from '@/components/ReferenceColumnMappingForm.
 import LiteralColumnMappingForm from '@/components/LiteralColumnMappingForm.vue'
 import { displayToast } from '@/use-toast'
 import { mapGetters } from 'vuex'
+import { api } from '@/api'
 
 export default defineComponent({
   name: 'ColumnMappingEditView',
@@ -90,15 +91,12 @@ export default defineComponent({
   },
 
   methods: {
-    async onSubmit (resource: GraphPointer): Promise<void> {
+    async onSubmit (resource: GraphPointer<ResourceIdentifier>): Promise<void> {
       this.error = null
       this.isSubmitting = true
 
       try {
-        const columnMapping = await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
+        const columnMapping = await api.invokeSaveOperation(this.operation, resource)
 
         this.$store.commit('project/storeUpdatedColumnMapping', { table: this.table, columnMapping })
 

--- a/ui/src/views/CubeMetadataEdit.vue
+++ b/ui/src/views/CubeMetadataEdit.vue
@@ -15,41 +15,43 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
-import type { Shape } from '@rdfine/shacl'
-import { GraphPointer } from 'clownface'
-import SidePane from '@/components/SidePane.vue'
-import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
-import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
+import { computed, defineComponent } from 'vue'
+import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
+
 import { cc, cube } from '@cube-creator/core/namespace'
+
+import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
+import SidePane from '@/components/SidePane.vue'
 import { conciseBoundedDescription } from '@/graph'
+import { RootState } from '@/store/types'
+import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
-import { mapState } from 'vuex'
 
 export default defineComponent({
   name: 'CubeMetadataEdit',
   components: { SidePane, HydraOperationFormWithRaw },
 
   setup () {
-    const resource: Ref<GraphPointer | null> = ref(null)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
+    const store = useStore<RootState>()
+    const router = useRouter()
 
-    return {
-      resource,
-      shape,
-      error,
-      isSubmitting,
-    }
-  },
+    const cubeMetadata = store.state.project.cubeMetadata
+    if (!cubeMetadata) throw new Error('Cube metadata not loaded')
+    const operation = computed(() => cubeMetadata?.actions?.edit ?? null)
 
-  async mounted (): Promise<void> {
-    if (this.operation) {
-      this.shape = await api.fetchOperationShape(this.operation)
-    }
+    const form = useHydraForm(operation, {
+      afterSubmit () {
+        store.dispatch('project/fetchCubeMetadata')
+
+        displayToast({
+          message: 'Cube metadata was saved',
+          variant: 'success',
+        })
+
+        router.push({ name: 'CubeDesigner' })
+      }
+    })
 
     // Since the /dataset resource is loaded with a bunch on inlined data,
     // the form will only be populated with the concise description of cube metadata,
@@ -59,53 +61,12 @@ export default defineComponent({
       cc.observations,
       cc.dimensionMetadata
     ]
-    this.resource = Object.freeze(conciseBoundedDescription(this.cubeMetadata.pointer, exclude))
-  },
+    form.resource.value = Object.freeze(conciseBoundedDescription(cubeMetadata.pointer, exclude))
 
-  computed: {
-    ...mapState('project', {
-      cubeMetadata: 'cubeMetadata',
-    }),
-
-    operation (): RuntimeOperation | null {
-      return this.cubeMetadata.actions.edit
-    },
-
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
+    return form
   },
 
   methods: {
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
-
-      try {
-        await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
-
-        this.$store.dispatch('project/fetchCubeMetadata')
-
-        displayToast({
-          message: 'Cube metadata was saved',
-          variant: 'success',
-        })
-
-        this.$router.push({ name: 'CubeDesigner' })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
-
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
-      }
-    },
-
     onCancel (): void {
       this.$router.push({ name: 'CubeDesigner' })
     },

--- a/ui/src/views/DimensionEdit.vue
+++ b/ui/src/views/DimensionEdit.vue
@@ -18,51 +18,63 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
-import { Shape } from '@rdfine/shacl'
-import { GraphPointer } from 'clownface'
-import { DimensionMetadata } from '@cube-creator/model'
-import SidePane from '@/components/SidePane.vue'
-import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
-import TermDisplay from '@/components/TermDisplay.vue'
-import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
-import { conciseBoundedDescription } from '@/graph'
 import { rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
+import { GraphPointer } from 'clownface'
+import { computed, defineComponent, shallowRef, watch } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+
 import { meta } from '@cube-creator/core/namespace'
+import { DimensionMetadata } from '@cube-creator/model'
+
+import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
+import SidePane from '@/components/SidePane.vue'
+import TermDisplay from '@/components/TermDisplay.vue'
+import { conciseBoundedDescription } from '@/graph'
+import { RootState } from '@/store/types'
+import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
-import { mapGetters, mapState } from 'vuex'
 
 export default defineComponent({
   name: 'DimensionEditView',
   components: { SidePane, HydraOperationFormWithRaw, TermDisplay },
 
   setup () {
-    const resource: Ref<GraphPointer | null> = ref(null)
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
+    const store = useStore<RootState>()
+    const router = useRouter()
+    const route = useRoute()
 
-    return {
-      resource,
-      error,
-      isSubmitting,
-      shape,
-    }
-  },
+    const cubeMetadata = store.state.project.cubeMetadata
+    const cubeUri = computed(() => cubeMetadata?.hasPart[0]?.id.value)
 
-  async mounted (): Promise<void> {
-    if (this.operation) {
-      const shape = await api.fetchOperationShape(this.operation)
+    const findDimension = store.getters['project/findDimension']
+    const dimensions = store.getters['project/dimensions']
 
-      if (!shape) throw new Error('Shape not found')
+    const dimension = findDimension(route.params.dimensionId)
+    const operation = shallowRef(dimension.actions.edit)
 
-      // Manually build the dimensions list because `addList` causes a blank
-      // node clash
+    const form = useHydraForm(operation, {
+      afterSubmit () {
+        store.dispatch('project/refreshDimensionMetadataCollection')
+
+        displayToast({
+          message: 'Dimension metadata was saved',
+          variant: 'success',
+        })
+
+        router.push({ name: 'CubeDesigner' })
+      },
+    })
+
+    // Populate dimensions selector
+    watch(form.shape, () => {
+      const shape = form.shape.value
+      if (!shape) return
+
+      // Manually build the dimensions list because `addList` causes a blank node clash
       const dimensionsList = shape.pointer.blankNode('_dimensions-0')
       let position: GraphPointer<any> = dimensionsList
-      this.dimensions.forEach((d: DimensionMetadata, index: number) => {
+      dimensions.forEach((d: DimensionMetadata, index: number) => {
         position
           .addOut(rdf.first, d.about, dimPtr => {
             dimPtr.addOut(schema.name, d.name)
@@ -79,69 +91,21 @@ export default defineComponent({
         .out(sh.property).has(sh.path, meta.relatesTo)
         // .addList(sh.in, this.dimensions.map(({ about }) => about))
         .addOut(sh.in, dimensionsList)
+    })
 
-      this.shape = shape
+    if (dimension) {
+      form.resource.value = conciseBoundedDescription(dimension.pointer)
     }
 
-    this.resource = conciseBoundedDescription(this.dimension.pointer)
-  },
-
-  computed: {
-    ...mapGetters('project', {
-      dimensions: 'dimensions',
-      findDimension: 'findDimension',
-    }),
-    ...mapState('project', {
-      cubeMetadata: 'cubeMetadata',
-    }),
-
-    cubeUri (): string | undefined {
-      return this.cubeMetadata?.hasPart[0]?.id.value
-    },
-
-    dimension (): DimensionMetadata {
-      return this.findDimension(this.$route.params.dimensionId)
-    },
-
-    operation (): RuntimeOperation | null {
-      return this.dimension.actions.edit
-    },
-
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
+    return {
+      ...form,
+      dimension,
+      cubeMetadata,
+      cubeUri,
+    }
   },
 
   methods: {
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
-
-      try {
-        await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
-
-        this.$store.dispatch('project/refreshDimensionMetadataCollection')
-
-        displayToast({
-          message: 'Dimension metadata was saved',
-          variant: 'success',
-        })
-
-        this.$router.push({ name: 'CubeDesigner' })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
-
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
-      }
-    },
-
     onCancel (): void {
       this.$router.push({ name: 'CubeDesigner' })
     },

--- a/ui/src/views/DimensionMapping.vue
+++ b/ui/src/views/DimensionMapping.vue
@@ -14,105 +14,62 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
-import { Shape } from '@rdfine/shacl'
-import { GraphPointer } from 'clownface'
-import { Dataset, DimensionMetadata } from '@cube-creator/model'
+import { RdfResource } from '@tpluscode/rdfine/RdfResource'
+import { computed, defineComponent, onMounted, ref, Ref } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+
+import { api } from '@/api'
 import SidePane from '@/components/SidePane.vue'
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
-import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
-import { RdfResource } from '@tpluscode/rdfine/RdfResource'
-import { serializeResource } from '../store/serializers'
+import { serializeResource } from '@/store/serializers'
+import { RootState } from '@/store/types'
+import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
-import { mapGetters } from 'vuex'
 
 export default defineComponent({
   name: 'DimensionMappingView',
   components: { SidePane, HydraOperationForm },
 
   setup () {
+    const store = useStore<RootState>()
+    const router = useRouter()
+    const route = useRoute()
+
+    const findDimension = store.getters['project/findDimension']
+    const dimension = findDimension(route.params.dimensionId)
+
     const mappings: Ref<RdfResource | null> = ref(null)
-    const resource: Ref<GraphPointer | null> = ref(null)
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
 
-    return {
-      mappings,
-      resource,
-      error,
-      isSubmitting,
-      shape,
-    }
-  },
+    const operation = computed(() => mappings.value?.actions.replace ?? null)
 
-  async mounted (): Promise<void> {
-    if (this.dimension.mappings) {
-      const mappings = await api.fetchResource(this.dimension.mappings.value)
-      this.mappings = serializeResource(mappings)
-    }
-
-    if (this.operation) {
-      this.shape = await api.fetchOperationShape(this.operation)
-    }
-
-    this.resource = this.mappings?.pointer ?? null
-  },
-
-  computed: {
-    ...mapGetters('project', {
-      findDimension: 'findDimension',
-    }),
-
-    cubeMetadata (): Dataset | null {
-      return this.$store.state.project.cubeMetadata
-    },
-
-    dimension (): DimensionMetadata {
-      return this.findDimension(this.$route.params.dimensionId)
-    },
-
-    operation (): RuntimeOperation | null {
-      return this.mappings?.actions.replace ?? null
-    },
-
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
-  },
-
-  methods: {
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
-
-      try {
-        await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
-
-        this.$store.dispatch('project/fetchDimensionMetadataCollection')
+    const form = useHydraForm(operation, {
+      afterSubmit () {
+        store.dispatch('project/fetchDimensionMetadataCollection')
 
         displayToast({
           message: 'Mapping to shared dimension was saved',
           variant: 'success',
         })
 
-        this.$router.push({ name: 'CubeDesigner' })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
+        router.push({ name: 'CubeDesigner' })
+      },
+    })
 
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
-      }
-    },
+    onMounted(async () => {
+      const fetchedMappings = await api.fetchResource(dimension.mappings.value)
+      mappings.value = serializeResource(fetchedMappings)
 
+      form.resource.value = fetchedMappings.pointer
+    })
+
+    return {
+      ...form,
+      mappings,
+    }
+  },
+
+  methods: {
     onCancel (): void {
       this.$router.push({ name: 'CubeDesigner' })
     },

--- a/ui/src/views/HierarchyCreate.vue
+++ b/ui/src/views/HierarchyCreate.vue
@@ -15,88 +15,44 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
-import clownface, { GraphPointer } from 'clownface'
-import type { Shape } from '@rdfine/shacl'
-import { dataset } from '@rdf-esm/dataset'
-import SidePane from '@/components/SidePane.vue'
+import { defineComponent, shallowRef } from 'vue'
+import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
+
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
-import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
+import SidePane from '@/components/SidePane.vue'
+import { RootState } from '@/store/types'
+import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
-import { mapState } from 'vuex'
 
 export default defineComponent({
   name: 'HierarchyCreateView',
   components: { SidePane, HydraOperationForm },
 
   setup () {
-    const resource: Ref<GraphPointer | null> = ref(clownface({ dataset: dataset() }).namedNode(''))
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
-    const shapes: Ref<GraphPointer | null> = ref(null)
+    const store = useStore<RootState>()
+    const router = useRouter()
 
-    return {
-      resource,
-      error,
-      isSubmitting,
-      shape,
-      shapes,
-    }
-  },
+    const collection = store.state.sharedDimensions.hierarchies
+    const operation = shallowRef(collection?.actions.create ?? null)
 
-  async mounted (): Promise<void> {
-    if (this.operation) {
-      this.shape = await api.fetchOperationShape(this.operation)
-    }
-  },
-
-  computed: {
-    ...mapState('sharedDimensions', {
-      collection: 'hierarchies',
-    }),
-
-    operation (): RuntimeOperation | null {
-      return this.collection.actions.create
-    },
-
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
-  },
-
-  methods: {
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
-
-      try {
-        const hierarchy = await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
-
-        await this.$store.dispatch('sharedDimensions/fetchHierarchies')
+    const form = useHydraForm(operation, {
+      async afterSubmit (hierarchy: any) {
+        await store.dispatch('sharedDimensions/fetchHierarchies')
 
         displayToast({
           message: `Hierarchy ${hierarchy.name} successfully created`,
           variant: 'success',
         })
 
-        this.$router.push({ name: 'Hierarchy', params: { id: hierarchy.clientPath } })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
+        router.push({ name: 'Hierarchy', params: { id: hierarchy.clientPath } })
+      },
+    })
 
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
-      }
-    },
+    return form
+  },
 
+  methods: {
     onCancel (): void {
       this.$router.push({ name: 'Hierarchies' })
     },

--- a/ui/src/views/HierarchyEdit.vue
+++ b/ui/src/views/HierarchyEdit.vue
@@ -15,14 +15,16 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
-import { GraphPointer } from 'clownface'
-import type { Shape } from '@rdfine/shacl'
-import SidePane from '@/components/SidePane.vue'
-import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
+import { RdfResource } from 'alcaeus'
+import { computed, defineComponent, shallowRef, ShallowRef, watch } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+
 import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
+import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
+import SidePane from '@/components/SidePane.vue'
+import { RootState } from '@/store/types'
+import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
 
 export default defineComponent({
@@ -30,90 +32,49 @@ export default defineComponent({
   components: { SidePane, HydraOperationFormWithRaw },
 
   setup () {
-    const resource: Ref<GraphPointer | null> = ref(null)
-    const operation: Ref<RuntimeOperation | null> = ref(null)
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
-    const shapes: Ref<GraphPointer | null> = ref(null)
+    const store = useStore<RootState>()
+    const router = useRouter()
+    const route = useRoute()
 
-    return {
-      resource,
-      operation,
-      error,
-      isSubmitting,
-      shape,
-      shapes,
-    }
-  },
+    const hierarchy: ShallowRef<RdfResource | null> = shallowRef(null)
 
-  mounted (): void {
-    this.prepareForm()
-  },
-
-  computed: {
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
-  },
-
-  methods: {
-    async prepareForm (): Promise<void> {
-      this.resource = null
-      this.operation = null
-      this.shape = null
-
-      const hierarchyId = this.$route.params.id as string
-      const hierarchy = await api.fetchResource(hierarchyId)
-
-      this.resource = Object.freeze(hierarchy.pointer)
-      this.operation = hierarchy.actions.replace ?? null
-
-      if (this.operation) {
-        this.shape = await api.fetchOperationShape(this.operation)
+    watch(route, async (newRoute, oldRoute) => {
+      if ((!oldRoute || newRoute.name === oldRoute.name) && newRoute.params.id) {
+        const hierarchyId = newRoute.params.id as string
+        hierarchy.value = await api.fetchResource<RdfResource>(hierarchyId)
       }
-    },
+    }, { immediate: true })
 
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
+    const operation = computed(() => hierarchy.value?.actions.replace ?? null)
 
-      try {
-        await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
-
-        this.$store.dispatch('sharedDimensions/fetchCollection')
+    const form = useHydraForm(operation, {
+      afterSubmit () {
+        store.dispatch('sharedDimensions/fetchCollection')
 
         displayToast({
           message: 'Hierarchy successfully saved',
           variant: 'success',
         })
 
-        this.$router.push({ name: 'Hierarchies' })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
+        router.push({ name: 'Hierarchies' })
+      },
+    })
 
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
+    watch(hierarchy, () => {
+      if (hierarchy.value) {
+        form.resource.value = Object.freeze(hierarchy.value.pointer)
+      } else {
+        form.resource.value = null
       }
-    },
+    })
 
+    return form
+  },
+
+  methods: {
     onCancel (): void {
       this.$router.push({ name: 'Hierarchies' })
     },
-  },
-
-  watch: {
-    $route (newRoute, oldRoute) {
-      if (newRoute.name === oldRoute.name) {
-        this.prepareForm()
-      }
-    }
   },
 })
 </script>

--- a/ui/src/views/SharedDimensionCreate.vue
+++ b/ui/src/views/SharedDimensionCreate.vue
@@ -15,88 +15,44 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
-import clownface, { GraphPointer } from 'clownface'
-import type { Shape } from '@rdfine/shacl'
-import { dataset } from '@rdf-esm/dataset'
-import SidePane from '@/components/SidePane.vue'
+import { computed, defineComponent } from 'vue'
+import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
+
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
-import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
+import SidePane from '@/components/SidePane.vue'
+import { RootState } from '@/store/types'
+import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
-import { mapState } from 'vuex'
 
 export default defineComponent({
   name: 'SharedDimensionCreateView',
   components: { SidePane, HydraOperationForm },
 
   setup () {
-    const resource: Ref<GraphPointer | null> = ref(clownface({ dataset: dataset() }).namedNode(''))
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
-    const shapes: Ref<GraphPointer | null> = ref(null)
+    const store = useStore<RootState>()
+    const router = useRouter()
 
-    return {
-      resource,
-      error,
-      isSubmitting,
-      shape,
-      shapes,
-    }
-  },
+    const collection = store.state.sharedDimensions.collection
+    const operation = computed(() => collection?.actions.create ?? null)
 
-  async mounted (): Promise<void> {
-    if (this.operation) {
-      this.shape = await api.fetchOperationShape(this.operation)
-    }
-  },
-
-  computed: {
-    ...mapState('sharedDimensions', {
-      collection: 'collection',
-    }),
-
-    operation (): RuntimeOperation | null {
-      return this.collection.actions.create
-    },
-
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
-  },
-
-  methods: {
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
-
-      try {
-        const dimension = await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
-
-        await this.$store.dispatch('sharedDimensions/fetchCollection')
+    const form = useHydraForm(operation, {
+      async afterSubmit (dimension: any) {
+        await store.dispatch('sharedDimensions/fetchCollection')
 
         displayToast({
           message: `Shared dimension ${dimension.name} successfully created`,
           variant: 'success',
         })
 
-        this.$router.push({ name: 'SharedDimension', params: { id: dimension.clientPath } })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
+        router.push({ name: 'SharedDimension', params: { id: dimension.clientPath } })
+      },
+    })
 
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
-      }
-    },
+    return form
+  },
 
+  methods: {
     onCancel (): void {
       this.$router.push({ name: 'SharedDimensions' })
     },

--- a/ui/src/views/SharedDimensionTermCreate.vue
+++ b/ui/src/views/SharedDimensionTermCreate.vue
@@ -15,91 +15,52 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
-import clownface, { GraphPointer } from 'clownface'
-import type { Shape } from '@rdfine/shacl'
-import { dataset } from '@rdf-esm/dataset'
+import { computed, defineComponent } from 'vue'
+import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
+
 import SidePane from '@/components/SidePane.vue'
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
-import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
+import { RootState } from '@/store/types'
+import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
-import { mapState } from 'vuex'
 
 export default defineComponent({
   name: 'SHaredDimensionTermCreateView',
   components: { SidePane, HydraOperationForm },
 
   setup () {
-    const resource: Ref<GraphPointer | null> = ref(clownface({ dataset: dataset() }).namedNode(''))
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
-    const shapes: Ref<GraphPointer | null> = ref(null)
+    const store = useStore<RootState>()
+    const router = useRouter()
 
-    return {
-      resource,
-      error,
-      isSubmitting,
-      shape,
-      shapes,
-    }
-  },
+    const dimension = store.state.sharedDimension.dimension
+    if (!dimension) throw new Error('Dimension not loaded')
 
-  async mounted (): Promise<void> {
-    if (this.operation) {
-      this.shape = await api.fetchOperationShape(this.operation, {
-        targetClass: this.dimension.id
-      })
-    }
-  },
+    const operation = computed(() => dimension.actions.create)
 
-  computed: {
-    ...mapState('sharedDimension', {
-      dimension: 'dimension',
-    }),
+    const form = useHydraForm(operation, {
+      fetchShapeParams: { targetClass: dimension.id },
+      saveHeaders: { Prefer: `target-class=${dimension.id.value}` },
 
-    operation (): RuntimeOperation | null {
-      return this.dimension.actions.create
-    },
-
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
-  },
-
-  methods: {
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
-
-      try {
-        const term = await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-          headers: { Prefer: `target-class=${this.dimension.id.value}` },
-        })
-
-        this.$store.dispatch('sharedDimension/addTerm', term)
+      afterSubmit (term: any) {
+        store.dispatch('sharedDimension/addTerm', term)
 
         displayToast({
           message: 'Shared dimension term successfully created',
           variant: 'success',
         })
 
-        this.$router.push({ name: 'SharedDimension', params: { id: this.dimension.clientPath } })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
+        router.push({ name: 'SharedDimension', params: { id: dimension.clientPath } })
+      },
+    })
 
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
-      }
-    },
+    return {
+      ...form,
+      dimension,
+    }
+  },
 
+  methods: {
     onCancel (): void {
       this.$router.push({ name: 'SharedDimension', params: { id: this.dimension.clientPath } })
     },

--- a/ui/src/views/SharedDimensionTermEdit.vue
+++ b/ui/src/views/SharedDimensionTermEdit.vue
@@ -21,120 +21,83 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import { RuntimeOperation } from 'alcaeus'
-import { GraphPointer } from 'clownface'
-import type { Shape } from '@rdfine/shacl'
-import SidePane from '@/components/SidePane.vue'
-import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
+import { computed, defineComponent, shallowRef, ShallowRef, watch } from 'vue'
+import { useStore } from 'vuex'
+import { RouteLocation, useRoute, useRouter } from 'vue-router'
+
 import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
-import { serializeSharedDimensionTerm } from '../store/serializers'
-import { SharedDimensionTerm } from '../store/types'
+import HydraOperationFormWithRaw from '@/components/HydraOperationFormWithRaw.vue'
+import SidePane from '@/components/SidePane.vue'
+import { serializeSharedDimensionTerm } from '@/store/serializers'
+import { RootState, SharedDimensionTerm } from '@/store/types'
+import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
-import { mapState } from 'vuex'
 
 export default defineComponent({
   name: 'SharedDimensionTermEditView',
   components: { SidePane, HydraOperationFormWithRaw },
 
   setup () {
-    const resource: Ref<GraphPointer | null> = ref(null)
+    const store = useStore<RootState>()
+    const router = useRouter()
+    const route = useRoute()
+
+    const dimension = store.state.sharedDimension.dimension
+    if (!dimension) throw new Error('Dimension not loaded')
+
     const term: ShallowRef<SharedDimensionTerm | null> = shallowRef(null)
-    const operation: ShallowRef<RuntimeOperation | null> = shallowRef(null)
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
-    const shapes: Ref<GraphPointer | null> = ref(null)
+    const termUri = computed(() => term.value?.canonical?.value || term.value?.id.value || null)
+    const operation = computed(() => term.value?.actions.replace ?? null)
 
-    return {
-      resource,
-      term,
-      operation,
-      error,
-      isSubmitting,
-      shape,
-      shapes,
-    }
-  },
+    const form = useHydraForm(operation, {
+      fetchShapeParams: { targetClass: dimension.id },
+      saveHeaders: { Prefer: `target-class=${dimension.id.value}` },
 
-  mounted (): void {
-    this.prepareForm()
-  },
-
-  computed: {
-    ...mapState('sharedDimension', {
-      dimension: 'dimension',
-    }),
-
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
-
-    termUri (): string | null {
-      return this.term?.canonical?.value || this.term?.id?.value || null
-    },
-  },
-
-  methods: {
-    async prepareForm (): Promise<void> {
-      this.resource = null
-      this.operation = null
-      this.shape = null
-
-      const termId = this.$route.params.termId as string
-      const term = await api.fetchResource(termId)
-
-      this.term = serializeSharedDimensionTerm(term)
-      this.resource = Object.freeze(term.pointer)
-      this.operation = term.actions.replace ?? null
-
-      if (this.operation) {
-        this.shape = await api.fetchOperationShape(this.operation, {
-          targetClass: this.dimension.id,
-        })
-      }
-    },
-
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
-
-      try {
-        const term = await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-          headers: { Prefer: `target-class=${this.dimension.id.value}` },
-        })
-
-        this.$store.dispatch('sharedDimension/updateTerm', term)
+      afterSubmit (savedTerm: any) {
+        store.dispatch('sharedDimension/updateTerm', savedTerm)
 
         displayToast({
           message: 'Shared dimension term successfully saved',
           variant: 'success',
         })
 
-        this.$router.push({ name: 'SharedDimension', params: { id: this.dimension.clientPath } })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
+        router.push({ name: 'SharedDimension', params: { id: dimension.clientPath } })
+      },
+    })
 
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
+    const fetchTerm = async () => {
+      const termId = route.params.termId as string
+      const fetchedTerm = await api.fetchResource(termId)
+
+      term.value = serializeSharedDimensionTerm(fetchedTerm)
+      form.resource.value = Object.freeze(term.value.pointer)
+    }
+
+    watch(route, (newRoute: RouteLocation) => {
+      if (newRoute.name === 'SharedDimensionTermEdit') {
+        fetchTerm()
       }
-    },
+    }, { immediate: true })
 
+    watch(term, () => {
+      if (term.value) {
+        form.resource.value = Object.freeze(term.value.pointer)
+      } else {
+        form.resource.value = null
+      }
+    })
+
+    return {
+      ...form,
+      dimension,
+      termUri,
+    }
+  },
+
+  methods: {
     onCancel (): void {
       this.$router.push({ name: 'SharedDimension', params: { id: this.dimension.clientPath } })
     },
-  },
-
-  watch: {
-    $route () {
-      this.prepareForm()
-    }
   },
 })
 </script>

--- a/ui/src/views/SourceEdit.vue
+++ b/ui/src/views/SourceEdit.vue
@@ -15,98 +15,49 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import { GraphPointer } from 'clownface'
-import { RuntimeOperation } from 'alcaeus'
-import type { Shape } from '@rdfine/shacl'
-import { CsvSource } from '@cube-creator/model'
+import { computed, defineComponent } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+
 import SidePane from '@/components/SidePane.vue'
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
-import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
+import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
-import { mapGetters, mapState } from 'vuex'
+import { RootState } from '@/store/types'
 
 export default defineComponent({
   name: 'CubeProjectEditView',
   components: { SidePane, HydraOperationForm },
 
   setup () {
-    const resource: Ref<GraphPointer | null> = ref(null)
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
+    const store = useStore<RootState>()
+    const router = useRouter()
+    const route = useRoute()
 
-    return {
-      resource,
-      error,
-      isSubmitting,
-      shape,
-    }
-  },
+    const findSource = store.getters['project/findSource']
+    const sourceId = route.params.sourceId as string
+    const source = findSource(sourceId)
+    const operation = computed(() => source.actions.edit)
 
-  async mounted (): Promise<void> {
-    this.resource = Object.freeze(this.source.pointer)
-
-    if (this.operation) {
-      this.shape = await api.fetchOperationShape(this.operation)
-    }
-  },
-
-  computed: {
-    ...mapState('project', {
-      project: 'project',
-    }),
-    ...mapGetters('project', {
-      findSource: 'findSource',
-    }),
-
-    source (): CsvSource {
-      const sourceId = this.$route.params.sourceId
-      return this.findSource(sourceId)
-    },
-
-    operation (): RuntimeOperation | null {
-      if (!this.source) return null
-
-      return this.source.actions.edit
-    },
-
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
-  },
-
-  methods: {
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
-
-      try {
-        await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
-
-        this.$store.dispatch('project/refreshSourcesCollection')
+    const form = useHydraForm(operation, {
+      afterSubmit () {
+        store.dispatch('project/refreshSourcesCollection')
 
         displayToast({
           message: 'Settings successfully saved',
           variant: 'success',
         })
 
-        this.$router.push({ name: 'CSVMapping' })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
+        router.push({ name: 'CSVMapping' })
+      },
+    })
 
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
-      }
-    },
+    form.resource.value = Object.freeze(source.pointer)
 
+    return form
+  },
+
+  methods: {
     onCancel (): void {
       this.$router.push({ name: 'CSVMapping' })
     },

--- a/ui/src/views/TableCreate.vue
+++ b/ui/src/views/TableCreate.vue
@@ -26,83 +26,77 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, Ref, shallowRef, ShallowRef } from 'vue'
-import clownface, { GraphPointer } from 'clownface'
-import { RuntimeOperation } from 'alcaeus'
-import { dataset } from '@rdf-esm/dataset'
 import { csvw, hydra } from '@tpluscode/rdf-ns-builders'
-import type { Shape } from '@rdfine/shacl'
+import { computed, defineComponent, onMounted, watch } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+
 import * as ns from '@cube-creator/core/namespace'
-import SidePane from '@/components/SidePane.vue'
+import { CsvColumn } from '@cube-creator/model'
+
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
-import { api } from '@/api'
-import { APIErrorValidation, ErrorDetails } from '@/api/errors'
-import { CsvSource, CsvColumn } from '@cube-creator/model'
+import SidePane from '@/components/SidePane.vue'
+import { RootState } from '@/store/types'
 import { displayToast } from '@/use-toast'
-import { mapGetters, mapState } from 'vuex'
+import { useHydraForm } from '@/use-hydra-form'
 
 export default defineComponent({
   name: 'TableCreateView',
   components: { SidePane, HydraOperationForm },
 
   setup () {
-    const resource: Ref<GraphPointer | null> = ref(clownface({ dataset: dataset() }).namedNode(''))
-    const error: ShallowRef<ErrorDetails | null> = shallowRef(null)
-    const isSubmitting = ref(false)
-    const shape: ShallowRef<Shape | null> = shallowRef(null)
+    const store = useStore<RootState>()
+    const router = useRouter()
+    const route = useRoute()
 
-    return {
-      resource,
-      error,
-      isSubmitting,
-      shape,
-    }
-  },
+    const sourcesCollection = store.state.project.sourcesCollection
+    const tableCollection = store.state.project.tableCollection
+    const findSource = store.getters['project/findSource']
+    const operation = computed(() => tableCollection?.actions.create ?? null)
 
-  async mounted (): Promise<void> {
-    this.resource = this.prepareResourceFromQueryParams()
-    this.shape = await this.prepareShape()
-  },
+    const form = useHydraForm(operation, {
+      afterSubmit (table: any) {
+        store.commit('project/storeTable', table)
 
-  computed: {
-    ...mapState('project', {
-      sourcesCollection: 'sourcesCollection',
-    }),
-    ...mapGetters('project', {
-      findSource: 'findSource',
-    }),
+        displayToast({
+          message: `Table ${table.name} was successfully created`,
+          variant: 'success',
+        })
 
-    operation (): RuntimeOperation | null {
-      return this.$store.state.project.tableCollection?.actions.create ?? null
-    },
+        router.push({ name: 'CSVMapping' })
+      },
+    })
 
-    title (): string {
-      return this.operation?.title ?? '...'
-    },
+    watch(form.shape, (shape) => {
+      if (shape) {
+        const sourceProperty: any = shape.property.find(p => p.class?.equals(ns.cc.CSVSource))
+        sourceProperty[hydra.collection.value] = sourcesCollection
+      }
+    })
 
-    preselectedSource (): CsvSource | null {
-      const sourceId = this.$route.query.source
+    const preselectedSource = computed(() => {
+      const sourceId = route.query.source
 
       if (sourceId && !Array.isArray(sourceId)) {
-        return this.findSource(sourceId)
+        return findSource(sourceId)
       } else {
         return null
       }
-    },
+    })
 
-    preselectedColumns (): CsvColumn[] {
-      const source = this.preselectedSource
+    const preselectedColumns = computed(() => {
+      const source = preselectedSource.value
 
       if (!source) return []
 
-      let columnIds = this.$route.query.columns || []
+      let columnIds = route.query.columns || []
       if (!Array.isArray(columnIds)) {
         columnIds = [columnIds]
       }
 
       return columnIds
         .map((columnId) => {
-          const column = source.columns.find((column) => column.clientPath === columnId)
+          const column = source.columns.find((column: any) => column.clientPath === columnId)
           if (column) {
             return column
           } else {
@@ -111,70 +105,34 @@ export default defineComponent({
           }
         })
         .filter((column): column is CsvColumn => column !== null)
-    },
-  },
+    })
 
-  methods: {
-    prepareResourceFromQueryParams (): GraphPointer {
-      const resource = clownface({ dataset: dataset() }).namedNode('')
+    const prepareResourceFromQueryParams = () => {
+      const resource = form.resource.value
+
+      if (!resource) return
 
       // Initialize data based on URL query params
-      const source = this.preselectedSource
+      const source = preselectedSource.value
       if (source) {
         resource.addOut(ns.cc.csvSource, source.id)
       }
 
-      this.preselectedColumns.forEach((column) => {
+      preselectedColumns.value.forEach((column) => {
         resource.addOut(csvw.column, column.id)
       })
 
       return resource
-    },
+    }
+    onMounted(prepareResourceFromQueryParams)
 
-    async prepareShape (): Promise<Shape | null> {
-      if (!this.operation) {
-        return null
-      }
+    return {
+      ...form,
+      preselectedColumns,
+    }
+  },
 
-      const shape = await api.fetchOperationShape(this.operation)
-
-      if (shape) {
-        const sourceProperty: any = shape.property.find(p => p.class?.equals(ns.cc.CSVSource))
-        sourceProperty[hydra.collection.value] = this.sourcesCollection
-      }
-
-      return shape
-    },
-
-    async onSubmit (resource: GraphPointer): Promise<void> {
-      this.error = null
-      this.isSubmitting = true
-
-      try {
-        const table = await this.$store.dispatch('api/invokeSaveOperation', {
-          operation: this.operation,
-          resource,
-        })
-
-        this.$store.commit('project/storeTable', table)
-
-        displayToast({
-          message: `Table ${table.name} was successfully created`,
-          variant: 'success',
-        })
-
-        this.$router.push({ name: 'CSVMapping' })
-      } catch (e: any) {
-        this.error = e.details ?? { detail: e.toString() }
-
-        if (!(e instanceof APIErrorValidation)) {
-          console.error(e)
-        }
-      } finally {
-        this.isSubmitting = false
-      }
-    },
-
+  methods: {
     onCancel (): void {
       this.$router.push({ name: 'CSVMapping' })
     },


### PR DESCRIPTION
All the views presenting a Hydra operation form consist of the same code with slight variations. This is a long overdue refactoring to extract the common parts.