### PR TITLE
fix: use canonical dimension URIs in hierarchy form

### DIFF
--- a/.changeset/giant-plants-invent.md
+++ b/.changeset/giant-plants-invent.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+When editing a hierarchy, no properties would show for dimensions defined inside Cube Creator

--- a/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
@@ -60,6 +60,8 @@ export const getTerms = asyncMiddleware(async (req, res, next) => {
     return next(new httpError.NotFound())
   }
 
+  res.locals.noRewrite = typeof req.query.canonical !== 'undefined'
+
   const pageSize = Number(query.out(hydra.limit).value || 10)
   const page = Number(query.out(hydra.pageIndex).value || 1)
   const offset = (page - 1) * pageSize

--- a/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
+++ b/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
@@ -31,6 +31,12 @@ export const patchResponseStream: express.RequestHandler = asyncMiddleware(async
   const { quadStream } = res
 
   res.quadStream = (stream: Stream & Readable) => {
+    if (res.locals.noRewrite) {
+      // when set, res.locals.noRewrite prevents the rewrite of
+      // canonical terms to cube-creator URIs
+      return quadStream(stream)
+    }
+
     const rewriteTerms = through2.obj(function (chunk: Quad, enc, callback) {
       this.push(rewriteQuad(chunk))
 

--- a/apis/shared-dimensions/lib/shapes/hierarchy.ts
+++ b/apis/shared-dimensions/lib/shapes/hierarchy.ts
@@ -90,7 +90,7 @@ export default function ({ rdfTypeProperty = false }: { rdfTypeProperty?: boolea
       order: 10,
       [hydra.search.value]: iriTemplate({
         variableRepresentation: hydra.ExplicitRepresentation,
-        template: '/dimension/_terms?dimension={dimension}{&q}',
+        template: '/dimension/_terms?canonical&dimension={dimension}{&q}',
         mapping: [{
           variable: 'dimension',
           property: md.sharedDimension,


### PR DESCRIPTION
I added a query param which disables the rewrite from cube creator URIs to canonical URIs

Because the canonical URIs were not returned, the introspection query does not return anything when trying to find shared term properties