### PR TITLE
fix: use only clownface for mappings to reduce memory

### DIFF
--- a/.changeset/fuzzy-moose-compare.md
+++ b/.changeset/fuzzy-moose-compare.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Reduce memory usage which would cause high memory spikes when saving large dimensions mappings (fixes #1444)

--- a/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
+++ b/apis/core/lib/domain/dimension-mapping/DimensionMapping.ts
@@ -81,6 +81,7 @@ export function ProvDictionaryMixinEx<Base extends Constructor<Dictionary>>(Reso
           this.pointer.addOut(prov.hadDictionaryMember, entry => {
             entry.addOut(prov.pairKey, key)
               .addOut(prov.pairEntity, entity)
+              .addOut(rdf.type, prov.KeyEntityPair)
           })
         }
       }

--- a/apis/core/package.json
+++ b/apis/core/package.json
@@ -49,7 +49,7 @@
     "http-errors": "^2.0.0",
     "hydra-box": "^0.6.6",
     "hydra-box-middleware-shacl": "1.1.0",
-    "is-graph-pointer": "^1.2.0",
+    "is-graph-pointer": "^1.3.0",
     "is-stream": "^2",
     "jwks-rsa": "^3.0.0",
     "merge2": "^1.4.1",

--- a/apis/core/test/domain/dimension-mapping/DimensionMappings.test.ts
+++ b/apis/core/test/domain/dimension-mapping/DimensionMappings.test.ts
@@ -1,7 +1,6 @@
 import { NamedNode } from 'rdf-js'
 import { describe, it, beforeEach } from 'mocha'
 import { fromPointer } from '@rdfine/prov/lib/Dictionary'
-import { fromPointer as keyEntityPair } from '@rdfine/prov/lib/KeyEntityPair'
 import { GraphPointer } from 'clownface'
 import { expect } from 'chai'
 import $rdf from 'rdf-ext'
@@ -10,8 +9,6 @@ import TermSet from '@rdfjs/term-set'
 import { prov, xsd } from '@tpluscode/rdf-ns-builders'
 import { blankNode, namedNode } from '@cube-creator/testing/clownface'
 import '../../../lib/domain'
-import { Initializer } from '@tpluscode/rdfine/RdfResource'
-import { KeyEntityPair } from '@rdfine/prov'
 
 const wtd = namespace('http://www.wikidata.org/entity/')
 
@@ -186,16 +183,17 @@ describe('lib/domain/DimensionMappings', () => {
       })
 
       // when
-      const { entriesChanged } = dictionary.replaceEntries([
-        keyEntityPair(blankNode(), {
+      const newEntries = blankNode()
+      fromPointer(newEntries, {
+        hadDictionaryMember: [{
           pairKey: 'so2',
           pairEntity: wikidata.sulphurDioxide,
-        }),
-        keyEntityPair(blankNode(), {
+        }, {
           pairKey: 'co',
           pairEntity: wikidata.carbonMonoxide,
-        }),
-      ])
+        }],
+      })
+      const { entriesChanged } = dictionary.replaceEntries(newEntries)
 
       // then
       expect(entriesChanged).to.be.true
@@ -214,12 +212,14 @@ describe('lib/domain/DimensionMappings', () => {
       })
 
       // when
-      const { entriesChanged } = dictionary.replaceEntries([
-        keyEntityPair(blankNode(), {
+      const newEntries = blankNode()
+      fromPointer(newEntries, {
+        hadDictionaryMember: [{
           pairKey: 'co',
           pairEntity: wikidata.carbonMonoxide,
-        }),
-      ])
+        }],
+      })
+      const { entriesChanged } = dictionary.replaceEntries(newEntries)
 
       // then
       expect(entriesChanged).to.be.true
@@ -235,13 +235,14 @@ describe('lib/domain/DimensionMappings', () => {
       })
 
       // when
