### PR TITLE
build(lando): node:custom

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -22,10 +22,11 @@ services:
     moreHttpPorts:
       - 45671
   ui:
-    type: node:18
+    type: node:custom
     command: (cd ui; yarn serve --public app.cube-creator.lndo.site --hostname 0.0.0.0 --port 80)
     ssl: true
     overrides:
+      image: node:18
       environment:
         NO_WEBSOCKET: "true"
   store:


### PR DESCRIPTION
Using `node:custom` and specifying the image version in `overrides` allows the local set up to work on macOS Catalina which is not supported by later versions of lando (last being 3.6.5)