### PR TITLE
refactor: graph store post new dimension mappings

### DIFF
--- a/.changeset/gorgeous-pens-deliver.md
+++ b/.changeset/gorgeous-pens-deliver.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Improve insert performance of new dimension mappings (re #1398)

--- a/apis/core/lib/domain/queries/dimension-mappings.ts
+++ b/apis/core/lib/domain/queries/dimension-mappings.ts
@@ -99,19 +99,13 @@ interface ImportMappingsFromSharedDimension {
    * By default, a function will query the database to find unmapped cube values.
    * Override this in automatic tests to with static values
    */
-  unmappedValuesSource?: Literal[]
+  unmappedValuesOverride?: Literal[]
 }
 
-export async function importMappingsFromSharedDimension({
-  dimensionMapping,
-  dimension,
-  predicate,
-  unmappedValuesSource,
-  validThrough,
-}: ImportMappingsFromSharedDimension, client = streamClient) {
-  let unmappedValues: Parameters<(typeof Readable)['from']>[0]
-  if (unmappedValuesSource != null) {
-    unmappedValues = unmappedValuesSource.map(value => ({ value }))
+export async function importMappingsFromSharedDimension({ dimensionMapping, dimension, predicate, unmappedValuesOverride, validThrough }: ImportMappingsFromSharedDimension, client = streamClient) {
+  let unmappedValues: AsyncIterable<{ value: Literal }> | Iterable<{ value: Literal }>
+  if (unmappedValuesOverride != null) {
+    unmappedValues = unmappedValuesOverride.map(value => ({ value }))
   } else {
     const cubeGraph = await findCubeGraph(dimensionMapping, client)
     unmappedValues = await unmappedValuesFromQuery(cubeGraph, dimensionMapping).execute(client.query)

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -45,6 +45,7 @@
     "express-jwt": "^8.3.0",
     "express-jwt-permissions": "^1.3.7",
     "express-rdf-request": "0.1.0",
+    "get-stream": "^6.0.1",
     "http-errors": "^2.0.0",
     "hydra-box": "^0.6.6",
     "hydra-box-middleware-shacl": "1.1.0",

--- a/apis/core/test/domain/queries/dimension-mappings.test.ts
+++ b/apis/core/test/domain/queries/dimension-mappings.test.ts
@@ -102,7 +102,7 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
 
     it('matches shared terms on string value of literals', async () => {
       // given
-      const unmappedValuesSource = [
+      const unmappedValuesOverride = [
         $rdf.literal('19'),
       ]
 
@@ -111,7 +111,7 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
         dimensionMapping: testMapping,
         dimension: $rdf.namedNode('http://example.com/dimension/cantons'),
         predicate: schema.identifier,
-        unmappedValuesSource,
+        unmappedValuesOverride,
       })
 
       // then
@@ -129,7 +129,7 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
 
     it('matches shared terms on typed literals', async () => {
       // given
-      const unmappedValuesSource = [
+      const unmappedValuesOverride = [
         $rdf.literal('19', xsd.integer),
       ]
 
@@ -138,7 +138,7 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
         dimensionMapping: testMapping,
         dimension: $rdf.namedNode('http://example.com/dimension/cantons'),
         predicate: schema.identifier,
-        unmappedValuesSource,
+        unmappedValuesOverride,
       })
 
       // then
@@ -156,7 +156,7 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
 
     it('matches only valid terms if required', async () => {
       // given
-      const unmappedValuesSource = [
+      const unmappedValuesOverride = [
         $rdf.literal('#00F'),
         $rdf.literal('#F00'),
       ]
@@ -166,7 +166,7 @@ describe('@cube-creator/core-api/lib/domain/queries/dimension-mappings @SPARQL',
         dimensionMapping: testMapping,
         dimension: $rdf.namedNode('http://example.com/dimension/colors'),
         predicate: schema.identifier,
-        unmappedValuesSource,
+        unmappedValuesOverride,
         validThrough: new Date(2021, 5, 20),
       })
 


### PR DESCRIPTION
This changes how new dimension mappings are saved to the database when "auto-mapping"

The current implementation performed an `INSERT` with a complex pattern and a long list `VALUES` clause. Potentially thousands of items long.

Since the full set of these `VALUES` is loaded to memory anyway, they are actually cross-referenced in memory and new items are streamed directly as quads using the graph protocol. This appears much more database-friendly. While Stardog does cope, local fuseki actually failed to insert when mapping a large dimension of municipalities (3k terms)