### PR TITLE
Hierarchies uris canonical

### DIFF
--- a/.changeset/long-jokes-talk.md
+++ b/.changeset/long-jokes-talk.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Hierarchy would dereference with wrong identifiers of shared dimensions/terms

--- a/apis/core/bootstrap/shapes/dataset.ts
+++ b/apis/core/bootstrap/shapes/dataset.ts
@@ -5,7 +5,7 @@ import { sparql, turtle } from '@tpluscode/rdf-string'
 import $rdf from 'rdf-ext'
 import { Draft, Published } from '@cube-creator/model/Cube'
 import env from '@cube-creator/core/env'
-import { lindasQuery } from '../lib/query'
+import { lindasQuery } from '@cube-creator/core/lindas'
 
 const shapeId = shape('dataset/edit-metadata')
 const temporalFromTo = $rdf.namedNode(shapeId.value + '#temporalFromTo')

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -4,7 +4,7 @@ import { sparql, turtle } from '@tpluscode/rdf-string'
 import { dash, hydra, prov, rdf, rdfs, schema, sh, qudt, time, xsd } from '@tpluscode/rdf-ns-builders'
 import namespace from '@rdfjs/namespace'
 import $rdf from 'rdf-ext'
-import { lindasQuery } from '../lib/query'
+import { lindasQuery } from '@cube-creator/core/lindas'
 import { placeholderEntity } from '../../lib/domain/dimension-mapping/DimensionMapping'
 
 const sou = namespace('http://qudt.org/vocab/sou/')

--- a/apis/shared-dimensions/lib/domain/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension.ts
@@ -29,6 +29,10 @@ export async function create({ resource, store }: CreateSharedDimension): Promis
     throw new DomainError('Missing dimension identifier')
   }
 