-      const so: Initializer<KeyEntityPair> = {
-        pairKey: 'co',
-        pairEntity: wikidata.carbonMonoxide,
-      }
-      const { entriesChanged } = dictionary.replaceEntries([
-        keyEntityPair(blankNode(), so),
-      ])
+      const newEntries = blankNode()
+      fromPointer(newEntries, {
+        hadDictionaryMember: [{
+          pairKey: 'co',
+          pairEntity: wikidata.carbonMonoxide,
+        }],
+      })
+      const { entriesChanged } = dictionary.replaceEntries(newEntries)
 
       // then
       expect(entriesChanged).to.be.false

--- a/apis/core/test/domain/dimension-mapping/DimensionMappings.test.ts
+++ b/apis/core/test/domain/dimension-mapping/DimensionMappings.test.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai'
 import $rdf from 'rdf-ext'
 import namespace from '@rdfjs/namespace'
 import TermSet from '@rdfjs/term-set'
-import { prov, xsd } from '@tpluscode/rdf-ns-builders'
+import { prov, rdf, xsd } from '@tpluscode/rdf-ns-builders'
 import { blankNode, namedNode } from '@cube-creator/testing/clownface'
 import '../../../lib/domain'
 
@@ -173,6 +173,28 @@ describe('lib/domain/DimensionMappings', () => {
   })
 
   describe('replaceEntries', () => {
+    it('adds rdf:type to all dictionary entries', () => {
+      // given
+      const dictionary = fromPointer(pointer)
+
+      // when
+      const newEntries = blankNode()
+      fromPointer(newEntries, {
+        hadDictionaryMember: [{
+          pairKey: 'so2',
+          pairEntity: wikidata.sulphurDioxide,
+        }, {
+          pairKey: 'co',
+          pairEntity: wikidata.carbonMonoxide,
+        }],
+      })
+      dictionary.replaceEntries(newEntries)
+
+      // then
+      expect(dictionary.pointer.out(prov.hadDictionaryMember).has(rdf.type, prov.KeyEntityPair).terms)
+        .have.length(2)
+    })
+
     it('returns true when entries are added', () => {
       // given
       const dictionary = fromPointer(pointer, {

--- a/apis/core/test/domain/dimension-mapping/update.test.ts
+++ b/apis/core/test/domain/dimension-mapping/update.test.ts
@@ -400,8 +400,8 @@ describe('domain/dimension-mapping/update', () => {
       expect(dimensionMapping.any().has([prov.pairKey, prov.pairEntity]).terms).to.have.length(2)
     })
 
-    it('keeps rdf:type prov:Entity triples of remaining pairs', () => {
-      expect(dimensionMapping.node(wikidata.carbonMonoxide).out(rdf.type).term).to.deep.eq(prov.Entity)
+    it('removes rdf:type prov:Entity triples of remaining pairs', () => {
+      expect(dimensionMapping.node(wikidata.carbonMonoxide).out(rdf.type).terms).to.be.empty
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9067,10 +9067,10 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
-is-graph-pointer@^1.2.0, is-graph-pointer@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/is-graph-pointer/-/is-graph-pointer-1.2.2.tgz#1517f8f99f5347b2a02b92943df9d442771fdf6a"
-  integrity sha512-lF59hoMoZxh9T1bRrjQEiifS+FNJC0cw2rlKCOlDMCfrpwgDbHmhkKE1L3NfVQBF8eNgm6U40rdy0M9SzwCS2A==
+is-graph-pointer@^1.2.2, is-graph-pointer@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/is-graph-pointer/-/is-graph-pointer-1.3.0.tgz#e7b7bc04b5993c83b0cc3abe4e719a9bf6a5138f"
+  integrity sha512-EN+CsvlI55+QVtBd8Taqxi6KQmsQ0RRjkTi6TCoAYkJV1OvSqS5Gi2ypmjQ6a1hRERr19MV1NSS06BM6WGY4rg==
   dependencies:
     "@types/clownface" "^1.5.0"
 


### PR DESCRIPTION
Using the strongly-types interface for manipulating (large) dimension mappings was quite memory-intensive to the point where pods were being restarted

This changes this process to use clownface directly