### PR TITLE
reactivate list shapes

### DIFF
--- a/cli/shapes.ttl
+++ b/cli/shapes.ttl
@@ -70,6 +70,3 @@ base <https://cube-creator.zazuko.com/shape#>
     sh:maxCount 1 ;
   ] ;
 .
-# consider instead removing sh:closed from :listnode in standalone-constraint-constraint
-<https://cube.link/shape/standalone-constraint-constraint#listnode> sh:deactivated true .
-<https://cube.link/shape/standalone-constraint-constraint#restvalue> sh:deactivated true .


### PR DESCRIPTION
list shapes were disabled to avoid validation errors with some weird lists having additional properties.
I could not reproduce the creation of such invalid lists anymore, so I suspect the problem is either fixed by a concurring change (the `observedBy` value) or due to some data inconsistency (blank node collision) during development.

Hopefully, we can restore the list shapes