### PR TITLE
fix: job timeout ignored jobs without `dcterms:modified`

### DIFF
--- a/.changeset/big-jars-sneeze.md
+++ b/.changeset/big-jars-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/cli": patch
+---
+
+Timeout pipeline skipped jobs which never actually started (or were never marked as such). This caused dangling jobs with blinking status

--- a/cli/lib/commands/timeoutJobs.ts
+++ b/cli/lib/commands/timeoutJobs.ts
@@ -39,7 +39,7 @@ export async function timeoutJobs({
       graph ?job {
         ?job a ${cc.Job} .
         ?job ${schema.actionStatus} ?status .
-        ?job ${dcterms.modified} ?modified .
+        ?job ${dcterms.modified}|${dcterms.created} ?modified .
 
         filter ( ?status ${IN(schema.ActiveActionStatus, schema.PotentialActionStatus)} )
         filter (


### PR DESCRIPTION
While investigating #1218 I found that there are still numerous jobs "blinking"

That was because the query checked only for `dcterms:modified` which is set one job starts and the status gets updated. A new job, which never got the first update would not match.