### PR TITLE
fix: clean up dimension mapping graphs

### DIFF
--- a/.changeset/tiny-carrots-chew.md
+++ b/.changeset/tiny-carrots-chew.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+When dimension mappings were removed, `<> a prov:Entity` were not cleaned up (fixes #1314)

--- a/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
+++ b/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
@@ -65,6 +65,11 @@ export function ProvDictionaryMixinEx<Base extends Constructor<Dictionary>>(Reso
         newEntryMap.delete(entry.pairKey)
       }
 
+      this.pointer.any()
+        .has(rdf.type, prov.Entity)
+        .filter(entity => entity.in().values.length === 0)
+        .forEach(entity => entity.deleteOut())
+
       // Insert new entries
       this.hadDictionaryMember = [
         ...this.hadDictionaryMember,

--- a/apis/core/test/domain/dimension-mapping/update.test.ts
+++ b/apis/core/test/domain/dimension-mapping/update.test.ts
@@ -45,6 +45,10 @@ describe('domain/dimension-mapping/update', () => {
         member
           .addOut(prov.pairKey, 'so2')
       })
+    dimensionMapping.node(wikidata.carbonMonoxide)
+      .addOut(rdf.type, prov.Entity)
+    dimensionMapping.node(wikidata.sulphurDioxide)
+      .addOut(rdf.type, prov.Entity)
 
     store = new TestResourceStore([
       dimensionMapping,
@@ -321,6 +325,14 @@ describe('domain/dimension-mapping/update', () => {
         },
       })
     })
+
+    it('removes rdf:type prov:Entity triples of removed pairs', () => {
+      expect(dimensionMapping.node(wikidata.carbonMonoxide).out().terms).to.be.empty
+    })
+
+    it('removes all superfluous rdf:type prov:Entity triples', () => {
+      expect(dimensionMapping.node(wikidata.sulphurDioxide).out().terms).to.be.empty
+    })
   })
 
   describe('updating with "applyMapping" flag set to false', () => {
@@ -386,6 +398,10 @@ describe('domain/dimension-mapping/update', () => {
         },
       })
       expect(dimensionMapping.any().has([prov.pairKey, prov.pairEntity]).terms).to.have.length(2)
+    })
+
+    it('keeps rdf:type prov:Entity triples of remaining pairs', () => {
+      expect(dimensionMapping.node(wikidata.carbonMonoxide).out(rdf.type).term).to.deep.eq(prov.Entity)
     })
   })
 


### PR DESCRIPTION
Dimension mappings are stored as instances of `prov:KeyEntityPair` similar to 

```turtle
[
  rdf:type prov:KeyEntityPair ;
  prov:pairKey "164" ;
  prov:pairEntity <https://ld.admin.ch/dimension/term> ;
] .

<https://ld.admin.ch/dimension/term> a prov:Entity .
```

When such a pair was removed, the `a prov:Entity` triple was left over. It does not have any side effects but is clutter nonetheless. This PR ensures that they will be removed when a dimension mapping is saved.

Additioanally the query below can be used to clean up any dangling triples from mapping graphs.

```sparql
PREFIX prov: <http://www.w3.org/ns/prov#>
PREFIX csvw: <http://www.w3.org/ns/csvw#>
PREFIX cube: <https://cube.link/>

DELETE {
    graph ?mapping {
        ?entity a prov:Entity .
    }
}
where {
    graph ?mapping {
        ?mapping a prov:Dictionary .
        ?entity a prov:Entity .

        filter not exists {
            ?pair prov:pairEntity ?entity .
        }
    }
}
```