### PR TITLE
fix: no enormous CONSTRUCT

### DIFF
--- a/.changeset/great-dingos-dress.md
+++ b/.changeset/great-dingos-dress.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Further reduce the Shared Dimension export query (re #1184)

--- a/apis/shared-dimensions/lib/domain/shared-dimension.ts
+++ b/apis/shared-dimensions/lib/domain/shared-dimension.ts
@@ -149,15 +149,15 @@ export async function getExportedDimension({ resource, store, client = streamCli
 
   const dimensionAndTerms = sparql`?term ${schema.inDefinedTermSet}* ${dimension.term} .`
 
-  const quads = await CONSTRUCT`?s ?p ?o`
+  const quads = await CONSTRUCT`?dimensionTerm ?p ?o`
     .FROM(store.graph)
     .WHERE`
       ${resourceShapePatterns(dimensionAndTerms, true)}
 
       ?shape ${sh.property} ?shProp .
       ?shProp ${sh.path} ?p .
-      ?shape ${sh.targetNode} ?s .
-      ?s ?p ?o .
+      ?shape ${sh.targetNode} ?dimensionTerm .
+      ?dimensionTerm ?p ?o .
 
       FILTER (?p NOT ${IN(...excludedProps)})
   `.execute(client.query)


### PR DESCRIPTION
We are still having issues with `413 Payload Too Large` when exporting dimensions with many terms

This is because currently the export happens in two queries. First one find all properties of shared terms from their persisted shapes. The second then does a massive CONSTRUCT with those exact patterns. It quickly grows out of proportion and it simply unnecessary. Here's a sample diff of how this PR changes the export to be executed in only one query

```diff
CONSTRUCT {
  ?s ?p ?o 
}
FROM <https://lindas.admin.ch/cube/dimension>
WHERE {   
  {     
    SELECT ?rootShape  WHERE {   
      ?term schema:inDefinedTermSet* <https://ld.admin.ch/cube/dimension/baqua> .   
      ?rootShape sh:targetNode ?term .    
      MINUS {    
        # Exclude shapes which are children of property shapes   
        ?propertyShape sh:node ?rootShape .  
      }    
    }   
  }
- ?rootShape (!sh:targetNode)* ?s .
+ ?rootShape (!sh:targetNode)* ?shape .

+ ?shape sh:property ?shProp .
+ ?shProp sh:path ?p .
+ ?shape sh:targetNode ?s .
  ?s ?p ?o .
}

-CONSTRUCT {
- <https://ld.admin.ch/cube/dimension/baqua/ag>
-       a md:SharedDimensionTerm , schema:DefinedTerm , hydra:Resource ;
-       schema:hasPart <https://ld.admin.ch/dimension/bgdi/inlandwaters/bathingwater/CH19006> .
-
- # and all else explicit
-}
-FROM <https://lindas.admin.ch/cube/dimension>
-WHERE {
- <https://ld.admin.ch/cube/dimension/baqua/ag>
-       a md:SharedDimensionTerm , schema:DefinedTerm , hydra:Resource ;
-       schema:hasPart <https://ld.admin.ch/dimension/bgdi/inlandwaters/bathingwater/CH19006> .
-
- # and all else explicit
-}
```

Rather than building all the resource patterns in the second `CONSTRUCT`, they are simply rebuilt from the `sh:property/sh:path` of the shapes inline in one query