### PR TITLE
fix: errors should be cleared

### DIFF
--- a/.changeset/four-jokes-sin.md
+++ b/.changeset/four-jokes-sin.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Cube errors were not cleared as expected after transformation (fixes #1290)


### PR DESCRIPTION
**Background**

In cube creator, we attach a `schema:error` to cubes when problems are identified with the data, etc. They should be removed after transformation when these problems no longer occur.

**Problem**

The 2 warnings in the issue report were not properly removed because the query in the form `DELETE/INSERT/WHERE` prevented that from happening. The `WHERE` clause did not match the issue condition and thus the `DELETE` was not performed.

**Solution**

Instead of a single update, I separated them to make two

```sparql
# delete old error if exists
DELETE {} WHERE {}

# add again if necessary
INSERT {} WHERE {}
```

This way, the delete is always done and if the `INSERT` find nothing, then an existing error is gone for good. It also made it possible to remove an `OPTIONAL`, now unnecessary