### PR TITLE
refactor: only poll jobs when necessary

### DIFF
--- a/ui/src/store/serializers.ts
+++ b/ui/src/store/serializers.ts
@@ -175,7 +175,7 @@ export function serializeDimensionMetadata (dimension: DimensionMetadata): Dimen
 export function serializeJobCollection (collection: JobCollection): JobCollection {
   const members = collection.member ?? []
 
-  return Object.freeze({
+  return {
     ...serializeResource(collection),
     actions: {
       ...serializeActions(collection.actions),
@@ -185,7 +185,7 @@ export function serializeJobCollection (collection: JobCollection): JobCollectio
       createImport: collection.actions.createImport,
     },
     member: members.map(Object.freeze),
-  }) as unknown as JobCollection
+  } as unknown as JobCollection
 }
 
 export function serializeCubeMetadata (cubeMetadata: Dataset): Dataset {

--- a/ui/src/use-polling.ts
+++ b/ui/src/use-polling.ts
@@ -1,0 +1,31 @@
+import { onBeforeUnmount, onMounted, ref, Ref } from 'vue'
+
+export function usePolling (poll: (...args: any[]) => any, interval = 3000) {
+  const poller: Ref<number | null> = ref(null)
+
+  const stopPolling = () => {
+    if (poller.value) {
+      window.clearInterval(poller.value)
+    }
+  }
+
+  const doPoll = async () => {
+    try {
+      await poll()
+    } catch (e) {
+      stopPolling()
+      throw e
+    }
+  }
+
+  const setupPolling = () => {
+    poller.value = window.setInterval(doPoll, interval)
+  }
+
+  onMounted(setupPolling)
+  onBeforeUnmount(stopPolling)
+
+  return {
+    poller
+  }
+}

--- a/ui/src/views/CubeProject.vue
+++ b/ui/src/views/CubeProject.vue
@@ -57,18 +57,9 @@ export default defineComponent({
   name: 'CubeProjectView',
   components: { PageContent, LoadingBlock },
 
-  data (): { poller: number | null } {
-    return {
-      poller: null,
-    }
-  },
-
   async mounted (): Promise<void> {
     const id = this.$route.params.id
     await this.$store.dispatch('project/fetchProject', id)
-
-    // Poll jobs
-    this.poller = window.setInterval(this.pollJobs, 3000)
 
     if (this.$route.name === 'CubeProject') {
       if (this.hasCSVMapping) {
@@ -80,7 +71,6 @@ export default defineComponent({
   },
 
   beforeUnmount (): void {
-    this.stopPolling()
     this.$store.dispatch('project/reset')
   },
 
@@ -98,21 +88,6 @@ export default defineComponent({
 
   methods: {
     isRouteActive,
-
-    async pollJobs (): Promise<void> {
-      try {
-        await this.$store.dispatch('project/fetchJobCollection')
-      } catch (e) {
-        this.stopPolling()
-        throw e
-      }
-    },
-
-    stopPolling (): void {
-      if (this.poller) {
-        clearInterval(this.poller)
-      }
-    },
   },
 })
 </script>

--- a/ui/src/views/Materialize.vue
+++ b/ui/src/views/Materialize.vue
@@ -28,17 +28,25 @@
 </template>
 
 <script lang="ts">
+import { RuntimeOperation } from 'alcaeus'
 import { defineComponent } from 'vue'
-import LoadingBlock from '@/components/LoadingBlock.vue'
+import { mapGetters, useStore } from 'vuex'
+
+import { JobCollection } from '@cube-creator/model'
+
 import JobForm from '@/components/JobForm.vue'
 import JobItem from '@/components/JobItem.vue'
-import { JobCollection } from '@cube-creator/model'
-import { RuntimeOperation } from 'alcaeus'
-import { mapGetters } from 'vuex'
+import LoadingBlock from '@/components/LoadingBlock.vue'
+import { usePolling } from '@/use-polling'
 
 export default defineComponent({
   name: 'PublicationView',
   components: { LoadingBlock, JobForm, JobItem },
+
+  setup () {
+    const store = useStore()
+    usePolling(() => store.dispatch('project/fetchJobCollection'))
+  },
 
   computed: {
     ...mapGetters('project', {

--- a/ui/src/views/Publication.vue
+++ b/ui/src/views/Publication.vue
@@ -51,16 +51,24 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import LoadingBlock from '@/components/LoadingBlock.vue'
+import { mapGetters, useStore } from 'vuex'
+
+import { JobCollection } from '@cube-creator/model'
+
+import ExternalTerm from '@/components/ExternalTerm.vue'
 import JobForm from '@/components/JobForm.vue'
 import JobItem from '@/components/JobItem.vue'
-import ExternalTerm from '@/components/ExternalTerm.vue'
-import { JobCollection } from '@cube-creator/model'
-import { mapGetters } from 'vuex'
+import LoadingBlock from '@/components/LoadingBlock.vue'
+import { usePolling } from '@/use-polling'
 
 export default defineComponent({
   name: 'PublicationView',
   components: { ExternalTerm, LoadingBlock, JobForm, JobItem },
+
+  setup () {
+    const store = useStore()
+    usePolling(() => store.dispatch('project/fetchJobCollection'))
+  },
 
   computed: {
     ...mapGetters('project', {


### PR DESCRIPTION
With the new structure of the app, it is a waste to poll all jobs every
3 seconds on any page of the project.

With this change, jobs will only be polled on jobs listing pages. And
the detail page of a job will only poll the job itself, not the full
collection.