### PR TITLE
fix: missing currencies

### DIFF
--- a/.changeset/funny-chairs-press.md
+++ b/.changeset/funny-chairs-press.md
@@ -1,0 +1,5 @@
+---
+"@cube-creator/core-api": patch
+---
+
+Currencies were not listed for selection in units dimension metadata (fixes #1463) (re https://gitlab.ldbar.ch/zazuko/misc/-/issues/162)

--- a/apis/core/bootstrap/shapes/dimension.ts
+++ b/apis/core/bootstrap/shapes/dimension.ts
@@ -22,8 +22,16 @@ WHERE
     { SELECT  ?unit ?name
       WHERE
         { GRAPH <https://lindas.admin.ch/ontologies>
-            { ?unit  a ${qudt.Unit} ;
-                     ${rdfs.label} ?label .
+            {
+              {
+                ?unit a ${qudt.Unit}
+              }
+              UNION
+              {
+                ?unit a ${qudt.CurrencyUnit}
+              }
+
+              ?unit ${rdfs.label} ?label .
 
               OPTIONAL { ?unit  ${qudt.symbol}  ?symbol }
               OPTIONAL { ?unit  ${qudt.ucumCode}  ?ucumCode }


### PR DESCRIPTION
The query for units needs to be expanded to find both `qudt:Unit` and `qudt:CurrencyUnit`