### PR TITLE
Auto mapping shared dimensions

### DIFF
--- a/.changeset/beige-schools-pump.md
+++ b/.changeset/beige-schools-pump.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Add paging to dimension mapping screen

--- a/.changeset/serious-rocks-lay.md
+++ b/.changeset/serious-rocks-lay.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Remove `applyMappings` box from dimension mapping form

--- a/.changeset/tender-actors-warn.md
+++ b/.changeset/tender-actors-warn.md
@@ -1,0 +1,6 @@
+---
+"@cube-creator/core-api": minor
+"@cube-creator/ui": minor
+---
+
+Importing dimension mappings from shared dimension

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -466,7 +466,16 @@ ${shape('dimension/shared-mapping-import')} {
       ${dash.editor} ${editor.PropertyEditor} ;
       ${sh.nodeKind} ${sh.IRI} ;
       ${sh.order} 20 ;
-    ];
+    ] , [
+      ${sh.path} ${md.onlyValidTerms} ;
+      ${sh.name} "Only current terms" ;
+      ${sh.description} "Uncheck to import all Shared Terms, including deprecated" ;
+      ${sh.datatype} ${xsd.boolean} ;
+      ${sh.defaultValue} true ;
+      ${sh.minCount} 1 ;
+      ${sh.maxCount} 1 ;
+      ${sh.order} 30 ;
+    ]  ;
   .
 }
 `

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -443,6 +443,32 @@ ${shape('dimension/metadata')} {
 }
 `
 
+export const SharedDimensionMappingImportShape = turtle`
+${shape('dimension/shared-mapping-import')} {
+  ${shape('dimension/shared-mapping-import')}
+    a ${sh.NodeShape}, ${hydra.Resource} ;
+    ${sh.property} [
+      ${sh.path} ${cc.sharedDimension} ;
+      ${sh.name} "Shared dimension" ;
+      ${dash.editor} ${dash.AutoCompleteEditor} ;
+      ${hydra.collection} ${sharedDimensionCollection} ;
+      ${sh.nodeKind} ${sh.IRI} ;
+      ${sh.order} 10 ;
+      ${sh.minCount} 1 ;
+      ${sh.maxCount} 1 ;
+    ] , [
+      ${sh.path} ${rdf.predicate} ;
+      ${sh.minCount} 1 ;
+      ${sh.maxCount} 1 ;
+      ${sh.defaultValue} ${schema.identifier} ;
+      ${dash.editor} ${editor.PropertyEditor} ;
+      ${sh.nodeKind} ${sh.IRI} ;
+      ${sh.order} 20 ;
+    ];
+  .
+}
+`
+
 export const SharedDimensionMappingShape = turtle`
 ${shape('dimension/shared-mapping')} {
   ${shape('dimension/shared-mapping')}

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -481,15 +481,6 @@ ${shape('dimension/shared-mapping')} {
       ${sh.order} 20 ;
       ${dash.editor} ${dash.DetailsEditor} ;
       ${sh.class} ${prov.KeyEntityPair} ;
-    ] , [
-      ${sh.path} ${cc.applyMappings} ;
-      ${sh.name} "Apply mappings" ;
-      ${sh.description} "If checked, the Cube will be immediately updated with new mappings. Otherwise, running the transformation/import will be necessary" ;
-      ${sh.order} 30 ;
-      ${sh.datatype} ${xsd.boolean} ;
-      ${sh.defaultValue} false ;
-      ${sh.minCount} 1 ;
-      ${sh.maxCount} 1 ;
     ]
   .
 

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -458,6 +458,8 @@ ${shape('dimension/shared-mapping-import')} {
       ${sh.maxCount} 1 ;
     ] , [
       ${sh.path} ${rdf.predicate} ;
+      ${sh.name} "Identifier property" ;
+      ${sh.description} """Value of this property can be directly on the Shared Term or inside a \`schema:PropertyValue\` such as \`schema:identifier [ schema:value "ID" ] \`""" ;
       ${sh.minCount} 1 ;
       ${sh.maxCount} 1 ;
       ${sh.defaultValue} ${schema.identifier} ;

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -5,7 +5,6 @@ import { dash, hydra, prov, rdf, rdfs, schema, sh, qudt, time, xsd } from '@tplu
 import namespace from '@rdfjs/namespace'
 import $rdf from 'rdf-ext'
 import { lindasQuery } from '../lib/query'
-import { placeholderEntity } from '../../lib/domain/dimension-mapping/DimensionMapping'
 
 const sou = namespace('http://qudt.org/vocab/sou/')
 
@@ -478,6 +477,7 @@ ${shape('dimension/shared-mapping')} {
       ${sh.path} ${prov.hadDictionaryMember} ;
       ${sh.node} _:keyEntityPair ;
       ${sh.name} "Mappings" ;
+      ${sh.description} "New mappings will only be applied after transformation is ran" ;
       ${sh.order} 20 ;
       ${dash.editor} ${dash.DetailsEditor} ;
       ${sh.class} ${prov.KeyEntityPair} ;
@@ -497,8 +497,7 @@ ${shape('dimension/shared-mapping')} {
       ${sh.name} "Shared Dimension term" ;
       ${dash.editor} ${dash.AutoCompleteEditor} ;
       ${sh.nodeKind} ${sh.IRI} ;
-      ${sh.defaultValue} ${placeholderEntity} ;
-      ${sh.minCount} 1 ;
+      ${sh1.minCount} 1 ; # sh1:minCount will be changed into sh:minCount in the client to force a dropdown being rendered
       ${sh.maxCount} 1 ;
       ${sh1.itemHelptextPath} ( ${schema.inDefinedTermSet} ${schema.name} ) ;
       ${hydra.search} [
@@ -523,6 +522,4 @@ ${shape('dimension/shared-mapping')} {
       ${sh.order} 20 ;
     ];
   .
-
-  ${placeholderEntity} ${rdfs.label} "Select" .
 }`

--- a/apis/core/bootstrap/shapes/index.ts
+++ b/apis/core/bootstrap/shapes/index.ts
@@ -4,7 +4,7 @@ import { DatasetShape } from './dataset'
 import { CSVSourceCreateShape, CSVSourceUpdateShape } from './csv-source'
 import { JobUpdateShape, JobTriggerShape } from './jobs'
 import { ColumnMappingShape } from './column-mapping'
