### PR TITLE
fix: visualize link dataset as query string

### DIFF
--- a/.changeset/twenty-carrots-behave.md
+++ b/.changeset/twenty-carrots-behave.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Use updated scheme for Visualize links (re #1335)

--- a/apis/core/lib/domain/job/create.ts
+++ b/apis/core/lib/domain/job/create.ts
@@ -167,9 +167,8 @@ function lindasWebQueryLink(cube: NamedNode, version: number, cubeGraph: NamedNo
 }
 
 function visualizeLink(cube: NamedNode) {
-  const language = 'en'
-  const visualizeLink = new URL(`/${language}/browse/dataset/${encodeURIComponent(cube.value)}`, env.VISUALIZE_UI)
-
+  const visualizeLink = new URL(env.VISUALIZE_UI)
+  visualizeLink.searchParams.set('dataset', cube.value)
   return visualizeLink.toString()
 }
 


### PR DESCRIPTION
Related: https://gitlab.ldbar.ch/vshn/gitops-main/-/merge_requests/86