### PR TITLE
fix: publishing cube with sh:or

### DIFF
--- a/.changeset/grumpy-planes-enjoy.md
+++ b/.changeset/grumpy-planes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+When published, cube properties would have incomplete `sh:or` list of datatype alternatives (fixes #1189)

--- a/cli/lib/loadCube.ts
+++ b/cli/lib/loadCube.ts
@@ -21,7 +21,7 @@ interface Params {
  * which will be processed alongside the rest of cube metadata
  */
 export async function loadCube(this: Pipeline.Context, { jobUri, endpoint, user, password }: Params): Promise<Stream> {
-  const project = await loadProject(jobUri, this)
+  const { project } = await loadProject(jobUri, this)
 
   const patterns = sparql`
     ?cube a ${cube.Cube} ; !${cube.observationConstraint}* ?s .

--- a/cli/lib/project.ts
+++ b/cli/lib/project.ts
@@ -21,7 +21,7 @@ export async function loadProject(jobUri: string, { variables, logger }: Context
 
       logger.info(`Source graph <${project.cubeGraph.value}>`)
 
-      return project
+      return { project, job }
     } finally {
       span.end()
     }

--- a/cli/test/lib/metadata.test.ts
+++ b/cli/test/lib/metadata.test.ts
@@ -1,0 +1,83 @@
+import { DatasetCore } from 'rdf-js'
+import { insertTestProject } from '@cube-creator/testing/lib/seedData'
+import { before, describe, it } from 'mocha'
+import getStream from 'get-stream'
+import { Context } from 'barnard59-core/lib/Pipeline'
+import env from '@cube-creator/core/env'
+import clownface, { GraphPointer } from 'clownface'
+import { expect } from 'chai'
+import { VariableMap, Variables } from 'barnard59-core'
+import { Hydra } from 'alcaeus/node'
+import * as Models from '@cube-creator/model'
+import { toRdf } from 'rdf-literal'
+import $rdf from 'rdf-ext'
+import { sh } from '@tpluscode/rdf-ns-builders/strict'
+import { setupEnv } from '../support/env'
+import { loadCubeMetadata } from '../../lib/metadata'
+import { logger } from '../support/logger'
+
+Hydra.resources.factory.addMixin(...Object.values(Models))
+
+describe('@cube-creator/cli/lib/metadata @SPARQL', function () {
+  this.timeout(20000)
+
+  let context: Context
+  let variables: VariableMap
+
+  before(async () => {
+    setupEnv()
+    await insertTestProject()
+
+    variables = new Map<keyof Variables, any>([
+      ['revision', 1],
+      ['namespace', 'https://environment.ld.admin.ch/foen/'],
+      ['cubeIdentifier', 'ubd/28'],
+      ['apiClient', Hydra],
+      ['timestamp', toRdf(new Date())],
+      ['metadata', $rdf.dataset()],
+    ])
+    context = {
+      variables,
+      logger,
+    }
+  })
+
+  describe('loadCubeMetadata', () => {
+    it('should exclude properties of concepts linked from observations', async () => {
+      // given
+      const jobUri = 'https://cube-creator.lndo.site/cube-project/ubd/csv-mapping/jobs/test-publish-job'
+
+      // when
+      const [dataset] = await getStream.array<DatasetCore>(await loadCubeMetadata.call(context, {
+        jobUri,
+        endpoint: env.STORE_QUERY_ENDPOINT,
+      }))
+
+      // then
+      const concept = clownface({ dataset })
+        .namedNode('https://environment.ld.admin.ch/foen/ubd/28/1/station/blBAS')
+      expect(concept.out().terms).to.have.length(0)
+      expect(concept.in().terms).to.have.length.greaterThan(0)
+    })
+  })
+
+  it('should include complete sh:or lists of  properties', async () => {
+    // given
+    const jobUri = 'https://cube-creator.lndo.site/cube-project/ubd/csv-mapping/jobs/test-publish-job'
+
+    // when
+    const [dataset] = await getStream.array<DatasetCore>(await loadCubeMetadata.call(context, {
+      jobUri,
+      endpoint: env.STORE_QUERY_ENDPOINT,
+    }))
+
+    // then
+    const shOr = clownface({ dataset })
+      .has(sh.path, $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/dimension/year'))
+      .out(sh.or)
+      .list()!
+    expect([...shOr]).to.containAll((ptr: GraphPointer) => {
+      return ptr.has(sh.datatype).terms.length > 0
+    })
+  })
+})

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -292,7 +292,9 @@ graph <cube-project/ubd/cube-data> {
     sh:maxCount  1 ;
     sh:minCount  1 ;
     sh:nodeKind  sh:Literal ;
-    sh:path      <https://environment.ld.admin.ch/foen/ubd/28/dimension/year> .
+    sh:path      <https://environment.ld.admin.ch/foen/ubd/28/dimension/year> ;
+    sh:or ( [ sh:datatype cube:Undefined ] [ sh:datatype xsd:gYear ] ) ;
+  .
 
   _:dimension-value
     sh:datatype  xsd:decimal ;


### PR DESCRIPTION
The query built to retrieve cube metadata was previously meant to exclude concepts which appear in `sh:in` lists

The filter used inadvertently also excluded triples deep inside `sh:or`, which resulted in dangling blank nodes without the expected `sh:datatype`