### PR TITLE
Fix observer

### DIFF
--- a/.changeset/loud-news-drop.md
+++ b/.changeset/loud-news-drop.md
@@ -1,0 +1,7 @@
+---
+"@cube-creator/model": patch
+"@cube-creator/core-api": patch
+"@cube-creator/cli": patch
+---
+
+Fix: set correct cube:observedBy during transform

--- a/.changeset/loud-news-drop.md
+++ b/.changeset/loud-news-drop.md
@@ -4,4 +4,4 @@
 "@cube-creator/cli": patch
 ---
 
-Fix: set correct cube:observedBy during transform
+Fix: set correct `cube:observedBy` during transform

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - run: yarn seed-data
 
       - name: Hydra e2e tests
-        run: docker-compose -f docker-compose.yml -f docker-compose.posix.yml run e2e-tests
+        run: docker compose -f docker-compose.yml -f docker-compose.posix.yml run e2e-tests
       - name: core logs on fail
         if: ${{ failure() }}
         run: lando logs -s core

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ There are two types of e2e tests:
 
 ### API e2e tests
 
-Running the E2E tests can be done using: `docker-compose run --rm e2e-tests`, and `docker-compose run --rm e2e-tests -- --grep pattern` lets you select which tests to run.
+Running the E2E tests can be done using: `docker compose run --rm e2e-tests`, and `docker compose run --rm e2e-tests -- --grep pattern` lets you select which tests to run.
 
 For brevity, use npm script `npm run test:e2e --grep pattern`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -96,12 +96,12 @@ Here's an example of converting local files using a locally-built image:
 1. (optionally) Ensure a fresh container is built
 
     ```
-    docker-composer build cli
+    docker compose build cli
     ```
