### PR TITLE
fix: smaller CONSTRUCT

### DIFF
--- a/.changeset/thin-frogs-explode.md
+++ b/.changeset/thin-frogs-explode.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+`Payload too large` when exporting shared dimensions (fixes #1184)

--- a/apis/shared-dimensions/lib/domain/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension.ts
@@ -163,11 +163,9 @@ export async function getExportedDimension({ resource, store, client = streamCli
     .filter(shape => !shape.in(sh.node).terms.length) // exclude nested shapes
   const patterns = getPatternsFromShape(shapes)
 
-  const quads = await CONSTRUCT`${patterns}`
+  const quads = await CONSTRUCT.WHERE`${patterns}`
     .FROM(store.graph)
-    .WHERE`
-      ${patterns}
-    `.execute(client.query, { operation: 'postUrlencoded' })
+    .execute(client.query, { operation: 'postUrlencoded' })
 
   const baseUriPattern = new RegExp(`^${env.MANAGED_DIMENSIONS_BASE}`)
   function removeBase<T extends Term>(term: T): T {

--- a/apis/shared-dimensions/lib/resource.ts
+++ b/apis/shared-dimensions/lib/resource.ts
@@ -56,13 +56,13 @@ export function getPatternsFromShape(shapes: AnyPointer, nextVariable = variable
     const childShapes = property.out(sh.node).toArray()
 
     const uniqueProperties = new TermSet(property.out(sh.path).terms)
-    const ownPatterns = [...uniqueProperties].map(path => {
-      return sparql`${node} ${path} ${nextVariable()} .`
-    })
+    const ownPatterns = [...uniqueProperties].reduce((patterns, path) => {
+      return sparql`${patterns} ${path} ${nextVariable()} ;`
+    }, sparql`${node}`)
     const childPatterns = childShapes.flatMap(child => getPatternsFromShape(child, nextVariable, seen))
 
     return [
-      ...ownPatterns,
+      sparql`${ownPatterns} .`,
       ...childPatterns,
     ]
   })

--- a/apis/shared-dimensions/package.json
+++ b/apis/shared-dimensions/package.json
@@ -19,7 +19,7 @@
     "@tpluscode/rdf-ns-builders": "^1.0.0",
     "@tpluscode/rdf-string": "^0.2.21",
     "@tpluscode/rdfine": "^0.5.25",
-    "@tpluscode/sparql-builder": "^0.3.15",
+    "@tpluscode/sparql-builder": "^0.3.21",
     "camouflage-rewrite": "^1.2.0",
     "clownface": "^1.4.0",
     "cors": "^2.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,10 +2455,10 @@
     clownface "^1"
     once "^1.4.0"
 
-"@tpluscode/sparql-builder@^0.3.15", "@tpluscode/sparql-builder@^0.3.17", "@tpluscode/sparql-builder@^0.3.9":
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/@tpluscode/sparql-builder/-/sparql-builder-0.3.18.tgz#8b0d881b530c9836a49f3f915f2f7070a60404d6"
-  integrity sha512-jAsXLZ3vbWDnnkZeptogYPniHJWPNFRcUPj0N5I5w2grtIZg1gMNYSWUpgO7GNgCBe24p98xs1NBeO8x159j1w==
+"@tpluscode/sparql-builder@^0.3.15", "@tpluscode/sparql-builder@^0.3.17", "@tpluscode/sparql-builder@^0.3.21", "@tpluscode/sparql-builder@^0.3.9":
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/@tpluscode/sparql-builder/-/sparql-builder-0.3.21.tgz#d094f4476d2f982d41b57cded3987b9f9609f25e"
+  integrity sha512-cbKPB1lqD6D9MeHMLET9bQSmqA5d2hCjE2i5tsWfKPelhefveYrfAtJyVjTH1RQPpzFQddqGgU+fMEtiEVwxHA==
   dependencies:
     "@rdf-esm/data-model" "^0.5.4"
     "@rdf-esm/term-set" "^0.5.0"
@@ -5598,14 +5598,7 @@ cron-parser@^2.7.3:
     is-nan "^1.3.0"
     moment-timezone "^0.5.31"
 
-cross-fetch@^3.0.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
-  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
-  dependencies:
-    node-fetch "2.6.1"
-
-cross-fetch@^3.0.6:
+cross-fetch@^3.0.4, cross-fetch@^3.0.6:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -9754,11 +9747,6 @@ node-env-run@^4.0.2:
     pkginfo "^0.4.1"
     upath "^1.2.0"
     yargs "^15.4.1"
-
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@2.6.7, node-fetch@^2.3.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"


### PR DESCRIPTION
Reduces the size of `CONSTRUCT` by combing patterns of common subject. To prevent an excess of duplicate triples, which can bring down the database, the `WHERE` patterns are separated into a series of UNION to prevent a massive cartesian