### PR TITLE
fix: shared dimension API Documentation resource

### DIFF
--- a/.changeset/shaggy-pants-hunt.md
+++ b/.changeset/shaggy-pants-hunt.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Updated alcaeus

--- a/.changeset/spotty-panthers-train.md
+++ b/.changeset/spotty-panthers-train.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/shared-dimensions-api": patch
+---
+
+Problems with forms in Shared Dimensions (fixes #1233)

--- a/apis/shared-dimensions/hydra/index.ttl
+++ b/apis/shared-dimensions/hydra/index.ttl
@@ -10,9 +10,19 @@ BASE <urn:hydra-box:api>
 @prefix query: <http://hypermedia.app/query#> .
 @prefix hex: <https://w3id.org/hydra/extension#> .
 
-<api>
+<dimension/api>
   a hydra:ApiDocumentation ;
   hydra:entrypoint <dimension/> ;
+  hydra:supportedClass
+    hydra:Resource ,
+    md:SharedDimensions ,
+    md:Hierarchies ,
+    sh:NodeShape ,
+    md:SharedDimensionExport ,
+    md:SharedDimensionTerms ,
+    md:SharedDimension ,
+    md:Hierarchy ,
+    md:SharedDimensionTerm
 .
 
 hydra:Resource

--- a/apis/shared-dimensions/index.ts
+++ b/apis/shared-dimensions/index.ts
@@ -22,6 +22,7 @@ export async function sharedDimensions(): Promise<Router> {
       rewriteHeaders: true,
     }))
     .use(await hydraBox({
+      term: $rdf.namedNode(`${env.MANAGED_DIMENSIONS_API_BASE}dimension/api`),
       apiPath,
       codePath,
       baseUri: env.MANAGED_DIMENSIONS_API_BASE,

--- a/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
+++ b/apis/shared-dimensions/lib/middleware/canonicalRewrite.ts
@@ -7,7 +7,7 @@ import { oa } from '@tpluscode/rdf-ns-builders'
 import $rdf from 'rdf-ext'
 import env from '../env'
 
-export function rewriteTerm<T extends Term>(term: T): T {
+function rewriteTerm<T extends Term>(term: T): T {
   if (term.termType === 'NamedNode') {
     return $rdf.namedNode(term.value.replace(env.MANAGED_DIMENSIONS_BASE, env.MANAGED_DIMENSIONS_API_BASE)) as any
   }

--- a/apis/shared-dimensions/package.json
+++ b/apis/shared-dimensions/package.json
@@ -6,7 +6,7 @@
     "@cube-creator/api-errors": "0.0.5",
     "@cube-creator/core": "0.3.4",
     "@cube-creator/express": "0.0.0",
-    "@hydrofoil/labyrinth": "^0.4.1",
+    "@hydrofoil/labyrinth": "^0.4.2",
     "@rdfine/hydra": "^0.8.2",
     "@rdfine/rdfs": "^0.6.4",
     "@rdfine/schema": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,10 +1431,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@hydrofoil/labyrinth@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@hydrofoil/labyrinth/-/labyrinth-0.4.1.tgz#405dce31a12d7d8bb16818eebd4ea1183c4dad35"
-  integrity sha512-TO9I3U+lQ8MHTCSRty6IP5Sy71ybxunMuL9N/PysmTcACOPHciAbsG0/Xpdmr+tqTyJqhcB9cvMsO1rHfBRy0g==
+"@hydrofoil/labyrinth@^0.4.1", "@hydrofoil/labyrinth@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@hydrofoil/labyrinth/-/labyrinth-0.4.2.tgz#5fe4ea9bab31fccd51f84082eee3baaef166da0b"
+  integrity sha512-tUIp30bcuoyXXAo7NgecExAomNe+ADy4E3c+gGX6J4q276nLMEh960HBStx3kRlxFq5dIl5edvclFE4tTARcHQ==
   dependencies:
     "@fcostarodrigo/walk" "^5.0.0"
     "@rdfine/hydra" "^0.6"
@@ -2917,10 +2917,10 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/parse-link-header@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/parse-link-header/-/parse-link-header-1.0.1.tgz#6eade790736a050b9242c7c6b2fceda9b3dc394a"
-  integrity sha512-E2+Go9rQgPbmpkeA2iFXTWSTxX38KXlXwcdiIbt71Oorqr+G5QtH4AhpuDdxwRVyiTzdUrHnaaIumW/LhiZwVg==
+"@types/parse-link-header@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-link-header/-/parse-link-header-2.0.0.tgz#a94d86ac2d13e3cdef4429c977217084e32378e7"
+  integrity sha512-KbqcQLdRaawDOfXnwqr6nvhe1MV+Uv/Ww+ViSx7Ujgw9X5qCgObLP52B1ZSJqZD8FK1y/4o+bJQTUrZOynegcg==
 
 "@types/parse-prefer-header@^1.0.0", "@types/parse-prefer-header@^1.0.1":
   version "1.0.1"
@@ -4218,10 +4218,10 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-alcaeus@^2, alcaeus@^2.1, alcaeus@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/alcaeus/-/alcaeus-2.2.1.tgz#c23b69355fd399ca0f2339ec9a5db64cf0a71bcf"
-  integrity sha512-41mYgOKy943xyurR5Ux08QB7n+aWrBTlcaMM0VYhMjLFbnV9Prr0eFscJbmG8EkxkQDzdB4Fvkck6dD0tu+TQA==
+alcaeus@^2, alcaeus@^2.2.0, alcaeus@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/alcaeus/-/alcaeus-2.2.2.tgz#66aae95a4db032ee6c92044d07b41415303aaa76"
+  integrity sha512-XoGn4gdK8t0Ew3Ywvc6+w5LUtc0imGvVd5j+ZB7fbNzzbXOwujt9SmyVMwtfdHTljmvhZBZoaiYZz/WN9senjw==
   dependencies:
     "@rdf-esm/data-model" "^0.5.3"
     "@rdf-esm/formats-common" "^0.5.6"
@@ -4235,7 +4235,7 @@ alcaeus@^2, alcaeus@^2.1, alcaeus@^2.2.0:
     "@rdfjs/types" "*"
     "@tpluscode/rdf-ns-builders" "^1.0.0"
     "@tpluscode/rdfine" "^0.5.29"
-    "@types/parse-link-header" "^1.0.0"
+    "@types/parse-link-header" "^2.0.0"
     clownface "^1.1.0"
     isomorphic-fetch "^3.0.0"
     isomorphic-form-data "^2.0.0"


### PR DESCRIPTION
hydra-box by default create the ApiDocumentation term using request context. Because we use `camouflage-rewrite`, that would have been a bogus `https://ld.admin.ch/dimension/api`. 

This would have caused issues when the front end failed to find the right hypermedia descriptions to generate forms