### PR TITLE
fix: only show 'real' hierarchies in the list

### DIFF
--- a/.changeset/chilled-brooms-end.md
+++ b/.changeset/chilled-brooms-end.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Hierarchies instantiated in cubes would show in the list (fixes #1202)

--- a/apis/shared-dimensions/lib/handlers/hierarchies.ts
+++ b/apis/shared-dimensions/lib/handlers/hierarchies.ts
@@ -1,5 +1,5 @@
 import { asyncMiddleware } from 'middleware-async'
-import { md, meta } from '@cube-creator/core/namespace'
+import { md } from '@cube-creator/core/namespace'
 import { protectedResource } from '@hydrofoil/labyrinth/resource'
 import { hydra } from '@tpluscode/rdf-ns-builders'
 import clownface from 'clownface'
@@ -29,7 +29,7 @@ export const get = asyncMiddleware(async (req, res, next) => {
   const collection = await getCollection({
     memberQuads: await getHierarchies(queryParams).execute(parsingClient.query),
     collectionType: md.Hierarchies,
-    memberType: meta.Hierarchy,
+    memberType: md.Hierarchy,
     collection: req.hydra.resource.term,
   })
 


### PR DESCRIPTION
A hierarchy used in a cube have the type `meta:Hierarchy`. We used same class to select hierarchies to show on the list. Thus, any time we would add a hierarchy (copy) to a cube, it would appear as another duplicate. Also blank node so a dead link effectively

The fix was to select only the editable hierarchies using a different class `md:Hierarchy` that gets added for that exact purpose