### PR TITLE
fix: remove hierarchy roots from page

### DIFF
--- a/.changeset/happy-colts-mate.md
+++ b/.changeset/happy-colts-mate.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Remove roots listed in the hierarchy definition

--- a/ui/src/views/Hierarchy.vue
+++ b/ui/src/views/Hierarchy.vue
@@ -101,16 +101,11 @@ export default defineComponent({
         return []
       }
 
-      const roots = hierarchy.hierarchyRoot.map(root => ({
-        text: `Root: ${root.value}`
-      }))
-
       const nextLevel = toNextLevelNode(hierarchy.nextInHierarchy)
 
       return [{
         text: `Dimension: ${hierarchy.dimension.value}`,
       },
-      ...roots,
       {
         text: 'Levels:',
         children: [nextLevel]


### PR DESCRIPTION
Removed the root URIs from the hierarchy "Definition" since they are repeated anyway in the expandable tree just below