### PR TITLE
fix: form data binding

### DIFF
--- a/.changeset/polite-pens-shave.md
+++ b/.changeset/polite-pens-shave.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+On some forms, switching tabs would immediately revert to the first tab (fixes #1177)

--- a/ui/src/components/HydraRawRdfForm.vue
+++ b/ui/src/components/HydraRawRdfForm.vue
@@ -79,11 +79,22 @@ export default defineComponent({
   },
   emits: ['submit', 'cancel'],
 
-  data (): { parseError: string | null, editorQuads: Quad[] | null, editorPrefixes: string } {
+  data (): { parseError: string | null, editorQuads: Quad[] | null, editorPrefixes: string, value?: GraphPointer } {
     return {
       parseError: null,
       editorQuads: null,
       editorPrefixes: ['hydra', 'rdf', 'rdfs', 'schema', 'xsd'].join(','),
+      value: undefined
+    }
+  },
+
+  watch: {
+    editorQuads (editorQuads) {
+      this.value = clownface({
+        dataset: $rdf.dataset(editorQuads),
+        term: this.resource.term,
+        graph: this.graph,
+      })
     }
   },
 
@@ -98,16 +109,6 @@ export default defineComponent({
       return [
         ...this.resource.dataset.match(null, null, null, this.graph)
       ]
-    },
-
-    clone (): GraphPointer | null {
-      if (!this.resource || !this.editorQuads) return null
-
-      return clownface({
-        dataset: $rdf.dataset(this.editorQuads),
-        term: this.resource.term,
-        graph: this.graph,
-      })
     },
 
     _submitLabel (): string {
@@ -130,8 +131,8 @@ export default defineComponent({
     async onSubmit (): Promise<void> {
       await this.waitParsing()
 
-      if (this.clone) {
-        this.$emit('submit', this.clone)
+      if (this.value) {
+        this.$emit('submit', this.value)
       }
     },
 


### PR DESCRIPTION
I'm shooting blind a little but I managed to improve the form, slightly defective since vue3 update

Tl;dr; the graph passed to the pointer would be repeatedly set to the form element, causing it to "reset". This is why the tab would reverted to the initial as well as what happens in #1179, that switching between SHACL form and RDF editor would not preserve the changes.

What I did is to remove a little bit of the magical reactivity and instead use watchers to update the form only when necessary