-1. Run with docker-compose
+1. Run with `docker compose`
 
     ```
-    docker-compose run --rm cli transform \ 
+    docker compose run --rm cli transform \ 
         --to filesystem \
         --job <URI>
         --debug

--- a/cli/lib/commands/transform.ts
+++ b/cli/lib/commands/transform.ts
@@ -1,5 +1,7 @@
 import * as Csvw from '@rdfine/csvw'
 import { ThingMixin } from '@rdfine/schema'
+import { Project, TransformJob } from '@cube-creator/model'
+import { cube } from '@cube-creator/core/namespace'
 import * as runner from './runner'
 
 interface TransformRunOptions extends runner.RunOptions {
@@ -11,10 +13,23 @@ export default runner.create<TransformRunOptions>({
     const { to } = command
     return ['main', 'from-api', `to-${to}`, 'validate']
   },
-  prepare(_, variable) {
-    variable.set('lastTransformed', {})
-
+  async prepare(options, variable) {
     const Hydra = variable.get('apiClient')
+
+    const jobResource = await Hydra.loadResource<TransformJob>(options.job)
+    const job = jobResource.representation?.root
+    if (!job) {
+      throw new Error(`Did not find representation of job ${options.job}. Server responded ${jobResource.response?.xhr.status}`)
+    }
+
+    const projectResource = await Hydra.loadResource<Project>(job.project)
+    const project = projectResource.representation?.root
+    if (!project) {
+      throw new Error(`Did not find representation of project ${job.project}. Server responded ${projectResource.response?.xhr.status}`)
+    }
+    const observer = project.maintainer.pointer.out(cube.observedBy).term
+    variable.set('observer', observer?.value)
+    variable.set('lastTransformed', {})
 
     Hydra.resources.factory.addMixin(...Object.values(Csvw))
     Hydra.resources.factory.addMixin(ThingMixin)

--- a/cli/lib/job.ts
+++ b/cli/lib/job.ts
@@ -32,12 +32,12 @@ async function loadTransformJob(jobUri: string, log: Logger, variables: Params['
     throw new Error(`Did not find representation of job ${jobUri}. Server responded ${response?.xhr.status}`)
   }
 
-  if (!representation.root.cubeGraph) {
-    throw new Error('Cannot transform project. Missing output cube id')
+  if (representation.root.cubeGraph) {
+    log.info(`Will write output triples to graph <${representation.root.cubeGraph.value}>`)
+    variables.set('graph', representation.root.cubeGraph.value)
+  } else {
+    log.warn('Cannot transform project. Missing output cube id')
   }
-
-  log.info(`Will write output triples to graph <${representation.root.cubeGraph.value}>`)
-  variables.set('graph', representation.root.cubeGraph.value)
 
   return representation.root
 }

--- a/cli/lib/metadata.ts
+++ b/cli/lib/metadata.ts
@@ -296,3 +296,17 @@ export async function injectObservedBy(this: Context, jobUri: string) {
     callback()
   })
 }
+
+export async function getObserver(this: Context, jobUri: string) {
+  const Hydra = this.variables.get('apiClient')
+  const { maintainer } = await loadDataset(jobUri, Hydra)
+  return obj(function (quad: Quad, _, callback) {
+    const creatorTerms = maintainer.pointer.out(cube.observedBy).terms
+    for (const creator of creatorTerms) {
+      if (creator.termType === 'NamedNode') {
+        return creator
+      }
+    }
+    callback()
+  })
+}

--- a/cli/lib/metadata.ts
+++ b/cli/lib/metadata.ts
@@ -1,5 +1,4 @@
-import type { Literal, NamedNode, Quad } from '@rdfjs/types'
-import { obj } from 'through2'
+import type { Literal, NamedNode } from '@rdfjs/types'
 import $rdf from 'rdf-ext'
 import { dcat, dcterms, rdf, schema, sh, _void, foaf, xsd } from '@tpluscode/rdf-ns-builders'
 import { cc, cube } from '@cube-creator/core/namespace'
@@ -273,19 +272,5 @@ export async function loadCubeMetadata(this: Context, { jobUri, endpoint, user, 
       this.push(metadata)
       this.push(null)
     },
-  })
-}
-
-export async function getObserver(this: Context, jobUri: string) {
-  const Hydra = this.variables.get('apiClient')
-  const { maintainer } = await loadDataset(jobUri, Hydra)
-  return obj(function (quad: Quad, _, callback) {
-    const creatorTerms = maintainer.pointer.out(cube.observedBy).terms
-    for (const creator of creatorTerms) {
-      if (creator.termType === 'NamedNode') {
-        return creator
-      }
-    }
-    callback()
   })
 }

--- a/cli/lib/metadata.ts
+++ b/cli/lib/metadata.ts
@@ -276,29 +276,6 @@ export async function loadCubeMetadata(this: Context, { jobUri, endpoint, user, 
   })
 }
 
-/*
-export async function injectObservedBy(this: Context, jobUri: string) {
-  const Hydra = this.variables.get('apiClient')
-
-  const { maintainer } = await loadDataset(jobUri, Hydra)
-
-  return obj(function (quad: Quad, _, callback) {
-    if (quad.predicate.equals(cube.observedBy)) {
-      const creatorTerms = maintainer.pointer.out(cube.observedBy).terms
-      for (const creator of creatorTerms) {
-        if (creator.termType === 'NamedNode') {
-          this.push($rdf.quad(quad.subject, cube.observedBy, creator))
-        }
-      }
-    } else {
-      this.push(quad)
-    }
-
-    callback()
-  })
-}
-*/
-
 export async function getObserver(this: Context, jobUri: string) {
   const Hydra = this.variables.get('apiClient')
   const { maintainer } = await loadDataset(jobUri, Hydra)

--- a/cli/lib/metadata.ts
+++ b/cli/lib/metadata.ts
@@ -276,6 +276,7 @@ export async function loadCubeMetadata(this: Context, { jobUri, endpoint, user, 
   })
 }
 
+/*
 export async function injectObservedBy(this: Context, jobUri: string) {
   const Hydra = this.variables.get('apiClient')
 
@@ -296,6 +297,7 @@ export async function injectObservedBy(this: Context, jobUri: string) {
     callback()
   })
 }
+*/
 
 export async function getObserver(this: Context, jobUri: string) {
   const Hydra = this.variables.get('apiClient')

--- a/cli/lib/variables.ts
+++ b/cli/lib/variables.ts
@@ -39,5 +39,6 @@ declare module 'barnard59-core' {
     originalValueQuads: DatasetExt
     cubeCreatorVersion: string
     cliVersion: string
+    observer: string
   }
 }

--- a/cli/pipelines/main.ttl
+++ b/cli/pipelines/main.ttl
@@ -168,12 +168,17 @@
                        code:link <node:barnard59-cube/cube.js#toObservation>
                      ] ;
   code:arguments [
+                      code:name "observer";
+                      code:value [
+		                   a code:EcmaScript ;
+                                   code:link <file:../lib/metadata#getObserver>
+		                 ]
+                   ], [
                       code:name "observations";
                                 code:value [
                                              a code:EcmaScript ;
                                              code:link <file:../lib/cube#getObservationSetId>
                                          ]
-
                     ], [
                          code:name "observation";
                          code:value "({ dataset, observations }) => ([...dataset][0].subject)"^^code:EcmaScript

--- a/cli/pipelines/main.ttl
+++ b/cli/pipelines/main.ttl
@@ -169,10 +169,7 @@
                      ] ;
   code:arguments [
                       code:name "observer";
-                      code:value [
-		                   a code:EcmaScript ;
-                                   code:link <file:../lib/metadata#getObserver>
-		                 ]
+                      code:value "observer"^^:VariableName
                    ], [
                       code:name "observations";
                                 code:value [

--- a/cli/pipelines/publish.ttl
+++ b/cli/pipelines/publish.ttl
@@ -67,7 +67,6 @@
   :steps [ :stepList ( <#loadCube>
                        <#countInputQuads>
                        <#injectCubeRevision>
-                       <#injectObservedBy>
                        <#injectSoftwareVersions>
                      ) ]
 .

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -475,6 +475,10 @@ describe('@cube-creator/cli/lib/commands/publish', function () {
           minCount: 1,
         },
       })
+
+      const observedByIns = [props.has(sh.path, cube.observedBy).out(sh.in).list()!].map(ptr => ptr.term)
+      expect(observedByIns).to.deep.contain.members([$rdf.namedNode('https://ld.admin.ch/office/VII.1.7')])
+      expect(observedByIns).to.have.length(1)
     })
 
     it('removes all csvw triples', async () => {

--- a/cli/test/lib/commands/publish.test.ts
+++ b/cli/test/lib/commands/publish.test.ts
@@ -476,9 +476,9 @@ describe('@cube-creator/cli/lib/commands/publish', function () {
         },
       })
 
-      const observedByIns = [props.has(sh.path, cube.observedBy).out(sh.in).list()!].map(ptr => ptr.term)
-      expect(observedByIns).to.deep.contain.members([$rdf.namedNode('https://ld.admin.ch/office/VII.1.7')])
+      const observedByIns = Array.from(props.has(sh.path, cube.observedBy).out(sh.in).list() ?? [])
       expect(observedByIns).to.have.length(1)
+      expect(observedByIns[0].value).to.equal('https://ld.admin.ch/office/VII.1.7')
     })
 
     it('removes all csvw triples', async () => {

--- a/cli/test/lib/commands/transform.test.ts
+++ b/cli/test/lib/commands/transform.test.ts
@@ -84,9 +84,12 @@ describe('@cube-creator/cli/lib/commands/transform', function () {
           path: rdf.type,
           hasValue: cube.Observation,
           minCount: 1,
+          maxCount: 1,
         }, {
           path: cube.observedBy,
+          hasValue: $rdf.namedNode('https://ld.admin.ch/office/VII.1.7'),
           minCount: 1,
+          maxCount: 1,
         }, {
           path: $rdf.namedNode('https://environment.ld.admin.ch/foen/ubd/28/dimension/year'),
           hasValue: $rdf.literal('2000', xsd.gYear),

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -769,7 +769,6 @@ graph <cube-project/ubd/jobs> {
 graph <cube-project/ubd/csv-mapping/jobs/test-job> {
   <cube-project/ubd/csv-mapping/jobs/test-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
-    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "cli-test" ;
@@ -785,7 +784,6 @@ graph <cube-project/ubd/csv-mapping/jobs/test-job> {
 graph <cube-project/ubd/csv-mapping/jobs/failed-job> {
   <cube-project/ubd/csv-mapping/jobs/failed-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
-    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "failed job" ;
@@ -808,7 +806,6 @@ graph <cube-project/ubd/csv-mapping/jobs/failed-job> {
 graph <cube-project/ubd/csv-mapping/jobs/hung-job> {
   <cube-project/ubd/csv-mapping/jobs/hung-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
-    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "hung job" ;
@@ -824,7 +821,6 @@ graph <cube-project/ubd/csv-mapping/jobs/hung-job> {
 graph <cube-project/ubd/csv-mapping/jobs/active-job> {
   <cube-project/ubd/csv-mapping/jobs/active-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
-    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:project <cube-project/ubd> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
@@ -840,7 +836,6 @@ graph <cube-project/ubd/csv-mapping/jobs/active-job> {
 graph <cube-project/ubd/csv-mapping/jobs/broken-job> {
   <cube-project/ubd/csv-mapping/jobs/broken-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
-    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/no-tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "broken job" ;
@@ -905,7 +900,6 @@ graph <cube-project/ubd/csv-mapping/jobs/test-unlist-job> {
 graph <cube-project/ubd/csv-mapping/jobs/canceled-job> {
   <cube-project/ubd/csv-mapping/jobs/canceled-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
-    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:project <cube-project/ubd> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;

--- a/fuseki/sample-ubd.trig
+++ b/fuseki/sample-ubd.trig
@@ -208,7 +208,7 @@ graph <cube-project/ubd/cube-data> {
 
   <https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-2003-annualmean>
     a                cube:Observation ;
-    cube:observedBy  <urn:will:replace> ;
+    cube:observedBy  <https://ld.admin.ch/office/VII.1.7> ;
     <https://environment.ld.admin.ch/foen/ubd/28/aggregation>     <https://environment.ld.admin.ch/foen/ubd/28/aggregation/annualmean> ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/value> "6.2"^^xsd:decimal ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/year>  "2003"^^xsd:gYear ;
@@ -219,7 +219,7 @@ graph <cube-project/ubd/cube-data> {
 
   <https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-2002-annualmean>
     a                cube:Observation ;
-    cube:observedBy  <urn:will:replace> ;
+    cube:observedBy  <https://ld.admin.ch/office/VII.1.7> ;
     <https://environment.ld.admin.ch/foen/ubd/28/aggregation>     <https://environment.ld.admin.ch/foen/ubd/28/aggregation/annualmean> ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/value> "6.1"^^xsd:decimal ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/year>  "2002"^^xsd:gYear ;
@@ -230,7 +230,7 @@ graph <cube-project/ubd/cube-data> {
 
   <https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-2004-annualmean>
     a                cube:Observation ;
-    cube:observedBy  <urn:will:replace> ;
+    cube:observedBy  <https://ld.admin.ch/office/VII.1.7> ;
     <https://environment.ld.admin.ch/foen/ubd/28/aggregation>     <https://environment.ld.admin.ch/foen/ubd/28/aggregation/annualmean> ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/value> "6.1"^^xsd:decimal ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/year>  "2002"^^xsd:gYear ;
@@ -242,7 +242,7 @@ graph <cube-project/ubd/cube-data> {
 
   <https://environment.ld.admin.ch/foen/ubd/28/observation/blBAS-1999-annualmean>
     a                cube:Observation ;
-    cube:observedBy  <urn:will:replace> ;
+    cube:observedBy  <https://ld.admin.ch/office/VII.1.7> ;
     <https://environment.ld.admin.ch/foen/ubd/28/aggregation>     <https://environment.ld.admin.ch/foen/ubd/28/aggregation/annualmean> ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/value> "5.4"^^xsd:decimal ;
     <https://environment.ld.admin.ch/foen/ubd/28/dimension/year>  "1999"^^xsd:gYear ;
@@ -282,7 +282,7 @@ graph <cube-project/ubd/cube-data> {
     sh:path      <https://environment.ld.admin.ch/foen/ubd/28/aggregation> .
 
   _:observedBy
-    sh:in        ( <https://ld.stadt-zuerich.ch/> ) ;
+    sh:in        ( <https://ld.admin.ch/office/VII.1.7> ) ;
     sh:maxCount  1 ;
     sh:minCount  1 ;
     sh:nodeKind  sh:IRI ;
@@ -769,6 +769,7 @@ graph <cube-project/ubd/jobs> {
 graph <cube-project/ubd/csv-mapping/jobs/test-job> {
   <cube-project/ubd/csv-mapping/jobs/test-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
+    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "cli-test" ;
@@ -784,6 +785,7 @@ graph <cube-project/ubd/csv-mapping/jobs/test-job> {
 graph <cube-project/ubd/csv-mapping/jobs/failed-job> {
   <cube-project/ubd/csv-mapping/jobs/failed-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
+    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "failed job" ;
@@ -806,6 +808,7 @@ graph <cube-project/ubd/csv-mapping/jobs/failed-job> {
 graph <cube-project/ubd/csv-mapping/jobs/hung-job> {
   <cube-project/ubd/csv-mapping/jobs/hung-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
+    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "hung job" ;
@@ -821,6 +824,7 @@ graph <cube-project/ubd/csv-mapping/jobs/hung-job> {
 graph <cube-project/ubd/csv-mapping/jobs/active-job> {
   <cube-project/ubd/csv-mapping/jobs/active-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
+    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:project <cube-project/ubd> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
@@ -836,6 +840,7 @@ graph <cube-project/ubd/csv-mapping/jobs/active-job> {
 graph <cube-project/ubd/csv-mapping/jobs/broken-job> {
   <cube-project/ubd/csv-mapping/jobs/broken-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
+    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/no-tables> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;
     schema:name "broken job" ;
@@ -900,6 +905,7 @@ graph <cube-project/ubd/csv-mapping/jobs/test-unlist-job> {
 graph <cube-project/ubd/csv-mapping/jobs/canceled-job> {
   <cube-project/ubd/csv-mapping/jobs/canceled-job>
     a hydra:Resource, cc:Job, cc:TransformJob ;
+    cc:project <cube-project/ubd> ;
     cc:tables <cube-project/ubd/csv-mapping/tables> ;
     cc:project <cube-project/ubd> ;
     cc:dimensionMetadata <cube-project/ubd/dimensions-metadata> ;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:cli:publish": "yarn c8 -o coverage/publish mocha --recursive cli/**/*.test.ts --grep @cube-creator/cli/lib/commands/publish",
     "test:cli:transform": "yarn c8 -o coverage/transform mocha --recursive cli/**/*.test.ts --grep @cube-creator/cli/lib/commands/transform",
     "test:cli:timeoutJobs": "yarn c8 -o coverage/transform mocha --recursive cli/**/*.test.ts --grep @cube-creator/cli/lib/commands/timeoutJobs",
-    "test:e2e": "docker-compose run --rm e2e-tests --",
+    "test:e2e": "docker compose run --rm e2e-tests --",
     "seed-data": "dotenv -e .local.env -- bash -c \"ts-node packages/testing/index.ts -i ubd dimensions px-cube hierarchies\""
   },
   "workspaces": [

--- a/packages/model/Job.ts
+++ b/packages/model/Job.ts
@@ -27,6 +27,7 @@ export interface Job extends Action, Rdfs.Resource, RdfResource {
 }
 
 export interface TransformJob extends Job {
+  project: NamedNode
   cubeGraph: NamedNode
   tableCollection: Link<TableCollection>
   dimensionMetadata: Link<DimensionMetadataCollection>
@@ -95,6 +96,9 @@ JobMixin.appliesTo = cc.Job
 
 export function TransformJobMixin<Base extends Constructor<RdfResource>>(base: Base): Mixin {
   class Impl extends ResourceMixin(ActionMixin(base)) implements Partial<TransformJob> {
+    @property({ path: cc.project })
+    project!: NamedNode
+
     @property.resource({ path: cc.tables })
     tableCollection!: Link<TableCollection>
 


### PR DESCRIPTION
builds upon #1508 . The `cube:observedBy` property is set with the correct value during the _transform_  job, avoiding the need to replace the values during the _publish_ job. We gain in simplicity: the correct value, derived from the publishing profile in the project settings, is passed as ENV variable, it's used for all observations and the corresponding cube constraint is automatically derived. The only downsize I see is the need to rerun the _transform_  job if one changes the publishing profile.