### PR TITLE
fix: slow queries on some environments

### DIFF
--- a/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
+++ b/apis/shared-dimensions/lib/handlers/shared-dimensions.ts
@@ -13,7 +13,7 @@ import { shaclValidate } from '../middleware/shacl'
 import { getSharedDimensions, getSharedTerms } from '../domain/shared-dimensions'
 import { create } from '../domain/shared-dimension'
 import { store } from '../store'
-import { parsingClient } from '../sparql'
+import { parsingClient, streamClient } from '../sparql'
 import env from '../env'
 import { rewrite, rewriteTerm } from '../rewrite'
 import { postImportedDimension } from './shared-dimension/import'
@@ -36,7 +36,7 @@ export const get = asyncMiddleware(async (req, res, next) => {
 
   const collection = getCollection({
     view: $rdf.namedNode(req.absoluteUrl()),
-    memberQuads: await getSharedDimensions(parsingClient, queryParams),
+    memberQuads: await getSharedDimensions(streamClient, queryParams),
     collectionType: md.SharedDimensions,
     memberType: schema.DefinedTermSet,
     collection: req.hydra.resource.term,

--- a/apis/shared-dimensions/lib/shapes/dimensions-query-shape.ttl
+++ b/apis/shared-dimensions/lib/shapes/dimensions-query-shape.ttl
@@ -66,6 +66,7 @@ prefix md: <https://cube-creator.zazuko.com/shared-dimensions/vocab#>
     ] ;
   sh:property
     [
+      sh:deactivated true ;
       sh:path md:terms ;
       sh:values
         [
@@ -83,6 +84,7 @@ prefix md: <https://cube-creator.zazuko.com/shared-dimensions/vocab#>
     ] ;
   sh:property
     [
+      sh:deactivated true ;
       sh:path md:export ;
       sh:values
         [


### PR DESCRIPTION
We may later understand why the repeated subqueries are so inefficient on TEST. For now, we can remove that problem by creating the computed values in memory