-import { DimensionMetadataShape, SharedDimensionMappingShape } from './dimension'
+import { DimensionMetadataShape, SharedDimensionMappingShape, SharedDimensionMappingImportShape } from './dimension'
 
 export default [
   CubeProjectShape,
@@ -17,4 +17,5 @@ export default [
   JobTriggerShape,
   DimensionMetadataShape,
   SharedDimensionMappingShape,
+  SharedDimensionMappingImportShape,
 ]

--- a/apis/core/hydra/dimension-mapping.ttl
+++ b/apis/core/hydra/dimension-mapping.ttl
@@ -1,3 +1,4 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 BASE <urn:hydra-box:api>
 prefix schema: <http://schema.org/>
 prefix hydra: <http://www.w3.org/ns/hydra/core#>
@@ -13,6 +14,10 @@ prov:Dictionary
     [
       a code:EcmaScript ;
       code:link <file:handlers/dimension-mapping#prepareEntries> ;
+    ] ;
+  hydra:supportedProperty
+    [
+      hydra:property cc:batchMapping ;
     ] ;
   hydra:supportedOperation
     [
@@ -30,3 +35,21 @@ prov:Dictionary
     ] .
 
 <shape/dimension/shared-mapping> a sh:Shape .
+
+cc:batchMapping
+  a rdf:Property ;
+  hydra:supportedOperation
+    [
+      a cc:BatchMappingAction ;
+      hydra:method "POST" ;
+      hydra:title "Map terms from a Shared Dimension" ;
+      hydra:expects <shape/dimension/shared-mapping-import> ;
+      code:implementedBy
+        [
+          a code:EcmaScript ;
+          code:link <file:handlers/dimension-mapping#importMappingsRequest> ;
+        ] ;
+    ] ;
+.
+
+<shape/dimension/shared-mapping-import> a sh:Shape .

--- a/apis/core/lib/ResourceStore.ts
+++ b/apis/core/lib/ResourceStore.ts
@@ -52,6 +52,8 @@ export interface ResourceStore {
    * Removes the named graph from the triple store
    */
   delete(id: NamedNode): void
+
+  save(): Promise<void>
 }
 
 interface TripleStoreFacade {

--- a/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
+++ b/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
@@ -41,6 +41,10 @@ export function ProvDictionaryMixinEx<Base extends Constructor<Dictionary>>(Reso
       const newEntries = new TermMap()
 
       const newEntryMap = entries.reduce<Map<Term, Term | undefined>>((map, { pairKey, pairEntity }) => {
+        if (!pairEntity) {
+          return map
+        }
+
         return pairKey ? map.set(pairKey, pairEntity?.id) : map
       }, new TermMap())
 

--- a/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
+++ b/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
@@ -22,8 +22,6 @@ declare module '@rdfine/prov' {
   }
 }
 
-export const placeholderEntity = $rdf.namedNode('urn:placeholder:entity')
-
 export function ProvDictionaryMixinEx<Base extends Constructor<Dictionary>>(Resource: Base) {
   class ProvDictionaryEx extends Resource implements DictionaryEx {
     @property({ path: schema.about })
@@ -43,10 +41,6 @@ export function ProvDictionaryMixinEx<Base extends Constructor<Dictionary>>(Reso
       const newEntries = new TermMap()
 
       const newEntryMap = entries.reduce<Map<Term, Term | undefined>>((map, { pairKey, pairEntity }) => {
-        if (pairEntity?.id.equals(placeholderEntity)) {
-          return map
-        }
-
         return pairKey ? map.set(pairKey, pairEntity?.id) : map
       }, new TermMap())
 

--- a/apis/core/lib/domain/dimension-mapping/update.ts
+++ b/apis/core/lib/domain/dimension-mapping/update.ts
@@ -3,10 +3,7 @@ import { GraphPointer } from 'clownface'
 import error from 'http-errors'
 import { Dictionary } from '@rdfine/prov'
 import { fromPointer } from '@rdfine/prov/lib/Dictionary'
-import { cc } from '@cube-creator/core/namespace'
 import { ResourceStore } from '../../ResourceStore'
-import { replaceValueWithDefinedTerms } from '../queries/dimension-mappings'
-import * as log from '../../log'
 
 interface UpdateDimensionMapping {
   resource: NamedNode
@@ -32,14 +29,7 @@ export async function update({
   dimensionMappings.changeSharedDimensions(sharedDimensions)
 
   dimensionMappings.onlyValidTerms = newMappings.onlyValidTerms
-
-  const newEntries = dimensionMappings.replaceEntries(newMappings.hadDictionaryMember)
-
-  const { applyMappings } = cc
-  if (newEntries.size && mappings.out(applyMappings).value === 'true') {
-    replaceValueWithDefinedTerms({ dimensionMapping: resource, terms: newEntries })
-      .catch((err: Error) => log.error(`Failed to update observations: ${err.message}`))
-  }
+  dimensionMappings.replaceEntries(newMappings.hadDictionaryMember)
 
   return dimensionMappings.pointer
 }

--- a/apis/core/lib/domain/dimension/update.ts
+++ b/apis/core/lib/domain/dimension/update.ts
@@ -5,6 +5,7 @@ import $rdf from 'rdf-ext'
 import { DimensionMetadataCollection, Project } from '@cube-creator/model'
 import { createNoMeasureDimensionError, Error } from '@cube-creator/model/DimensionMetadata'
 import { prov, rdf, schema } from '@tpluscode/rdf-ns-builders'
+import { cc } from '@cube-creator/core/namespace'
 import { ResourceStore } from '../../ResourceStore'
 import * as id from '../identifiers'
 import { findProject } from '../cube-projects/queries'
@@ -50,6 +51,7 @@ export async function update({
     dimensionMapping
       .addOut(rdf.type, prov.Dictionary)
       .addOut(schema.about, dimension.about)
+      .addOut(cc.batchMapping, $rdf.namedNode(dimensionMapping.value + '/_import-terms'))
 
     dimension.mappings = dimensionMapping.term
   } else if (!canBeMappedToSharedDimension(dimension) && dimension.mappings) {

--- a/apis/core/lib/domain/queries/dimension-mappings.ts
+++ b/apis/core/lib/domain/queries/dimension-mappings.ts
@@ -1,11 +1,10 @@
 import { Literal, Term } from 'rdf-js'
-import { DELETE, SELECT } from '@tpluscode/sparql-builder'
+import { SELECT } from '@tpluscode/sparql-builder'
 import { sparql } from '@tpluscode/rdf-string'
 import { rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
 import { cc, cube } from '@cube-creator/core/namespace'
-import TermMap from '@rdfjs/term-map'
 import TermSet from '@rdfjs/term-set'
-import { parsingClient, streamClient } from '../../query-client'
+import { parsingClient } from '../../query-client'
 
 function patternsToFindCubeGraph(dimensionMapping: Term) {
   return sparql`BIND ( ${dimensionMapping} as ?dimensionMapping )
@@ -29,45 +28,6 @@ function patternsToFindCubeGraph(dimensionMapping: Term) {
                ${cc.dataset} ?dataset ;
                ${cc.cubeGraph} ?cubeGraph .
     }`
-}
-
-export async function replaceValueWithDefinedTerms({ dimensionMapping, terms }: { dimensionMapping: Term; terms: TermMap }, client = streamClient): Promise<void> {
-  if (terms.size === 0) {
-    return
-  }
-
-  const pairs = [...terms.entries()].reduce((values, [originalValue, sharedTerm]) => {
-    return sparql`${values}\n    ( ${originalValue} ${sharedTerm} )`
-  }, sparql``)
-
-  await DELETE`
-    graph ?cubeGraph {
-      ?listNode ${rdf.first} ?originalValue .
-      ?observation ?dimension ?originalValue .
-    }
-  `.INSERT`
-    graph ?cubeGraph {
-      ?listNode ${rdf.first} ?sharedTerm .
-      ?observation ?dimension ?sharedTerm .
-    }
-  `.WHERE`
-   ${patternsToFindCubeGraph(dimensionMapping)}
-  `.WHERE`
-    VALUES ( ?originalValue ?sharedTerm ) {
-      ${pairs}
-    }
-
-    graph ?cubeGraph {
-      ?observation a ${cube.Observation} .
-      ?shapeProperty ${sh.path} ?dimension .
-
-      OPTIONAL { ?observation ?dimension ?originalValue . }
-      OPTIONAL {
-        ?shapeProperty ${sh.in}/${rdf.rest}* ?listNode .
-        ?listNode ${rdf.first} ?originalValue .
-      }
-    }
-  `.execute(client.query)
 }
 
 export async function getUnmappedValues(dimensionMapping: Term, dimension: Term, client = parsingClient): Promise<Set<Literal>> {

--- a/apis/core/lib/domain/queries/dimension-mappings.ts
+++ b/apis/core/lib/domain/queries/dimension-mappings.ts
@@ -1,13 +1,16 @@
-import { Literal, Term } from 'rdf-js'
-import { SELECT } from '@tpluscode/sparql-builder'
+import { Literal, NamedNode, Term } from 'rdf-js'
+import { INSERT, SELECT } from '@tpluscode/sparql-builder'
 import { sparql } from '@tpluscode/rdf-string'
 import { rdf, schema, sh } from '@tpluscode/rdf-ns-builders'
 import { cc, cube } from '@cube-creator/core/namespace'
 import TermSet from '@rdfjs/term-set'
+import { prov } from '@tpluscode/rdf-ns-builders/strict'
+import env from '@cube-creator/core/env'
+import { Dictionary } from '@rdfine/prov'
 import { parsingClient } from '../../query-client'
 
-function patternsToFindCubeGraph(dimensionMapping: Term) {
-  return sparql`BIND ( ${dimensionMapping} as ?dimensionMapping )
+async function findCubeGraph(dimensionMapping: Term, client: typeof parsingClient): Promise<NamedNode> {
+  const patternsToFindCubeGraph = sparql`BIND ( ${dimensionMapping} as ?dimensionMapping )
 
   graph ?dimensionMapping {
       ?dimensionMapping ${schema.about} ?dimension .
@@ -28,40 +31,90 @@ function patternsToFindCubeGraph(dimensionMapping: Term) {
                ${cc.dataset} ?dataset ;
                ${cc.cubeGraph} ?cubeGraph .
     }`
+
+  const [{ cubeGraph }] = await SELECT`?cubeGraph`
+    .WHERE`${patternsToFindCubeGraph}`
+    .execute(client.query)
+
+  return cubeGraph as any
 }
 
-export async function getUnmappedValues(dimensionMapping: Term, dimension: Term, client = parsingClient): Promise<Set<Literal>> {
-  const [{ cubeGraph }] = await SELECT`?cubeGraph`
-    .WHERE`${patternsToFindCubeGraph(dimensionMapping)}`
+function unmappedValuesQuery(cubeGraph: NamedNode, dimensionMapping: Term) {
+  return SELECT.DISTINCT`?value`
+    .WHERE`
+      # find mapped dimension URL
+      GRAPH ${dimensionMapping} {
+        ${dimensionMapping} ${schema.about} ?dimension
+      }
+
+      # find all values from observation and shape
+      GRAPH ${cubeGraph} {
+        {
+          ?shape a ${cube.Constraint} ; ${sh.property} ?propShape .
+          ?propShape ${sh.path} ?dimension ;
+                     ${sh.in}/${rdf.rest}* ?listNode .
+          ?listNode ${rdf.first} ?value .
+        }
+        UNION
+        {
+          ?observation a ${cube.Observation} ; ?dimension ?value .
+        }
+
+        filter ( !isIRI(?value) )
+      }
+
+    # exclude values which are already mapped
+    FILTER ( NOT EXISTS {
+      GRAPH ${dimensionMapping} {
+        ${dimensionMapping} ${prov.hadDictionaryMember} [
+           ${prov.pairKey} ?value ; ${prov.pairEntity} []
+        ]
+      }
+    })
+    `
+}
+
+export async function getUnmappedValues(dimensionMapping: Term, client = parsingClient): Promise<Set<Literal>> {
+  const cubeGraph = await findCubeGraph(dimensionMapping, client)
+
+  const unmappedValues = await unmappedValuesQuery(cubeGraph, dimensionMapping)
     .execute(client.query)
 
-  const results = await SELECT.DISTINCT`?value`
-    .FROM(cubeGraph as any)
-    .WHERE`{
-      SELECT ?value
-      WHERE {
-        ?shape a ${cube.Constraint} ; ${sh.property}  ?propShape .
-        ?propShape ${sh.path} ${dimension} ;
-                   ${sh.in}/${rdf.rest}* ?listNode .
-        ?listNode ${rdf.first} ?value .
-      }
+  return new TermSet(unmappedValues.map(result => result.value as any))
+}
+
+export async function importMappingsFromSharedDimension(dimensionMapping: Dictionary, client = parsingClient) {
+  const cubeGraph = await findCubeGraph(dimensionMapping.id, client)
+
+  const unmappedValuesSelect = unmappedValuesQuery(cubeGraph, dimensionMapping.id)
+
+  const insert = INSERT`
+    GRAPH ${dimensionMapping.id} {
+      ${dimensionMapping.id} ${prov.hadDictionaryMember} [
+        a ${prov.KeyEntityPair} ;
+        ${prov.pairKey} ?value ;
+        ${prov.pairEntity} ?term
+      ]
     }
-    UNION
+  `.WHERE`
     {
-      SELECT ?value
-      WHERE {
-        ?observation a ${cube.Observation} ; ${dimension} ?value .
+      ${unmappedValuesSelect}
+    }
+
+    GRAPH ${dimensionMapping.id} {
+      ${dimensionMapping.id} ${cc.sharedDimension} ?dimension
+    }
+
+    SERVICE <${env.PUBLIC_QUERY_ENDPOINT}> {
+      {
+        ?term ${schema.inDefinedTermSet} ?dimension ;
+              ${schema.identifier} ?value .
+      } union {
+        ?term ${schema.inDefinedTermSet} ?dimension ;
+              ${schema.identifier}/${schema.value} ?value .
       }
     }
+  `
 
-    filter ( !isIRI(?value) )`
-    .execute(client.query)
-
-  return results.reduce((missingValues, row) => {
-    if (row.value && row.value.termType === 'Literal') {
-      return missingValues.add(row.value)
-    }
-
-    return missingValues
-  }, new TermSet<Literal>())
+  await insert.execute(client.query)
 }

--- a/apis/core/lib/handlers/dimension-mapping.ts
+++ b/apis/core/lib/handlers/dimension-mapping.ts
@@ -10,7 +10,7 @@ import { Dictionary } from '@rdfine/prov'
 import { cc } from '@cube-creator/core/namespace'
 import { rdf } from '@tpluscode/rdf-ns-builders/strict'
 import error from 'http-errors'
-import { isGraphPointer } from 'is-graph-pointer'
+import { isNamedNode } from 'is-graph-pointer'
 import { shaclValidate } from '../middleware/shacl'
 import { update } from '../domain/dimension-mapping/update'
 import { getUnmappedValues, importMappingsFromSharedDimension } from '../domain/queries/dimension-mappings'
@@ -85,14 +85,14 @@ export const importMappingsRequest = protectedResource(
     const dimension = args.out(cc.sharedDimension)
     const predicate = args.out(rdf.predicate)
 
-    if (!isGraphPointer(dimension) || !isGraphPointer(predicate)) {
+    if (!isNamedNode(dimension) || !isNamedNode(predicate)) {
       return next(new error.BadRequest())
     }
 
     await importMappingsFromSharedDimension({
-      dimensionMapping,
-      dimension,
-      predicate,
+      dimensionMapping: dimensionMapping.id,
+      dimension: dimension.term,
+      predicate: predicate.term,
     })
 
     res.end()

--- a/apis/core/lib/middleware/resource.ts
+++ b/apis/core/lib/middleware/resource.ts
@@ -1,11 +1,11 @@
 import express from 'express'
 import once from 'once'
-import ResourceStoreImpl, { SparqlStoreFacade } from '../ResourceStore'
+import ResourceStoreImpl, { ResourceStore, SparqlStoreFacade } from '../ResourceStore'
 import { streamClient } from '../query-client'
 
 declare module 'express-serve-static-core' {
   export interface Request {
-    resourceStore(): ResourceStoreImpl
+    resourceStore(): ResourceStore
   }
 }
 

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -48,6 +48,7 @@
     "http-errors": "^2.0.0",
     "hydra-box": "^0.6.4",
     "hydra-box-middleware-shacl": "1.1.0",
+    "is-graph-pointer": "^1.2.0",
     "is-stream": "^2",
     "jwks-rsa": "^2.0.5",
     "merge2": "^1.4.1",

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -59,6 +59,7 @@
     "parse-prefer-header": "^1.0.0",
     "rdf-cube-view-query": "^1.8.2",
     "rdf-ext": "^1.3.0",
+    "rdf-literal": "^1.3.0",
     "set-link": "^1.0.0",
     "slug": "^5.0.0",
     "sparql-http-client": "^2.2.2",

--- a/apis/core/test/domain/dimension-mapping/update.test.ts
+++ b/apis/core/test/domain/dimension-mapping/update.test.ts
@@ -76,7 +76,7 @@ describe('domain/dimension-mapping/update', () => {
       const mappings = namedNode(resource)
         .addOut(rdf.type, prov.Dictionary)
         .addOut(schema.about, dimension)
-        .addOut(cc.sharedDimension, ex('http://example.com/dimension/chemicals'))
+        .addOut(cc.sharedDimension, $rdf.namedNode('http://example.com/dimension/chemicals'))
         .addOut(prov.hadDictionaryMember, member => {
           member
             .addOut(prov.pairKey, 'co')
@@ -147,7 +147,7 @@ describe('domain/dimension-mapping/update', () => {
           }, {
             property: {
               path: prov.pairKey,
-              hasValue: 'so2',
+              hasValue: 'Pb',
             },
           }],
         },

--- a/apis/core/test/domain/dimension-mapping/update.test.ts
+++ b/apis/core/test/domain/dimension-mapping/update.test.ts
@@ -127,16 +127,28 @@ describe('domain/dimension-mapping/update', () => {
       expect(dimensionMapping).to.matchShape({
         property: {
           path: prov.hadDictionaryMember,
-          minCount: 4,
-          maxCount: 4,
+          minCount: 3,
+          maxCount: 3,
           property: [{
-            path: prov.pairKey,
+            path: prov.pairEntity,
             minCount: 1,
             maxCount: 1,
+          }],
+          xone: [{
+            property: {
+              path: prov.pairKey,
+              hasValue: 'co',
+            },
           }, {
-            path: prov.pairEntity,
-            minCount: 0,
-            maxCount: 1,
+            property: {
+              path: prov.pairKey,
+              hasValue: 'As',
+            },
+          }, {
+            property: {
+              path: prov.pairKey,
+              hasValue: 'so2',
+            },
           }],
         },
       })
@@ -277,12 +289,11 @@ describe('domain/dimension-mapping/update', () => {
       })
     })
 
-    it('update dictionary entry', () => {
+    it('removes key/value pairs', () => {
       expect(dimensionMapping).to.matchShape({
         property: {
           path: prov.hadDictionaryMember,
-          minCount: 2,
-          maxCount: 2,
+          maxCount: 0,
         },
       })
       expect(dimensionMapping).to.matchShape({

--- a/apis/core/test/domain/queries/dimension-mappings.test.ts
+++ b/apis/core/test/domain/queries/dimension-mappings.test.ts
@@ -15,11 +15,9 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
   })
 
   describe('getUnmappedValues', () => {
-    const dimension = $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/pollutant')
-
     it('returns combined unmapped values from shapes and observations', async () => {
       // when
-      const unmappedValues = await getUnmappedValues(dimensionMapping, dimension, ccClients.parsingClient)
+      const unmappedValues = await getUnmappedValues(dimensionMapping, ccClients.parsingClient)
 
       // then
       expect(unmappedValues).to.have.property('size', 3)

--- a/apis/core/test/domain/queries/dimension-mappings.test.ts
+++ b/apis/core/test/domain/queries/dimension-mappings.test.ts
@@ -1,14 +1,9 @@
-import { Term } from 'rdf-js'
 import { describe, it, beforeEach } from 'mocha'
-import sinon from 'sinon'
 import $rdf from 'rdf-ext'
 import { expect } from 'chai'
-import { DESCRIBE } from '@tpluscode/sparql-builder'
 import { ccClients } from '@cube-creator/testing/lib'
 import { insertTestProject } from '@cube-creator/testing/lib/seedData'
-import clownface from 'clownface'
-import TermMap from '@rdfjs/term-map'
-import { replaceValueWithDefinedTerms, getUnmappedValues } from '../../../lib/domain/queries/dimension-mappings'
+import { getUnmappedValues } from '../../../lib/domain/queries/dimension-mappings'
 
 describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL', function () {
   this.timeout(20000)
@@ -17,47 +12,6 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
 
   beforeEach(async () => {
     await insertTestProject()
-  })
-
-  describe('replaceValueWithDefinedTerms', () => {
-    let terms: Map<Term, Term>
-    const sparqlSpy = sinon.spy(ccClients.streamClient.query, 'update')
-
-    beforeEach(async () => {
-      terms = new TermMap()
-
-      sparqlSpy.resetHistory()
-    })
-
-    it('does nothing when called without any terms', async () => {
-    // when
-      await replaceValueWithDefinedTerms({ dimensionMapping, terms }, ccClients.streamClient)
-
-      // then
-      expect(sparqlSpy).not.to.have.been.called
-    })
-
-    it('updates observations', async () => {
-    // given
-      const observationId = $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-2003-annualmean')
-      const definedTerm = $rdf.namedNode('http://www.wikidata.org/entity/Q5282')
-      terms.set($rdf.literal('so2'), definedTerm)
-
-      // when
-      await replaceValueWithDefinedTerms({ dimensionMapping, terms }, ccClients.streamClient)
-
-      // then
-      const quads = await DESCRIBE`${observationId}`.execute(ccClients.parsingClient.query)
-      const observation = clownface({ dataset: $rdf.dataset(quads) }).namedNode(observationId)
-      expect(observation).to.matchShape({
-        property: {
-          path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/pollutant'),
-          hasValue: definedTerm,
-          minCount: 1,
-          maxCount: 1,
-        },
-      })
-    })
   })
 
   describe('getUnmappedValues', () => {

--- a/apis/core/test/domain/queries/dimension-mappings.test.ts
+++ b/apis/core/test/domain/queries/dimension-mappings.test.ts
@@ -1,23 +1,27 @@
-import { describe, it, beforeEach } from 'mocha'
+import { describe, it, beforeEach, afterEach } from 'mocha'
 import $rdf from 'rdf-ext'
 import { expect } from 'chai'
 import { ccClients } from '@cube-creator/testing/lib'
-import { insertTestProject } from '@cube-creator/testing/lib/seedData'
-import { getUnmappedValues } from '../../../lib/domain/queries/dimension-mappings'
+import { insertTestDimensions, insertTestProject } from '@cube-creator/testing/lib/seedData'
+import { dcterms, prov, schema } from '@tpluscode/rdf-ns-builders/strict'
+import { ASK, sparql } from '@tpluscode/sparql-builder'
+import { IN, VALUES } from '@tpluscode/sparql-builder/expressions'
+import { getUnmappedValues, importMappingsFromSharedDimension } from '../../../lib/domain/queries/dimension-mappings'
 
 describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL', function () {
   this.timeout(20000)
 
-  const dimensionMapping = $rdf.namedNode('https://cube-creator.lndo.site/cube-project/ubd/dimension-mapping/pollutant')
+  const pollutantMapping = $rdf.namedNode('https://cube-creator.lndo.site/cube-project/ubd/dimension-mapping/pollutant')
 
   beforeEach(async () => {
     await insertTestProject()
+    await insertTestDimensions()
   })
 
   describe('getUnmappedValues', () => {
     it('returns combined unmapped values from shapes and observations', async () => {
       // when
-      const unmappedValues = await getUnmappedValues(dimensionMapping, ccClients.parsingClient)
+      const unmappedValues = await getUnmappedValues(pollutantMapping, ccClients.parsingClient)
 
       // then
       expect(unmappedValues).to.have.property('size', 3)
@@ -26,6 +30,100 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
         $rdf.literal('As'),
         $rdf.literal('Pb'),
       ])
+    })
+  })
+
+  describe('importMappingsFromSharedDimension', () => {
+    const testMapping = $rdf.namedNode('https://cube-creator.lndo.site/cube-project/test/dimension-mapping/test')
+
+    afterEach(async () => {
+      await ccClients.parsingClient.query.update(sparql`DROP SILENT GRAPH ${testMapping}`.toString())
+    })
+
+    it('creates new pairs for matched identifiers', async () => {
+      // when
+      await importMappingsFromSharedDimension({
+        dimensionMapping: pollutantMapping,
+        dimension: $rdf.namedNode('http://example.com/dimension/chemicals'),
+        predicate: schema.identifier,
+      })
+
+      // then
+      const sulphurOxidePairCreated = ASK`
+          ${pollutantMapping} ${prov.hadDictionaryMember} [
+            ${prov.pairKey} "so2" ;
+            ${prov.pairEntity} <http://example.com/dimension/chemicals/sulphur-oxide> ;
+          ] , [
+            ${prov.pairKey} "O3" ;
+            ${prov.pairEntity} <http://example.com/dimension/chemicals/ozone> ;
+          ] .
+        `
+        .FROM(pollutantMapping)
+        .execute(ccClients.parsingClient.query)
+      const ozonePairCreated = ASK`
+          ${pollutantMapping} ${prov.hadDictionaryMember} [
+            ${prov.pairKey} "so2" ;
+            ${prov.pairEntity} <http://example.com/dimension/chemicals/sulphur-oxide> ;
+          ] , [
+            ${prov.pairKey} "O3" ;
+            ${prov.pairEntity} <http://example.com/dimension/chemicals/ozone> ;
+          ] .
+        `
+        .FROM(pollutantMapping)
+        .execute(ccClients.parsingClient.query)
+
+      await expect(sulphurOxidePairCreated).to.eventually.be.true
+      await expect(ozonePairCreated).to.eventually.be.true
+    })
+
+    it('does not create pairs if rdf:predicate does not match', async () => {
+      // when
+      await importMappingsFromSharedDimension({
+        dimensionMapping: pollutantMapping,
+        dimension: $rdf.namedNode('http://example.com/dimension/chemicals'),
+        predicate: dcterms.identifier,
+      })
+
+      // then
+      const pairsCreated = await ASK`
+          ${pollutantMapping} ${prov.hadDictionaryMember} [
+            ${prov.pairKey} ?key ;
+            ${prov.pairEntity} <http://example.com/dimension/chemicals/sulphur-oxide> ;
+          ] .
+
+          FILTER(?key ${IN('"O3"', '"so2"')})
+        `
+        .FROM(pollutantMapping)
+        .execute(ccClients.parsingClient.query)
+
+      expect(pairsCreated).to.be.false
+    })
+
+    it('matches shared terms on string value of literals', async () => {
+      // given
+      const unmappedValuesGraphPatterns = VALUES(
+        { value: '19' },
+      )
+
+      // when
+      await importMappingsFromSharedDimension({
+        dimensionMapping: testMapping,
+        dimension: $rdf.namedNode('http://example.com/dimension/cantons'),
+        predicate: schema.identifier,
+        unmappedValuesGraphPatterns,
+      })
+
+      // then
+      const pairsCreated = await ASK`
+          ${testMapping} ${prov.hadDictionaryMember} [
+            ${prov.pairKey} "19" ;
+            ${prov.pairEntity} <http://example.com/dimension/canton/ZH> ;
+          ] .
+        `
+        .FROM(testMapping)
+        .execute(ccClients.parsingClient.query)
+
+      expect(pairsCreated).to.be.true
     })
   })
 })

--- a/apis/core/test/domain/queries/dimension-mappings.test.ts
+++ b/apis/core/test/domain/queries/dimension-mappings.test.ts
@@ -24,11 +24,12 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
       const unmappedValues = await getUnmappedValues(pollutantMapping, ccClients.parsingClient)
 
       // then
-      expect(unmappedValues).to.have.property('size', 3)
+      expect(unmappedValues).to.have.property('size', 4)
       expect([...unmappedValues]).to.have.deep.members([
         $rdf.literal('so2'),
         $rdf.literal('As'),
         $rdf.literal('Pb'),
+        $rdf.literal('O3'),
       ])
     })
   })

--- a/e2e-tests/dimension-mapping/update.hydra
+++ b/e2e-tests/dimension-mapping/update.hydra
@@ -23,7 +23,6 @@ With Operation schema:ReplaceAction {
 
         <cube-project/ubd/dimension-mapping/pollutant>
             a prov:Dictionary ;
-            cc:applyMappings "false"^^xsd:boolean ;
             cc:sharedDimension <http://example.com/dimension/chemicals> ;
             md:onlyValidTerms true .
         ```
@@ -44,7 +43,6 @@ With Operation schema:ReplaceAction {
 
         <cube-project/ubd/dimension-mapping/pollutant>
             schema:about <https://environment.ld.admin.ch/foen/ubd/28/pollutant> ;
-            cc:applyMappings "false"^^xsd:boolean ;
             cc:sharedDimension <http://example.com/dimension/chemicals> ;
             md:onlyValidTerms true .
         ```
@@ -67,7 +65,6 @@ With Operation schema:ReplaceAction {
         <cube-project/ubd/dimension-mapping/pollutant>
             a prov:Dictionary ;
             schema:about <https://environment.ld.admin.ch/foen/ubd/28/pollutants> ;
-            cc:applyMappings "false"^^xsd:boolean ;
             cc:sharedDimension <http://example.com/dimension/chemicals> ;
             md:onlyValidTerms true .
         ```
@@ -91,7 +88,6 @@ With Operation schema:ReplaceAction {
             a prov:Dictionary ;
             schema:about <https://environment.ld.admin.ch/foen/ubd/28/pollutant> ;
             cc:sharedDimension <http://example.com/dimension/chemicals> ;
-            cc:applyMappings "false"^^xsd:boolean ;
             md:onlyValidTerms true ;
             prov:hadDictionaryMember [
                 a prov:KeyEntityPair ;

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -213,7 +213,7 @@ graph <cube-project/ubd/cube-data> {
     <https://environment.ld.admin.ch/foen/ubd/28/aggregation>     <https://environment.ld.admin.ch/foen/ubd/28/aggregation/annualmean> ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/value> "6.1"^^xsd:decimal ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/year>  "2002"^^xsd:gYear ;
-    <https://environment.ld.admin.ch/foen/ubd/28/pollutant>       "so2" ;
+    <https://environment.ld.admin.ch/foen/ubd/28/pollutant>       "O3" ;
     <https://environment.ld.admin.ch/foen/ubd/28/station>         <https://environment.ld.admin.ch/foen/ubd/28/station/blBAS> ;
     <https://environment.ld.admin.ch/foen/ubd/28/unit>            <http://qudt.org/vocab/unit/MicroGM-PER-M3> ;
   .

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -134,6 +134,7 @@ graph <cube-project/ubd/dimension-mapping/pollutant> {
     a prov:Dictionary, hydra:Resource ;
     schema:about <https://environment.ld.admin.ch/foen/ubd/28/pollutant> ;
     cc:sharedDimension <http://example.com/dimension/chemicals> ;
+    cc:batchMapping <cube-project/ubd/dimension-mapping/pollutant/_batch-mapping> ;
   .
 
   <cube-project/ubd/dimension-mapping/pollutant>
@@ -157,6 +158,7 @@ graph <cube-project/ubd/dimension-mapping/station> {
   <cube-project/ubd/dimension-mapping/station>
     a prov:Dictionary, hydra:Resource ;
     schema:about <https://environment.ld.admin.ch/foen/ubd/28/station> ;
+    cc:batchMapping <cube-project/ubd/dimension-mapping/station/_batch-mapping> ;
   .
 }
 
@@ -166,6 +168,7 @@ graph <cube-project/ubd/dimension-mapping/unit> {
     a prov:Dictionary, hydra:Resource ;
     schema:about <https://environment.ld.admin.ch/foen/ubd/28/unit> ;
     cc:sharedDimension <http://example.com/dimension/units> ;
+    cc:batchMapping <cube-project/ubd/dimension-mapping/unit/_batch-mapping> ;
   .
 
   <cube-project/ubd/dimension-mapping/unit>

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -134,7 +134,7 @@ graph <cube-project/ubd/dimension-mapping/pollutant> {
     a prov:Dictionary, hydra:Resource ;
     schema:about <https://environment.ld.admin.ch/foen/ubd/28/pollutant> ;
     cc:sharedDimension <http://example.com/dimension/chemicals> ;
-    cc:batchMapping <cube-project/ubd/dimension-mapping/pollutant/_batch-mapping> ;
+    cc:batchMapping <cube-project/ubd/dimension-mapping/pollutant/_import-terms> ;
   .
 
   <cube-project/ubd/dimension-mapping/pollutant>
@@ -158,7 +158,7 @@ graph <cube-project/ubd/dimension-mapping/station> {
   <cube-project/ubd/dimension-mapping/station>
     a prov:Dictionary, hydra:Resource ;
     schema:about <https://environment.ld.admin.ch/foen/ubd/28/station> ;
-    cc:batchMapping <cube-project/ubd/dimension-mapping/station/_batch-mapping> ;
+    cc:batchMapping <cube-project/ubd/dimension-mapping/station/_import-terms> ;
   .
 }
 
@@ -168,7 +168,7 @@ graph <cube-project/ubd/dimension-mapping/unit> {
     a prov:Dictionary, hydra:Resource ;
     schema:about <https://environment.ld.admin.ch/foen/ubd/28/unit> ;
     cc:sharedDimension <http://example.com/dimension/units> ;
-    cc:batchMapping <cube-project/ubd/dimension-mapping/unit/_batch-mapping> ;
+    cc:batchMapping <cube-project/ubd/dimension-mapping/unit/_import-terms> ;
   .
 
   <cube-project/ubd/dimension-mapping/unit>

--- a/fuseki/shared-dimensions.trig
+++ b/fuseki/shared-dimensions.trig
@@ -65,6 +65,22 @@ graph <http://example.com/dimension/chemicals> {
     schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
     schema:name "Chemical substances"@en, "Chemikalien"@de, "Substances chimiques"@fr, "Sostanze chimiche"@it ;
   .
+
+  <http://example.com/dimension/chemicals/sulphur-oxide>
+    a schema:DefinedTerm ;
+    schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
+    schema:inDefinedTermSet <http://example.com/dimension/chemicals> ;
+    schema:identifier "so2" ;
+    schema:name "Sulphur oxide"@en ;
+  .
+
+  <http://example.com/dimension/chemicals/ozone>
+    a schema:DefinedTerm ;
+    schema:validFrom "2021-01-20T23:59:59Z"^^xsd:dateTime ;
+    schema:inDefinedTermSet <http://example.com/dimension/chemicals> ;
+    schema:identifier [ schema:value "O3" ] ;
+    schema:name "Ozone"@en ;
+  .
 }
 
 <http://example.com/dimension/countries> void:inDataset <shared-dimensions> .

--- a/fuseki/shared-dimensions.trig
+++ b/fuseki/shared-dimensions.trig
@@ -29,7 +29,7 @@ graph <http://example.com/dimension/cantons> {
 
   <http://example.com/dimension/canton/ZH>
     a schema:DefinedTerm, <http://example.com/vocab#Canton> ;
-    schema:identifier "ZH" ;
+    schema:identifier 19 ;
     schema:containedInPlace <http://example.com/dimension/countries/Switzerland> ;
     gn:parentFeature <http://example.com/dimension/countries/Switzerland> ;
     schema:name "Zurich"@en ;

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -71,7 +71,6 @@ type CubeCreatorProperty =
   'dimensionMapping' |
   'sharedDimension' |
   'sharedDimensions' |
-  'applyMappings' |
   'dimensionType' |
   'CubeProject/sourceCube' |
   'CubeProject/sourceEndpoint' |

--- a/packages/core/namespace.ts
+++ b/packages/core/namespace.ts
@@ -34,7 +34,8 @@ type CubeCreatorClass =
   'ReplaceCSVAction' |
   'MediaLocal' |
   'MediaURL' |
-  'OriginalValuePredicate'
+  'OriginalValuePredicate' |
+  'BatchMappingAction'
 
 type CubeCreatorProperty =
   'projectSourceKind' |
@@ -77,7 +78,8 @@ type CubeCreatorProperty =
   'CubeProject/sourceGraph' |
   'export' |
   'projectDetails' |
-  'validationReport'
+  'validationReport' |
+  'batchMapping'
 
 type OtherTerms =
   'dash' |

--- a/packages/core/namespaces/shapes.ts
+++ b/packages/core/namespaces/shapes.ts
@@ -20,6 +20,7 @@ type ShapeTerms =
   'dimension/metadata#coreGroup' |
   'dimension/metadata#hierarchyGroup' |
   'dimension/shared-mapping' |
+  'dimension/shared-mapping-import' |
   'csv-source/s3Bucket'
 
 type ShapesNamespace = (term: ShapeTerms) => NamedNode

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -134,7 +134,7 @@ export const api = {
     }
   },
 
-  async invokeSaveOperation<T extends RdfResource = RdfResource> (operation: RuntimeOperation | null, resource: RdfResource | GraphPointer<ResourceIdentifier>, headers: HeadersInit = {}): Promise<T> {
+  async invokeSaveOperation<T extends RdfResource = RdfResource> (operation: RuntimeOperation | null | undefined, resource: RdfResource | GraphPointer<ResourceIdentifier>, headers: HeadersInit = {}): Promise<T | null | undefined> {
     const data = 'toJSON' in resource
       ? resource
       : RdfResourceImpl.factory.createEntity(resource) as RdfResource
@@ -152,11 +152,11 @@ export const api = {
     }
 
     const responseResource = response.representation?.root
-    if (!responseResource) {
+    if (response.response.xhr.status === 201 && !responseResource) {
       throw new Error('Response does not contain created resource')
     }
 
-    return responseResource as T
+    return responseResource
   },
 
   async invokeDeleteOperation (operation: RuntimeOperation | null): Promise<void> {

--- a/ui/src/forms/editors/index.ts
+++ b/ui/src/forms/editors/index.ts
@@ -112,6 +112,10 @@ export const autoComplete: Lazy<InstancesSelectEditor> = {
       })
 
       const loadInstance = async () => {
+        if (object?.value.startsWith('urn:')) {
+          return
+        }
+
         const instance = await this.loadInstance({ property: property.shape, value: object })
         if (instance) {
           const objectNode = property.shape.pointer.node(object)

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -23,6 +23,7 @@ import CubeDesigner from '@/views/CubeDesigner.vue'
 import CubeMetadataEdit from '@/views/CubeMetadataEdit.vue'
 import DimensionEdit from '@/views/DimensionEdit.vue'
 import DimensionMapping from '@/views/DimensionMapping.vue'
+import DimensionMappingImport from '@/views/DimensionMappingImport.vue'
 import ResourcePreview from '@/views/ResourcePreview.vue'
 import Materialize from '@/views/Materialize.vue'
 import MaterializeJobs from '@/views/MaterializeJobs.vue'
@@ -154,6 +155,11 @@ const routes: Array<RouteRecordRaw> = [
                 path: 'dimension/:dimensionId/map',
                 name: 'DimensionMapping',
                 component: DimensionMapping,
+              },
+              {
+                path: 'dimension/:dimensionId/map-import',
+                name: 'DimensionMappingImport',
+                component: DimensionMappingImport,
               },
               {
                 path: 'resource/:resourceId',

--- a/ui/src/use-hydra-form.ts
+++ b/ui/src/use-hydra-form.ts
@@ -4,7 +4,8 @@ import type { RdfResource, ResourceIdentifier, RuntimeOperation } from 'alcaeus'
 import clownface, { GraphPointer } from 'clownface'
 import { computed, ref, Ref, shallowRef, ShallowRef, watch } from 'vue'
 import { Term } from 'rdf-js'
-
+import { sh1 } from '@cube-creator/core/namespace'
+import { sh } from '@tpluscode/rdf-ns-builders/strict'
 import { api } from './api'
 import { APIErrorValidation, ErrorDetails } from './api/errors'
 
@@ -26,6 +27,11 @@ export function useHydraForm (operation: Ref<RuntimeOperation | null>, options: 
   const loadShape = async () => {
     if (operation.value) {
       shape.value = await api.fetchOperationShape(operation.value, options.fetchShapeParams)
+      const minCounts = shape.value?.pointer.any()
+        .has(sh1.minCount)
+      minCounts?.forEach(minCount => {
+        minCount.addOut(sh.minCount, minCount.out(sh1.minCount))
+      })
     } else {
       shape.value = null
     }

--- a/ui/src/use-hydra-form.ts
+++ b/ui/src/use-hydra-form.ts
@@ -13,12 +13,12 @@ const initResource = () => clownface({ dataset: $rdf.dataset() }).namedNode('')
 
 interface HydraFormOptions {
   beforeSubmit?: () => Promise<boolean> | boolean
-  afterSubmit?: (savedResource: RdfResource) => any
+  afterSubmit?: (savedResource: RdfResource | null | undefined) => any
   fetchShapeParams?: { targetClass?: Term }
   saveHeaders?: HeadersInit
 }
 
-export function useHydraForm (operation: Ref<RuntimeOperation | null>, options: HydraFormOptions = {}) {
+export function useHydraForm (operation: Ref<RuntimeOperation | null | undefined>, options: HydraFormOptions = {}) {
   const resource: Ref<GraphPointer | null> = ref(initResource())
   const shape: ShallowRef<Shape | null> = shallowRef(null)
   const error: ShallowRef<ErrorDetails | null> = shallowRef(null)

--- a/ui/src/views/DimensionMapping.vue
+++ b/ui/src/views/DimensionMapping.vue
@@ -59,7 +59,7 @@ export default defineComponent({
           variant: 'success',
         })
 
-        router.push({ name: 'DimensionMapping', params: { dimensionId: route.params.dimensionId } })
+        router.push({ name: 'CubeDesigner' })
       },
     })
 

--- a/ui/src/views/DimensionMapping.vue
+++ b/ui/src/views/DimensionMapping.vue
@@ -25,7 +25,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '@/api'
 import SidePane from '@/components/SidePane.vue'
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
-import { serializeResource } from '@/store/serializers'
 import { RootState } from '@/store/types'
 import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
@@ -47,7 +46,7 @@ export default defineComponent({
 
     const operation = computed(() => mappings.value?.actions.replace ?? null)
     const batchMappingOperation = computed(() =>
-      mappings.value?.get(cc.batchMapping).findOperations({
+      mappings.value?.get(cc.batchMapping, { strict: false })?.findOperations({
         bySupportedOperation: cc.BatchMappingAction
       }).shift())
 

--- a/ui/src/views/DimensionMappingImport.vue
+++ b/ui/src/views/DimensionMappingImport.vue
@@ -1,8 +1,5 @@
 <template>
   <side-pane :title="title" @close="onCancel">
-    <o-button v-if="batchMappingOperation" variant="primary" icon-left="magic" @click="importTerms">
-      Auto-fill from Shared Dimension
-    </o-button>
     <hydra-operation-form
       v-if="operation && resource"
       :operation="operation"
@@ -32,7 +29,7 @@ import { displayToast } from '@/use-toast'
 import { cc } from '@cube-creator/core/namespace'
 
 export default defineComponent({
-  name: 'DimensionMappingView',
+  name: 'DimensionMappingImportView',
   components: { SidePane, HydraOperationForm },
 
   setup () {
@@ -45,52 +42,46 @@ export default defineComponent({
 
     const mappings: Ref<RdfResource | null> = ref(null)
 
-    const operation = computed(() => mappings.value?.actions.replace ?? null)
-    const batchMappingOperation = computed(() =>
+    const operation = computed(() =>
       mappings.value?.get(cc.batchMapping).findOperations({
         bySupportedOperation: cc.BatchMappingAction
       }).shift())
 
     const form = useHydraForm(operation, {
       afterSubmit () {
-        store.dispatch('project/fetchDimensionMetadataCollection')
-
         displayToast({
-          message: 'Mapping to shared dimension was saved',
+          message: 'Mappings updated',
           variant: 'success',
         })
 
-        router.push({ name: 'DimensionMapping', params: { dimensionId: route.params.dimensionId } })
+        router.push({
+          name: 'DimensionMapping',
+          params: {
+            dimensionId: router.currentRoute.value.params.dimensionId
+          }
+        })
       },
     })
 
     onMounted(async () => {
       const fetchedMappings = await api.fetchResource(dimension.mappings.value)
       mappings.value = Object.freeze(fetchedMappings)
-
-      form.resource.value = fetchedMappings.pointer
     })
 
     return {
       ...form,
-      mappings,
-      batchMappingOperation
     }
   },
 
   methods: {
     onCancel (): void {
-      this.$router.push({ name: 'CubeDesigner' })
-    },
-
-    importTerms () {
       this.$router.push({
-        name: 'DimensionMappingImport',
+        name: 'DimensionMapping',
         params: {
           dimensionId: this.$router.currentRoute.value.params.dimensionId
         }
       })
-    }
+    },
   },
 })
 </script>

--- a/ui/src/views/DimensionMappingImport.vue
+++ b/ui/src/views/DimensionMappingImport.vue
@@ -22,7 +22,6 @@ import { useRoute, useRouter } from 'vue-router'
 import { api } from '@/api'
 import SidePane from '@/components/SidePane.vue'
 import HydraOperationForm from '@/components/HydraOperationForm.vue'
-import { serializeResource } from '@/store/serializers'
 import { RootState } from '@/store/types'
 import { useHydraForm } from '@/use-hydra-form'
 import { displayToast } from '@/use-toast'
@@ -43,7 +42,7 @@ export default defineComponent({
     const mappings: Ref<RdfResource | null> = ref(null)
 
     const operation = computed(() =>
-      mappings.value?.get(cc.batchMapping).findOperations({
+      mappings.value?.get(cc.batchMapping, { strict: false })?.findOperations({
         bySupportedOperation: cc.BatchMappingAction
       }).shift())
 

--- a/ui/src/views/DimensionMappingImport.vue
+++ b/ui/src/views/DimensionMappingImport.vue
@@ -7,6 +7,7 @@
       :shape="shape"
       :error="error"
       :is-submitting="isSubmitting"
+      show-cancel
       @cancel="onCancel"
       @submit="onSubmit"
     />

--- a/yarn.lock
+++ b/yarn.lock
@@ -8280,6 +8280,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-graph-pointer@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-graph-pointer/-/is-graph-pointer-1.2.0.tgz#6fe360e5e06043fdbc17a73ab4bb88b15f39f9a8"
+  integrity sha512-5lSwDjtQ35xc5PhgnKCUKHa1aMe64Osj2pm3uGnaoUn3Kto8kR1ukrmejTn9Pdlo1CEKWMifIiJv31bEu4K6qg==
+  dependencies:
+    "@types/clownface" "^1.5.0"
+
 is-installed-globally@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"


### PR DESCRIPTION
This brings a two changes:

1. In-browser paging of mapped terms
2. Import feature to populate the mappings from a Shared Dimension

**Live preview**

https://user-images.githubusercontent.com/588128/168161755-31677cef-8534-40b1-baef-6e29c1ea73e3.mp4

**Important notes**

Any new dimension mapped to a shared dimension will be automatically enabled for terms import.

Existing projects must be updated using a SPARQL update

<details>
<summary>

**🔍 Show query**

</summary>

```sparql
PREFIX prov: <http://www.w3.org/ns/prov#>
prefix cc: <https://cube-creator.zazuko.com/vocab#>

INSERT {
  GRAPH ?mappingDictionary {
	?mappingDictionary cc:batchMapping ?importTerms
  }
}
where {
  graph ?mappingDictionary {
    ?mappingDictionary a prov:Dictionary .
  }
  
  filter (
    not exists {
      graph ?mappingDictionary {
        ?mappingDictionary cc:batchMapping []
      }
    }
  )
  
  BIND(IRI(concat(str(?mappingDictionary), "/_import-terms")) as ?importTerms)
}
```

</details>