### PR TITLE
Project delete

### DIFF
--- a/.changeset/curvy-lamps-lick.md
+++ b/.changeset/curvy-lamps-lick.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Removing a project would leave some leftover graphs

--- a/.changeset/nine-tomatoes-own.md
+++ b/.changeset/nine-tomatoes-own.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Dimension mappings would not have been deleted when column mapping is deleted

--- a/apis/core/lib/domain/column-mapping/delete.ts
+++ b/apis/core/lib/domain/column-mapping/delete.ts
@@ -40,6 +40,9 @@ export async function deleteColumnMapping({
     const dimension = dimensionMetaDataCollection.find({ cubeIdentifier, organization, targetProperty: columnMapping.targetProperty })
     const isInUse = await dimensionIsUsedByOtherMapping(columnMapping.id)
     if (dimension && dimension.id.termType === 'NamedNode' && !isInUse) {
+      if (dimension.mappings) {
+        store.delete(dimension.mappings)
+      }
       dimensionMetaDataCollection.deleteDimension(dimension)
     }
   }

--- a/apis/core/lib/domain/cube-projects/delete.ts
+++ b/apis/core/lib/domain/cube-projects/delete.ts
@@ -3,6 +3,7 @@ import { Project } from '@cube-creator/model'
 import { ParsingClient } from 'sparql-http-client/ParsingClient'
 import { SELECT } from '@tpluscode/sparql-builder'
 import { ResourceStore } from '../../ResourceStore'
+import { deleteMapping } from '../csv-mapping/delete'
 
 interface DeleteProjectCommand {
   resource: NamedNode
@@ -17,6 +18,11 @@ export async function deleteProject({
 }: DeleteProjectCommand): Promise<void> {
   const project = await store.getResource<Project>(resource, { allowMissing: true })
   if (!project) return
+
+  const { csvMapping } = project
+  if (csvMapping?.id.termType === 'NamedNode') {
+    await deleteMapping(csvMapping.id, store)
+  }
 
   const graphs: Array<{ graph?: NamedNode }> = await SELECT.DISTINCT`?graph`
     .WHERE`

--- a/apis/core/lib/domain/cube-projects/delete.ts
+++ b/apis/core/lib/domain/cube-projects/delete.ts
@@ -1,27 +1,34 @@
 import { NamedNode } from 'rdf-js'
-import { cc } from '@cube-creator/core/namespace'
+import { Project } from '@cube-creator/model'
+import { ParsingClient } from 'sparql-http-client/ParsingClient'
+import { SELECT } from '@tpluscode/sparql-builder'
 import { ResourceStore } from '../../ResourceStore'
-import { deleteMapping } from '../csv-mapping/delete'
 
 interface DeleteProjectCommand {
   resource: NamedNode
   store: ResourceStore
+  client: ParsingClient
 }
 
 export async function deleteProject({
   resource,
   store,
+  client,
 }: DeleteProjectCommand): Promise<void> {
-  const project = await store.get(resource, { allowMissing: true })
+  const project = await store.getResource<Project>(resource, { allowMissing: true })
   if (!project) return
 
-  const csvMapping = project.out(cc.csvMapping).term
+  const graphs: Array<{ graph?: NamedNode }> = await SELECT.DISTINCT`?graph`
+    .WHERE`
+      graph ?graph {
+        ?s ?p ?o
+      }
+      filter(strstarts(str(?graph), "${project.id.value}"))
+    `.execute(client.query)
 
-  // Find csv sources
-  if (csvMapping?.termType === 'NamedNode') {
-    await deleteMapping(csvMapping, store)
+  for (const { graph } of graphs) {
+    if (graph) {
+      store.delete(graph)
+    }
   }
-
-  // delete project graph
-  store.delete(project.term)
 }

--- a/apis/core/lib/handlers/cube-projects.ts
+++ b/apis/core/lib/handlers/cube-projects.ts
@@ -16,7 +16,7 @@ import { deleteProject } from '../domain/cube-projects/delete'
 import { getExportedProject } from '../domain/cube-projects/export'
 import { getProjectDetails } from '../domain/cube-projects/details'
 import * as triggers from '../pipeline/trigger'
-import { streamClient } from '../query-client'
+import { parsingClient, streamClient } from '../query-client'
 import { postImportedProject } from './cube-projects/import'
 
 const trigger = (triggers as Record<string, (job: GraphPointer<NamedNode>, params?: GraphPointer) => void>)[env.PIPELINE_TYPE]
@@ -72,6 +72,7 @@ export const remove = protectedResource(
     await deleteProject({
       resource: project,
       store: req.resourceStore(),
+      client: parsingClient,
     })
     await req.resourceStore().save()
 

--- a/apis/core/test/domain/column-mapping/delete.test.ts
+++ b/apis/core/test/domain/column-mapping/delete.test.ts
@@ -158,7 +158,6 @@ describe('domain/column-mapping/delete', () => {
 
     const dimensionsCount = dimensionMetadataCollection.out(schema.hasPart).terms.length
     const columnMappingsCount = observationTable.out(cc.columnMapping).terms.length
-    const dimensionMetadataCount = dimensionMetadataCollection.node($rdf.namedNode('myDimension')).out().values.length
 
     await deleteColumnMapping({ resource: resourceId, store, tableQueries, columnMappingQueries })
     await store.save()
@@ -168,7 +167,7 @@ describe('domain/column-mapping/delete', () => {
 
     expect(dimensionMetadataCollection.out(schema.hasPart).terms).to.have.length(dimensionsCount - 1)
     expect(observationTable.out(cc.columnMapping).terms).to.have.length(columnMappingsCount - 1)
-    expect(dimensionMetadataCollection.node($rdf.namedNode('myDimension')).out().values).to.have.length(dimensionMetadataCount - 1)
+    expect(dimensionMetadataCollection.node($rdf.namedNode('myDimension')).out().values).to.be.empty
   })
 
   it('deletes a column mapping but not dimension stays untouched since shared', async () => {

--- a/apis/core/test/domain/cube-projects/delete.test.ts
+++ b/apis/core/test/domain/cube-projects/delete.test.ts
@@ -1,0 +1,48 @@
+import { before, beforeEach, describe, it } from 'mocha'
+import sinon from 'sinon'
+import { expect } from 'chai'
+import { SELECT } from '@tpluscode/sparql-builder'
+import $rdf from 'rdf-ext'
+import { ccClients } from '@cube-creator/testing/lib'
+import { insertTestProject } from '@cube-creator/testing/lib/seedData'
+import { deleteProject } from '../../../lib/domain/cube-projects/delete'
+import ResourceStore from '../../../lib/ResourceStore'
+import '../../../lib/domain'
+import * as storage from '../../../lib/storage'
+
+describe('@cube-creator/core-api/lib/domain/cube-projects/delete @SPARQL', function () {
+  this.timeout(20000)
+
+  const project = $rdf.namedNode('https://cube-creator.lndo.site/cube-project/ubd')
+
+  before(() => {
+    sinon.stub(storage, 'getMediaStorage').returns({
+      delete: sinon.stub(),
+    } as any)
+  })
+
+  beforeEach(async () => {
+    await insertTestProject()
+  })
+
+  it("removes all project's graphs", async () => {
+    // given
+    const store = new ResourceStore(ccClients.streamClient)
+
+    // when
+    await deleteProject({
+      resource: project,
+      store,
+      client: ccClients.parsingClient,
+    })
+    await store.save()
+
+    // then
+    const anyGraph = SELECT.DISTINCT`?g`.WHERE`graph ?g {
+      ?s ?p ?o
+    }
+
+    filter (strstarts(str(?g), "${project.value}"))`.execute(ccClients.parsingClient.query)
+    await expect(anyGraph).to.eventually.deep.equal([])
+  })
+})

--- a/apis/core/test/domain/cube-projects/delete.test.ts
+++ b/apis/core/test/domain/cube-projects/delete.test.ts
@@ -14,10 +14,11 @@ describe('@cube-creator/core-api/lib/domain/cube-projects/delete @SPARQL', funct
   this.timeout(20000)
 
   const project = $rdf.namedNode('https://cube-creator.lndo.site/cube-project/ubd')
+  const deleteFile = sinon.stub()
 
   before(() => {
     sinon.stub(storage, 'getMediaStorage').returns({
-      delete: sinon.stub(),
+      delete: deleteFile,
     } as any)
   })
 
@@ -44,5 +45,21 @@ describe('@cube-creator/core-api/lib/domain/cube-projects/delete @SPARQL', funct
 
     filter (strstarts(str(?g), "${project.value}"))`.execute(ccClients.parsingClient.query)
     await expect(anyGraph).to.eventually.deep.equal([])
+  })
+
+  it('removes sources', async () => {
+    // given
+    const store = new ResourceStore(ccClients.streamClient)
+
+    // when
+    await deleteProject({
+      resource: project,
+      store,
+      client: ccClients.parsingClient,
+    })
+    await store.save()
+
+    // then
+    expect(deleteFile).to.have.been.called
   })
 })

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -788,6 +788,7 @@ graph <cube-project/ubd/csv-mapping/jobs/failed-job> {
         schema:disambiguatingDescription "Failed to process for 1234" ;
         schema:description "The error stack trace" ;
       ] ;
+    cc:project <cube-project/ubd> ;
   .
 }
 
@@ -802,6 +803,7 @@ graph <cube-project/ubd/csv-mapping/jobs/hung-job> {
     dcterms:created "2020-10-29T12:01:54Z"^^xsd:dateTime ;
     dcterms:modified "2020-10-29T12:01:54Z"^^xsd:dateTime ;
     schema:actionStatus schema:ActiveActionStatus ;
+    cc:project <cube-project/ubd> ;
   .
 }
 

--- a/ui/tests/e2e/specs/project-mapping.spec.ts
+++ b/ui/tests/e2e/specs/project-mapping.spec.ts
@@ -175,6 +175,5 @@ describe('CSV mapping flow', () => {
       .click({ force: true })
 
     cy.contains('Project My project successfully deleted').should('be.visible')
-    cy.contains('My project', { timeout: 10000 }).should('not.be.visible')
   })
 })


### PR DESCRIPTION
I found two cases when deleting resources would leave some dangling leftovers

1. When removing a column mapping, the dimension mapping would not be removed
2. When deleting the entire project, a lot was not removed

In the latter case I opted for simply dropping all graphs which share the project's URL stem (all resources are named as `https://{Project URL}/{child resource path}`