### PR TITLE
fix: "inverse" toggle

### DIFF
--- a/.changeset/moody-rice-call.md
+++ b/.changeset/moody-rice-call.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+New hierarchy: toggling the "inverse" checkbox would stop working until a property was selected

--- a/ui/src/forms/editors/HierarchyPathEditor.vue
+++ b/ui/src/forms/editors/HierarchyPathEditor.vue
@@ -110,8 +110,8 @@ export default defineComponent({
           path.addOut(sh.inversePath, this.property)
         }
         this.update(path)
-      } else if (this.property) {
-        this.update(this.property)
+      } else {
+        this.update(this.property || pointer.namedNode('urn:placeholder:property'))
       }
     },
   },


### PR DESCRIPTION
By faking the selected property, we ensure that a new introspection query gets generated

Otherwise, it was impossible to properly toggle the checkbox without selecting a predicate