### PR TITLE
fix: no blank cube warnings

### DIFF
--- a/.changeset/large-phones-grow.md
+++ b/.changeset/large-phones-grow.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Prevent cube warnings without any text from appearing

--- a/apis/core/lib/domain/errors/deleteCurrent.ts
+++ b/apis/core/lib/domain/errors/deleteCurrent.ts
@@ -1,0 +1,21 @@
+import { Term } from 'rdf-js'
+import { DELETE } from '@tpluscode/sparql-builder'
+import { cc } from '@cube-creator/core/namespace'
+import { schema } from '@tpluscode/rdf-ns-builders/strict'
+
+export function deleteCurrentError(error: string, dimensionMetadataId: Term) {
+  return DELETE`
+    graph ?dataset {
+      ?dataset ${schema.error} ?currentError .
+      ?s ?p ?o
+    }
+  `.WHERE`
+    graph ?dataset {
+      ?dataset ${cc.dimensionMetadata} ${dimensionMetadataId} .
+      BIND(IRI(CONCAT(STR(?dataset), "#${error}")) as ?currentError)
+
+      ?currentError (<>|!<>)* ?s .
+      OPTIONAL { ?s ?p ?o }
+    }
+  `
+}

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -28,7 +28,7 @@
     "@tpluscode/rdf-ns-builders": "^1.0.0",
     "@tpluscode/rdf-string": "^0.2.23",
     "@tpluscode/rdfine": "^0.5.23",
-    "@tpluscode/sparql-builder": "^0.3.17",
+    "@tpluscode/sparql-builder": "^0.3.24",
     "@uppy/companion": "^3.5.0",
     "@zazuko/rdf-vocabularies": "^2021.3.17",
     "aws-sdk": "^2.1048.0",

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -65,7 +65,11 @@ graph <cube-project/ubd/dataset> {
     schema:workExample <https://ld.admin.ch/application/visualize> ;
     schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Draft> ;
     dcterms:creator <http://example.com/organization-id> ;
+    schema:error <cube-project/ubd/dataset#missing-values-error> ;
+    schema:error <cube-project/ubd/dataset#non-unique-observations> ;
   .
+
+  <cube-project/ubd/dataset#missing-values-error> schema:description "Test message" .
 
   <https://environment.ld.admin.ch/foen/ubd/28>
     a cube:Cube ;

--- a/packages/model/Dataset.ts
+++ b/packages/model/Dataset.ts
@@ -19,8 +19,8 @@ export interface Dataset extends RdfResource {
 }
 
 export const Error = {
-  MissingObservationValues: 'MissingObservationValues',
-  MultipleDimensionValues: 'MultipleDimensionValues',
+  MissingObservationValues: 'missing-values-error',
+  MultipleDimensionValues: 'non-unique-observations',
 } as const
 
 export function DatasetMixin<Base extends Constructor>(Resource: Base): Mixin {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2476,10 +2476,10 @@
     clownface "^1"
     once "^1.4.0"
 
-"@tpluscode/sparql-builder@^0.3.15", "@tpluscode/sparql-builder@^0.3.17", "@tpluscode/sparql-builder@^0.3.19", "@tpluscode/sparql-builder@^0.3.21", "@tpluscode/sparql-builder@^0.3.23":
-  version "0.3.23"
-  resolved "https://registry.yarnpkg.com/@tpluscode/sparql-builder/-/sparql-builder-0.3.23.tgz#a1c0a2dd0f3d42c04742f417a56f2837435e9561"
-  integrity sha512-qJYMAn5MNUcna+8fwloZTVbI7BZ1KjPLhuGluddC0GvcKo3VDqFFD3AwNCKsKdw9MHu5j2kiUufcZJpejOyBRw==
+"@tpluscode/sparql-builder@^0.3.15", "@tpluscode/sparql-builder@^0.3.19", "@tpluscode/sparql-builder@^0.3.21", "@tpluscode/sparql-builder@^0.3.23", "@tpluscode/sparql-builder@^0.3.24":
+  version "0.3.24"
+  resolved "https://registry.yarnpkg.com/@tpluscode/sparql-builder/-/sparql-builder-0.3.24.tgz#8fccd8f1323597ca3ad11b7a86c469529ed774f6"
+  integrity sha512-5DjQafLbdAOn3BwHv6eianSfO8jV54IJDy8usY6rO8Rz81e+BkpdUcqzx9gHoghISVgffgq2hwSLL44Fa/PG+Q==
   dependencies:
     "@rdf-esm/data-model" "^0.5.4"
     "@rdf-esm/term-set" "^0.5.0"


### PR DESCRIPTION
I noticed one more small issue, that instead of removing an error completely when it no longer applies to a given cube, empty yellow rows remain in the cube designer.

<img width="905" alt="image" src="https://user-images.githubusercontent.com/588128/195330329-ac503714-92ce-40e8-aa52-9ef384daf71b.png">

That is because the SPARQL removed the error details but not the error node itself. 

```turtle
<dataset>
  schema:error <dataset#error-id> .

# This was removed but the above was not
<dataset#error-id>
  schema:description "Displayed on UI" .
```

This PR makes sure that the errors are properly cleaned