+  if (identifier === 'hierarchy') {
+    throw new DomainError('`hierarchy` is not an allowed shared dimension identifier')
+  }
+
   const termSetId = newId(env.MANAGED_DIMENSIONS_BASE, `dimension/${identifier}`)
   if (await store.exists(termSetId, schema.DefinedTermSet)) {
     throw new httpError.Conflict(`Shared Dimension ${identifier} already exists`)

--- a/apis/shared-dimensions/lib/handlers/hierarchy.ts
+++ b/apis/shared-dimensions/lib/handlers/hierarchy.ts
@@ -1,15 +1,30 @@
+import { Term } from 'rdf-js'
 import { dcterms, sd } from '@tpluscode/rdf-ns-builders'
 import { asyncMiddleware } from 'middleware-async'
 import $rdf from 'rdf-ext'
-import env from '@cube-creator/core/env'
+import coreEnv from '@cube-creator/core/env'
+import env from '../../lib/env'
+
+const hierarchyBase = env.MANAGED_DIMENSIONS_BASE + 'dimension/hierarchy'
+
+function rewriteSharedDimensionTerms(term: Term) {
+  if (term.termType !== 'NamedNode') {
+    return false
+  }
+
+  return !term.value.startsWith(env.MANAGED_DIMENSIONS_BASE) ||
+    term.value.startsWith(hierarchyBase)
+}
 
 export const get = asyncMiddleware(async (req, res) => {
+  res.shouldRewrite = rewriteSharedDimensionTerms
+
   const hierarchy = await req.hydra.resource.clownface()
 
   if (!hierarchy.out(dcterms.source).terms.length) {
     hierarchy.addOut(dcterms.source, source => {
       source
-        .addOut(sd.endpoint, $rdf.namedNode(env.PUBLIC_QUERY_ENDPOINT))
+        .addOut(sd.endpoint, $rdf.namedNode(coreEnv.PUBLIC_QUERY_ENDPOINT))
     })
   }
 

--- a/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
@@ -60,8 +60,6 @@ export const getTerms = asyncMiddleware(async (req, res, next) => {
     return next(new httpError.NotFound())
   }
 
-  res.locals.noRewrite = typeof req.query.canonical !== 'undefined'
-
   const pageSize = Number(query.out(hydra.limit).value || 10)
   const page = Number(query.out(hydra.pageIndex).value || 1)
   const offset = (page - 1) * pageSize

--- a/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
+++ b/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
@@ -31,12 +31,6 @@ export const patchResponseStream: express.RequestHandler = asyncMiddleware(async
   const { quadStream } = res
 
   res.quadStream = (stream: Stream & Readable) => {
-    if (res.locals.noRewrite) {
-      // when set, res.locals.noRewrite prevents the rewrite of
-      // canonical terms to cube-creator URIs
-      return quadStream(stream)
-    }
-
     const rewriteTerms = through2.obj(function (chunk: Quad, enc, callback) {
       this.push(rewriteQuad(chunk))
 

--- a/apis/shared-dimensions/lib/shapes/hierarchy.ts
+++ b/apis/shared-dimensions/lib/shapes/hierarchy.ts
@@ -90,7 +90,7 @@ export default function ({ rdfTypeProperty = false }: { rdfTypeProperty?: boolea
       order: 10,
       [hydra.search.value]: iriTemplate({
         variableRepresentation: hydra.ExplicitRepresentation,
-        template: '/dimension/_terms?canonical&dimension={dimension}{&q}',
+        template: '/dimension/_terms?dimension={dimension}{&q}',
         mapping: [{
           variable: 'dimension',
           property: md.sharedDimension,

--- a/e2e-tests/hierarchies/hierarchy.hydra
+++ b/e2e-tests/hierarchies/hierarchy.hydra
@@ -1,0 +1,18 @@
+PREFIX meta: <https://cube.link/meta/>
+PREFIX md: <https://cube-creator.zazuko.com/shared-dimensions/vocab#>
+
+ENTRYPOINT "dimension/hierarchy/technologies"
+
+HEADERS {
+  x-user "john-doe"
+}
+
+With Class meta:Hierarchy {
+    Expect Property md:sharedDimension {
+        Expect Id <https://ld.admin.ch/cube/dimension/technologies>
+    }
+
+    Expect Property meta:hierarchyRoot {
+        Expect Id <https://ld.admin.ch/cube/dimension/technologies/sparql>
+    }
+}

--- a/fuseki/hierarchies.trig
+++ b/fuseki/hierarchies.trig
@@ -52,3 +52,36 @@ graph <https://lindas.admin.ch/cube/dimension> {
       ] ;
   ] .
 }
+
+graph <https://lindas.admin.ch/cube/dimension> {
+  <technologies> a meta:Hierarchy, hydra:Resource, md:Hierarchy ;
+    schema:name "Technologies" ;
+    md:sharedDimension <https://ld.admin.ch/cube/dimension/technologies> ;
+    meta:hierarchyRoot <https://ld.admin.ch/cube/dimension/technologies/sparql> ;
+    meta:nextInHierarchy <urn:hierarchyLevel:tech> ;
+  .
+
+  <urn:hierarchyLevel:tech>
+    schema:name "First level" ;
+    sh:path rdf:type ;
+  .
+
+  [
+    sh:targetNode <technologies> ;
+    sh:property
+      [ sh:path rdf:type ],
+      [ sh:path schema:name ],
+      [ sh:path meta:hierarchyRoot ],
+      [ sh:path md:sharedDimension ],
+      [
+        sh:path meta:nextInHierarchy ;
+        sh:node
+          [
+            sh:targetNode <urn:hierarchyLevel:tech> ;
+            sh:property
+              [ sh:path schema:name ],
+              [ sh:path sh:path ];
+          ]
+      ] ;
+  ] .
+}

--- a/packages/core/lindas.ts
+++ b/packages/core/lindas.ts
@@ -1,7 +1,7 @@
 import { NamedNode } from 'rdf-js'
 import $rdf from 'rdf-ext'
 import { SparqlTemplateResult } from '@tpluscode/rdf-string'
-import env from '@cube-creator/core/env'
+import env from './env'
 
 export function lindasQuery(query: SparqlTemplateResult): NamedNode {
   return $rdf.namedNode(`${env.PUBLIC_QUERY_ENDPOINT}?query=${encodeURIComponent(query.toString())}`)


### PR DESCRIPTION
This backs out of earlier attempt to mitigate the URL rewriting in shared dimension API responses

When working with hierarchies we should expect canonical identifiers of shared dimensions. This further modifies the `GET` handler of a hierarchy so that anything matching the `/dimension/*` pattern (except `/dimension/hierarchy*`) not to be rewritten in the response.

Additional, the hierarchy form would load shared dimension/terms from SPARQL directly to skip any of rewriting