### PR TITLE
feat: add agroscope as publisher

### DIFF
--- a/.changeset/seven-islands-battle.md
+++ b/.changeset/seven-islands-battle.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": minor
+---
+
+Added Agroscope publishing profile

--- a/apis/core/bootstrap/organizations.ts
+++ b/apis/core/bootstrap/organizations.ts
@@ -75,4 +75,20 @@ export const organizations = turtle`
     ${cube.observedBy} <https://ld.admin.ch/FCh> ;
   .
 }
+
+<organization/agroscope> {
+  <organization/agroscope>
+    a ${schema.Organization} ;
+    ${cc.publishGraph}  <https://lindas.admin.ch/agroscope/cube> ;
+    ${cc.namespace} <https://agriculture.ld.admin.ch/agroscope/> ;
+    ${schema.dataset} <https://agriculture.ld.admin.ch/.well-known/void> ;
+    ${rdfs.label} "Agroscope"@en ;
+    ${rdfs.label} "Agroscope"@de ;
+    ${rdfs.label} "Agroscope"@it ;
+    ${rdfs.label} "Agroscope"@fr ;
+    ${dcat.accessURL} <https://agriculture.ld.admin.ch/sparql> ;
+    ${_void.sparqlEndpoint} <https://agriculture.ld.admin.ch/query> ;
+    ${cube.observedBy} <https://register.ld.admin.ch/opendataswiss/org/agroscope> ;
+  .
+}
 `

--- a/apis/core/bootstrap/organizations.ts
+++ b/apis/core/bootstrap/organizations.ts
@@ -88,7 +88,7 @@ export const organizations = turtle`
     ${rdfs.label} "Agroscope"@fr ;
     ${dcat.accessURL} <https://agriculture.ld.admin.ch/sparql> ;
     ${_void.sparqlEndpoint} <https://agriculture.ld.admin.ch/query> ;
-    ${cube.observedBy} <https://register.ld.admin.ch/opendataswiss/org/agroscope> ;
+    ${cube.observedBy} <https://register.ld.admin.ch/staatskalender/organization/10003634> ;
   .
 }
 `


### PR DESCRIPTION
Voilà. 
As the link https://register.ld.admin.ch/opendataswiss/org/agroscope showed something, I used that one instead of the staatskalender...