### PR TITLE
fix: do not rewrite hierarchy roots

### DIFF
--- a/.changeset/yellow-peaches-pull.md
+++ b/.changeset/yellow-peaches-pull.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Hierarchy roots would be shown in wrong domain (cube-creator instead of `ld.admin.ch`)

--- a/apis/shared-dimensions/lib/handlers/hierarchy.ts
+++ b/apis/shared-dimensions/lib/handlers/hierarchy.ts
@@ -1,7 +1,10 @@
+import { Quad } from 'rdf-js'
 import { dcterms, sd } from '@tpluscode/rdf-ns-builders'
 import { asyncMiddleware } from 'middleware-async'
 import $rdf from 'rdf-ext'
 import env from '@cube-creator/core/env'
+import { meta } from '@cube-creator/core/namespace'
+import { ShouldRewrite } from '../middleware/canonicalRewrite'
 
 export const get = asyncMiddleware(async (req, res) => {
   const hierarchy = await req.hydra.resource.clownface()
@@ -12,6 +15,18 @@ export const get = asyncMiddleware(async (req, res) => {
         .addOut(sd.endpoint, $rdf.namedNode(env.PUBLIC_QUERY_ENDPOINT))
     })
   }
+
+  const noRewriteRoots: ShouldRewrite = (quad: Quad) => {
+    if (quad.predicate.equals(meta.hierarchyRoot)) {
+      return {
+        object: false,
+      }
+    }
+
+    return true
+  }
+
+  res.locals.noRewrite = noRewriteRoots
 
   return res.dataset(hierarchy.dataset)
 })

--- a/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
+++ b/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
@@ -16,6 +16,7 @@ export function rewriteTerm<T extends Term>(term: T): T {
 }
 
 export interface ShouldRewrite {
+  // eslint-disable-next-line no-unused-vars
   (quad: Quad): true | { [p in keyof Quad]?: false }
 }
 

--- a/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
+++ b/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
@@ -15,15 +15,36 @@ export function rewriteTerm<T extends Term>(term: T): T {
   return term
 }
 
+export interface ShouldRewrite {
+  (quad: Quad): true | { [p in keyof Quad]?: false }
+}
+
+const defaultShouldRewrite: ShouldRewrite = ({ predicate }) => {
+  if (predicate.equals(oa.canonical)) {
+    return {
+      subject: false,
+    }
+  }
+
+  return true
+}
+
 /**
  * Rewrites quad to change canonical URIs with API namespace with the exception of oa:canonical property
  */
-function rewriteQuad({ subject, predicate, object, graph }: Quad): Quad {
+function rewriteQuad(quad: Quad, shouldRewriteCheck: ShouldRewrite = defaultShouldRewrite): Quad {
+  const shouldRewrite = shouldRewriteCheck(quad)
+
+  const rewriteSubject = shouldRewrite === true || shouldRewrite.subject !== false
+  const rewritePredicate = shouldRewrite === true || shouldRewrite.predicate !== false
+  const rewriteObject = shouldRewrite === true || shouldRewrite.object !== false
+  const rewriteGraph = shouldRewrite === true || shouldRewrite.graph !== false
+
   return $rdf.quad(
-    rewriteTerm(subject),
-    rewriteTerm(predicate),
-    predicate.equals(oa.canonical) ? object : rewriteTerm(object),
-    rewriteTerm(graph),
+    rewriteSubject ? rewriteTerm(quad.subject) : quad.subject,
+    rewritePredicate ? rewriteTerm(quad.predicate) : quad.predicate,
+    rewriteObject ? rewriteTerm(quad.object) : quad.object,
+    rewriteGraph ? rewriteTerm(quad.graph) : quad.graph,
   )
 }
 
@@ -31,14 +52,18 @@ export const patchResponseStream: express.RequestHandler = asyncMiddleware(async
   const { quadStream } = res
 
   res.quadStream = (stream: Stream & Readable) => {
-    if (res.locals.noRewrite) {
-      // when set, res.locals.noRewrite prevents the rewrite of
+    if (res.locals.noRewrite === true) {
+      // when set to true, res.locals.noRewrite prevents the rewrite of
       // canonical terms to cube-creator URIs
       return quadStream(stream)
     }
 
     const rewriteTerms = through2.obj(function (chunk: Quad, enc, callback) {
-      this.push(rewriteQuad(chunk))
+      if (typeof res.locals.noRewrite === 'function') {
+        this.push(rewriteQuad(chunk, res.locals.noRewrite))
+      } else {
+        this.push(rewriteQuad(chunk))
+      }
 
       callback()
     })


### PR DESCRIPTION
Further tweaks to have hierarchy roots served in their canonical URI

Previously, in #1172, I added a change to have hierarchy roots loaded as `ld.admin.ch` in the editor form. This was not enough, because they would still be rewritten when loading the hierarchy itself (both when editing and showing the preview tree)

By expanding the semantics of `res.locals.noRewrite` there is more fine-grained control fo what gets rewritten. In this case we selectively exclude `meta:hierarchyRoot`