### PR TITLE
fix: submitting raw rdf form

### DIFF
--- a/.changeset/six-phones-matter.md
+++ b/.changeset/six-phones-matter.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/ui": patch
+---
+
+Clicking the submit button in "Edit raw RDF" mode did nothinig (fixes #1436)

--- a/ui/src/customElements/HydraRawRdfForm.ts
+++ b/ui/src/customElements/HydraRawRdfForm.ts
@@ -66,7 +66,7 @@ export class HydraRawRdfForm extends HydraOperationFormBase {
           .submitting="${this.submitting}"
           .showCancel="${this.showCancel}"
           ?disabled="${!this.shape}"
-          @submit="${this.onSubmit}"
+          @cc-submit="${this.onSubmit}"
           @cancel="${this.dispatchEvent(new Event('cancel'))}"
         ></cc-form-submit-cancel>`
   }


### PR DESCRIPTION
During previous refactoring the event handler was attached wrong and submit never happened from the element `cc-hydra-raw-rdf-form`